### PR TITLE
Add security mode and policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ These tests are executed with a local github runner called "hercules", which is 
 
 Follow the steps below to set up your development environment and run tests:
 
-```
+```bash
 git clone https://github.com/united-manufacturing-hub/benthos-umh.git
 cd serverless-stack
 nvm install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # benthos-umh
+
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![GitHub Actions](https://github.com/united-manufacturing-hub/benthos-umh/workflows/main/badge.svg)](https://github.com/united-manufacturing-hub/benthos-umh/actions)
 
@@ -24,6 +25,7 @@ We encourage you to try out `benthos-umh` and explore the broader [United Manufa
 To use benthos-umh in standalone mode with Docker, follow the instructions in the main article provided.
 
 1. Create a new file called benthos.yaml with the provided content
+
     ```yaml
     ---
     input:
@@ -46,9 +48,10 @@ To use benthos-umh in standalone mode with Docker, follow the instructions in th
         topic: 'ia/raw/opcuasimulator/${! meta("opcua_path") }'
         client_id: 'benthos-umh'
     ```
+
 2. Execute the docker run command to start a new benthos-umh container
     `docker run --rm --network="host" -v '<absolute path to your file>/benthos.yaml:/benthos.yaml' ghcr.io/united-manufacturing-hub/benthos-umh:latest`
-        
+
 ### With the United Manufacturing Hub (Kubernetes & Kafka)
 
 To deploy benthos-umh with the United Manufacturing Hub and its OPC-UA simulator, use the provided Kubernetes manifests in UMHLens/OpenLens.
@@ -73,7 +76,7 @@ data:
               "timestamp_unix": timestamp_unix()
             }
     output:
-      umh_output: 
+      umh_output:
         topic: 'ia.raw.${! meta("opcua_path") }'
 ---
 apiVersion: apps/v1
@@ -122,7 +125,7 @@ spec:
 
 ### Authentication and Security
 
-In benthos-umh, security and authentication are designed to be as robust as possible while maintaining flexibility. The software automates the process of selecting the highest level of security offered by an OPC-UA server for the selected Authentication Method. 
+In benthos-umh, security and authentication are designed to be as robust as possible while maintaining flexibility. The software automates the process of selecting the highest level of security offered by an OPC-UA server for the selected Authentication Method.
 
 #### How It Works
 
@@ -136,9 +139,9 @@ In benthos-umh, security and authentication are designed to be as robust as poss
 #### Supported Authentication Methods
 
 - **Anonymous**: No extra information is needed. The connection uses the highest security level available for anonymous connections.
-  
+
 - **Username and Password**: Specify the username and password in the configuration. The client opts for the highest security level that supports these credentials.
-  
+
 - **Certificate (Future Release)**: Certificate-based authentication is planned for future releases.
 
 #### Example: Configuration File
@@ -150,6 +153,8 @@ input:
   opcua:
     endpoint: 'opc.tcp://localhost:46010'
     nodeIDs: ['ns=2;s=IoTSensors']
+    securityMode: None | Sign | SignAndEncrypt # optional
+    securityPolicy: None | Basic256Sha256 | Aes256_Sha256_RsaPss | Aes128_Sha256_RsaOaep # optional
     username: 'your-username'  # optional
     password: 'your-password'  # optional
 ```
@@ -157,6 +162,7 @@ input:
 ## Testing
 
 We execute automated tests and verify that benthos-umh works:
+
 - (WAGO PFC100, 750-8101) Connect Anonymously
 - (WAGO PFC100, 750-8101) Connect Username / Password
 - (WAGO PFC100, 750-8101) Connect and get one float number
@@ -166,18 +172,20 @@ These tests are executed with a local github runner called "hercules", which is 
 ## Development
 
 ### Quickstart
+
 Follow the steps below to set up your development environment and run tests:
+
 ```
-$ git clone https://github.com/united-manufacturing-hub/benthos-umh.git
-$ cd serverless-stack
-$ nvm install
-$ npm install
-$ sudo apt-get install zip 
-$ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
-$ sudo apt update
-$ sudo apt install goreleaser
-$ make
-$ npm test
+git clone https://github.com/united-manufacturing-hub/benthos-umh.git
+cd serverless-stack
+nvm install
+npm install
+sudo apt-get install zip
+echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+sudo apt update
+sudo apt install goreleaser
+make
+npm test
 ```
 
 ### Additional Checks and Commands
@@ -185,15 +193,15 @@ $ npm test
 #### Gitpod and Tailscale
 
 By default when opening the repo in Gitpod, everything that you need should start automatically. If you want to connect to our local PLCs in our office, you can use tailscale, which you will be prompted to install.
-See also: https://www.gitpod.io/docs/integrations/tailscale
+See also: <https://www.gitpod.io/docs/integrations/tailscale>
 
-#### For Go Code:
+#### For Go Code
 
 1. **Linting**: Run `make lint` to check for linting errors. If any are found, you can automatically fix them by running `make format`.
-  
+
 2. **Unit Tests**: Run `make test` to execute all Go unit tests.
 
-#### For Other Code Types (Including Config Files):
+#### For Other Code Types (Including Config Files)
 
 1. **Benthos Tests**: Use `npm run test` to run all Benthos tests for configuration files. Note: We currently do not have these tests. [Learn more](https://www.benthos.dev/docs/configuration/unit_testing/).
 
@@ -208,4 +216,3 @@ All source code is distributed under the APACHE LICENSE, VERSION 2.0. See LICENS
 Feel free to provide us feedback on our [Discord channel](https://discord.gg/F9mqkZnm9d).
 
 For more information about the United Manufacturing Hub, visit [UMH Systems GmbH](https://www.umh.app). If you haven't worked with the United Manufacturing Hub before, [give it a try](https://umh.docs.umh.app/docs/getstarted/installation/)! Setting it up takes only a matter of minutes.
-

--- a/README.md
+++ b/README.md
@@ -18,27 +18,6 @@ Welcome to the benthos-umh repository! This is a version of benthos maintained b
 
 We encourage you to try out `benthos-umh` and explore the broader [United Manufacturing Hub](https://www.umh.app) project for a comprehensive solution to your industrial data integration needs.
 
-### Authentication and Security
-
-In benthos-umh, security and authentication are designed to be as robust as possible while maintaining flexibility. The software automates the process of selecting the highest level of security offered by an OPC-UA server for the selected Authentication Method.
-
-#### How It Works
-
-1. **Discover Endpoints**: Initially, benthos-umh discovers all available endpoints from the OPC-UA server.
-2. **Filter by Authentication**: Based on the provided authentication method, it filters the list of endpoints. It currently supports Anonymous and Username/Password methods. Certificate-based authentication is on the roadmap.
-3. **Select Endpoint**: The software then chooses the endpoint with the highest security level that matches the chosen authentication method.
-4. **Client Initialization**: Various client options are initialized, such as security policies, based on the selected endpoint.
-5. **Generate Certificates**: For secure communication, certificates are dynamically generated. However, this step is only essential for methods requiring it.
-6. **Final Connection**: Finally, it initiates a connection to the OPC-UA server using the chosen endpoint and authentication method.
-
-#### Supported Authentication Methods
-
-- **Anonymous**: No extra information is needed. The connection uses the highest security level available for anonymous connections.
-
-- **Username and Password**: Specify the username and password in the configuration. The client opts for the highest security level that supports these credentials.
-
-- **Certificate (Future Release)**: Certificate-based authentication is planned for future releases.
-
 ## Usage
 
 ### Standalone
@@ -144,6 +123,16 @@ spec:
             name: benthos-1-config
 ```
 
+### Authentication and Security
+
+In benthos-umh, security and authentication are designed to be as robust as possible while maintaining flexibility. The software automates the process of selecting the highest level of security offered by an OPC-UA server for the selected Authentication Method, but the user can specify their own Security Policy / Security Mode if they want (see further below at Configuration options)
+
+#### Supported Authentication Methods
+
+- **Anonymous**: No extra information is needed. The connection uses the highest security level available for anonymous connections.
+- **Username and Password**: Specify the username and password in the configuration. The client opts for the highest security level that supports these credentials.
+- **Certificate (Future Release)**: Certificate-based authentication is planned for future releases.
+
 ### Configuration Options
 
 The following options can be specified in the `benthos.yaml` configuration file:
@@ -196,21 +185,16 @@ input:
     password: 'your-password'
 ```
 
-#### Insecure Mode
-
-If the most secure endpoint selected by benthos-umh is not working or the server's security implementation is lacking, you can bypass encryption by setting `insecure: true``.
-
-```yaml
-input:
-  opcua:
-    endpoint: 'opc.tcp://localhost:46010'
-    nodeIDs: ['ns=2;s=IoTSensors']
-    insecure: true
-```
-
 #### Security Mode and Security Policy
 
-The security mode and security policy are automatically selected based on the endpoint and authentication method. However, you can override the default behavior by specifying the security mode and security policy in the configuration file.
+Security Mode: This defines the level of security applied to the messages. The options are:
+- None: No security is applied; messages are neither signed nor encrypted.
+- Sign: Messages are signed for integrity and authenticity but not encrypted.
+- SignAndEncrypt: Provides the highest security level where messages are both signed and encrypted.
+
+Security Policy: Specifies the set of cryptographic algorithms used for securing messages. This includes algorithms for encryption, decryption, and signing of messages. Some common policies include Basic256Sha256, Aes256Sha256RsaPss, and Aes128Sha256RsaOaep.
+
+While the security mode and policy are automatically selected based on the endpoint and authentication method, you have the option to override this by specifying them in the configuration file:
 
 ```yaml
 input:
@@ -219,6 +203,20 @@ input:
     nodeIDs: ['ns=2;s=IoTSensors']
     securityMode: SignAndEncrypt
     securityPolicy: Basic256Sha256
+```
+
+#### Insecure Mode
+
+Setting this to true will overwrite any configured securityMode and securityPolicy!
+
+If the most secure endpoint selected by benthos-umh is not working or the server's security implementation is lacking, you can bypass encryption by setting `insecure: true`. This will use the Security Mode "None".
+
+```yaml
+input:
+  opcua:
+    endpoint: 'opc.tcp://localhost:46010'
+    nodeIDs: ['ns=2;s=IoTSensors']
+    insecure: true
 ```
 
 #### Pull and Subscribe Methods

--- a/plugin/authentication.go
+++ b/plugin/authentication.go
@@ -9,6 +9,7 @@ import (
 // getReasonableEndpoint selects an appropriate OPC UA endpoint based on specified criteria.
 // It filters the endpoints based on the authentication method, security mode, and security policy.
 // If no suitable endpoint is found, it returns nil.
+// This can potentially be replaced by 
 func (g *OPCUAInput) getReasonableEndpoint(
 	endpoints []*ua.EndpointDescription,
 	selectedAuthentication ua.UserTokenType,

--- a/plugin/authentication.go
+++ b/plugin/authentication.go
@@ -9,7 +9,7 @@ import (
 // getReasonableEndpoint selects an appropriate OPC UA endpoint based on specified criteria.
 // It filters the endpoints based on the authentication method, security mode, and security policy.
 // If no suitable endpoint is found, it returns nil.
-// This can potentially be replaced by 
+// This can potentially be replaced by SelectEndpoint function in goopcua package
 func (g *OPCUAInput) getReasonableEndpoint(
 	endpoints []*ua.EndpointDescription,
 	selectedAuthentication ua.UserTokenType,

--- a/plugin/authentication.go
+++ b/plugin/authentication.go
@@ -6,39 +6,64 @@ import (
 	"github.com/gopcua/opcua/ua"
 )
 
-func (g *OPCUAInput) getReasonableEndpoint(endpoints []*ua.EndpointDescription, selectedAuthentication ua.UserTokenType, disableEncryption bool, overwriteSecurityMode string, overwriteSecurityPolicy string,) *ua.EndpointDescription {
+// getReasonableEndpoint selects an appropriate OPC UA endpoint based on specified criteria.
+// It filters the endpoints based on the authentication method, security mode, and security policy.
+// If no suitable endpoint is found, it returns nil.
+func (g *OPCUAInput) getReasonableEndpoint(
+	endpoints []*ua.EndpointDescription,
+	selectedAuthentication ua.UserTokenType,
+	disableEncryption bool,
+	securityMode string,
+	securityPolicy string,
+) *ua.EndpointDescription {
+
+	// Return nil immediately if no endpoints are provided.
 	if len(endpoints) == 0 {
 		return nil
 	}
 
+	// Sort endpoints in descending order of security level.
 	sort.Sort(sort.Reverse(bySecurityLevel(endpoints)))
 
-	for _, p := range endpoints {
-		// Take the first endpoint that supports our selectedAuthentication
-		for _, userIdentity := range p.UserIdentityTokens {
+	// Iterate over each endpoint to find a matching one.
+	for _, endpoint := range endpoints {
 
+		// Check each user identity token in the endpoint.
+		for _, userIdentity := range endpoint.UserIdentityTokens {
+
+			// Match the endpoint with the selected authentication type.
 			if selectedAuthentication == userIdentity.TokenType {
 
-				// Additionally check whether encryption is disabled
-				if disableEncryption && p.SecurityMode == ua.MessageSecurityModeFromString("None") {
-					return p
-				} else if !disableEncryption { // if encrpytion is not disabled, then take everything
-					if g.securityMode != "" {
-						p.SecurityMode = ua.MessageSecurityModeFromString(overwriteSecurityMode)
-					}
+				// Check for encryption requirements.
+				if disableEncryption && endpoint.SecurityMode == ua.MessageSecurityModeFromString("None") {
+					// Return if encryption is disabled and the endpoint has no security.
+					return endpoint
+				} else if !disableEncryption {
+					// Handle the case where encryption is not disabled.
 
-					if g.securityPolicy != "" {
-						p.SecurityPolicyURI = "http://opcfoundation.org/UA/SecurityPolicy#" + overwriteSecurityPolicy
+					// Check for a specific security mode if provided.
+					if securityMode != "" && endpoint.SecurityMode == ua.MessageSecurityModeFromString(securityMode) {
+
+						// Check for a specific security policy if provided.
+						if securityPolicy != "" && endpoint.SecurityPolicyURI == "http://opcfoundation.org/UA/SecurityPolicy#"+securityPolicy {
+							return endpoint
+						} else if securityPolicy == "" {
+							// If no specific security policy is needed, return the endpoint.
+							return endpoint
+						}
+						// Continue searching if the security policy doesn't match.
+					} else if securityMode == "" {
+						// If no specific security policy is needed, return the endpoint.
+						return endpoint
 					}
-					return p
 				}
-				// otherwise, continue searching
+				// Continue searching if other conditions are not met.
 			}
 		}
-
 	}
-	return nil
 
+	// Return nil if no suitable endpoint is found.
+	return nil
 }
 
 // Copy paste from opcua library

--- a/plugin/authentication.go
+++ b/plugin/authentication.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gopcua/opcua/ua"
 )
 
-func (g *OPCUAInput) getReasonableEndpoint(endpoints []*ua.EndpointDescription, selectedAuthentication ua.UserTokenType, disableEncryption bool) *ua.EndpointDescription {
+func (g *OPCUAInput) getReasonableEndpoint(endpoints []*ua.EndpointDescription, selectedAuthentication ua.UserTokenType, disableEncryption bool, overwriteSecurityMode string, overwriteSecurityPolicy string,) *ua.EndpointDescription {
 	if len(endpoints) == 0 {
 		return nil
 	}
@@ -23,10 +23,16 @@ func (g *OPCUAInput) getReasonableEndpoint(endpoints []*ua.EndpointDescription, 
 				if disableEncryption && p.SecurityMode == ua.MessageSecurityModeFromString("None") {
 					return p
 				} else if !disableEncryption { // if encrpytion is not disabled, then take everything
+					if g.securityMode != "" {
+						p.SecurityMode = ua.MessageSecurityModeFromString(overwriteSecurityMode)
+					}
+
+					if g.securityPolicy != "" {
+						p.SecurityPolicyURI = "http://opcfoundation.org/UA/SecurityPolicy#" + overwriteSecurityPolicy
+					}
 					return p
 				}
 				// otherwise, continue searching
-
 			}
 		}
 

--- a/plugin/opcua.go
+++ b/plugin/opcua.go
@@ -190,8 +190,8 @@ var OPCUAConfigSpec = service.NewConfigSpec().
 	Field(service.NewStringField("username").Description("Username for server access. If not set, no username is used.").Default("")).
 	Field(service.NewStringField("password").Description("Password for server access. If not set, no password is used.").Default("")).
 	Field(service.NewStringListField("nodeIDs").Description("List of OPC-UA node IDs to begin browsing.")).
-	Field(service.NewStringField("securityMode").Description("Security mode to use. If not set, a reasonable security mode will be set depending on the discovered endpoints.")).
-	Field(service.NewStringField("securityPolicy").Description("The security policy to use.  If not set, a reasonable security policy will be set depending on the discovered endpoints.")).
+	Field(service.NewStringField("securityMode").Description("Security mode to use. If not set, a reasonable security mode will be set depending on the discovered endpoints.").Default("")).
+	Field(service.NewStringField("securityPolicy").Description("The security policy to use.  If not set, a reasonable security policy will be set depending on the discovered endpoints.").Default("")).
 	Field(service.NewBoolField("insecure").Description("Set to true to bypass secure connections, useful in case of SSL or certificate issues. Default is secure (false).").Default(false)).
 	Field(service.NewBoolField("subscribeEnabled").Description("Set to true to subscribe to OPC-UA nodes instead of fetching them every seconds. Default is pulling messages every second (false).").Default(false))
 

--- a/plugin/opcua.go
+++ b/plugin/opcua.go
@@ -267,7 +267,7 @@ func newOPCUAInput(conf *service.ParsedConfig, mgr *service.Resources) (service.
 		password:         password,
 		nodeIDs:          parsedNodeIDs,
 		log:              mgr.Logger(),
-    securityMode:     securityMode,
+		securityMode:     securityMode,
 		securityPolicy:   securityPolicy,
 		insecure:         insecure,
 		subscribeEnabled: subscribeEnabled,
@@ -292,19 +292,19 @@ func init() {
 //------------------------------------------------------------------------------
 
 type OPCUAInput struct {
-	endpoint          string
-	username          string
-	password          string
-	nodeIDs           []*ua.NodeID
-	nodeList          []NodeDef
-  securityMode      string
-	securityPolicy    string
-  insecure          bool
-  client            *opcua.Client
-	log               *service.Logger
+	endpoint       string
+	username       string
+	password       string
+	nodeIDs        []*ua.NodeID
+	nodeList       []NodeDef
+	securityMode   string
+	securityPolicy string
+	insecure       bool
+	client         *opcua.Client
+	log            *service.Logger
 	// this is required for subscription
-	subscribeEnabled  bool
-	subNotifyChan     chan *opcua.PublishNotificationData
+	subscribeEnabled bool
+	subNotifyChan    chan *opcua.PublishNotificationData
 }
 
 func (g *OPCUAInput) Connect(ctx context.Context) error {
@@ -374,7 +374,7 @@ func (g *OPCUAInput) Connect(ctx context.Context) error {
 
 	// Step 3.1: Filter the endpoints based on the selected authentication method.
 	// This will eliminate endpoints that do not support the chosen method.
-	selectedEndpoint := g.getReasonableEndpoint(endpoints, selectedAuthentication, g.insecure)
+	selectedEndpoint := g.getReasonableEndpoint(endpoints, selectedAuthentication, g.insecure, g.securityMode, g.securityPolicy,)
 	if selectedEndpoint == nil {
 		g.log.Errorf("Could not select a suitable endpoint")
 		return err
@@ -387,13 +387,6 @@ func (g *OPCUAInput) Connect(ctx context.Context) error {
 	// Step 4: Initialize OPC UA client options
 	opts := make([]opcua.Option, 0)
 	opts = append(opts, opcua.SecurityFromEndpoint(selectedEndpoint, selectedAuthentication))
-	if g.securityMode != "" {
-		opts = append(opts, opcua.SecurityModeString(g.securityMode))
-	}
-
-	if g.securityPolicy != "" {
-		opts = append(opts, opcua.SecurityPolicy("http://opcfoundation.org/UA/SecurityPolicy#"+g.securityPolicy))
-	}
 
 	// Set additional options based on the authentication method
 	switch selectedAuthentication {

--- a/plugin/opcua_test.go
+++ b/plugin/opcua_test.go
@@ -466,7 +466,7 @@ func TestGetReasonableEndpoint_Insecure(t *testing.T) {
 	}
 
 	endpoints := MockGetEndpoints()
-	selectedEndpoint := input.getReasonableEndpoint(endpoints, ua.UserTokenTypeFromString("Anonymous"), input.insecure)
+	selectedEndpoint := input.getReasonableEndpoint(endpoints, ua.UserTokenTypeFromString("Anonymous"), input.insecure, "", "")
 
 	if selectedEndpoint != nil {
 		if selectedEndpoint.SecurityMode != ua.MessageSecurityModeFromString("None") {
@@ -484,11 +484,34 @@ func TestGetReasonableEndpoint_Insecure(t *testing.T) {
 		insecure: false,
 	}
 
-	selectedEndpoint2 := input.getReasonableEndpoint(endpoints, ua.UserTokenTypeFromString("Anonymous"), input2.insecure)
+	selectedEndpoint2 := input.getReasonableEndpoint(endpoints, ua.UserTokenTypeFromString("Anonymous"), input2.insecure, "", "")
 
 	if selectedEndpoint2 != nil {
 		if selectedEndpoint2.SecurityMode != ua.MessageSecurityModeFromString("SignAndEncrypt") {
 			t.Errorf("Expected selected endpoint to have encryption, but got %v", selectedEndpoint.SecurityMode)
+		}
+	} else {
+		t.Error("Expected a reasonable endpoint, but got nil")
+	}
+}
+
+func TestGetReasonableEndpoint_SecurityModeAndPolicy(t *testing.T) {
+	input := &OPCUAInput{
+		endpoint:       "",
+		username:       "",
+		password:       "",
+		nodeIDs:        nil,
+		insecure:       true,
+		securityMode:   "SignAndEncrypt",
+		securityPolicy: "Basic256Sha256",
+	}
+
+	endpoints := MockGetEndpoints()
+	selectedEndpoint := input.getReasonableEndpoint(endpoints, ua.UserTokenTypeFromString("Anonymous"), input.insecure, "", "")
+
+	if selectedEndpoint != nil {
+		if selectedEndpoint.SecurityMode != ua.MessageSecurityModeFromString(inpuy.securityMode) && selectedEndpoint.SecurityPolicyURI != "http://opcfoundation.org/UA/SecurityPolicy#"+input.securityPolicy {
+			t.Errorf("Expected selected endpoint to have encryption with security mode %v and policy %v, but got %v and %v", input.securityMode, input.securityPolicy, selectedEndpoint.SecurityMode, selectedEndpoint.SecurityPolicyURI)
 		}
 	} else {
 		t.Error("Expected a reasonable endpoint, but got nil")


### PR DESCRIPTION
This pull request adds support for specifying security mode and policy in the OPC-UA client options, and provides instructions for configuring benthos-umh in standalone mode with Docker. It also includes updates to the README.md file to reflect these changes.

---

I am not sure how you want the documentation and tests, so any guidance/help here is welcome :-)