### PR TITLE
Fix issue with OPCUA client disconnection

### DIFF
--- a/plugin/opcua.go
+++ b/plugin/opcua.go
@@ -664,6 +664,10 @@ func (g *OPCUAInput) ReadBatchPull(ctx context.Context) (service.MessageBatch, s
 			g.client.Close(ctx)
 			g.client = nil
 			return nil, nil, service.ErrNotConnected
+		case ua.StatusBadServerNotConnected:
+			g.client.Close(ctx)
+			g.client = nil
+			return nil, nil, service.ErrNotConnected
 		}
 
 		// return error and stop executing this function.


### PR DESCRIPTION
On a failed read, in case of a `StatusBadServerNotConnected` OPC UA error, returning the `service.ErrNotConnected` error triggers a logic that continuously tries to reconnect 

Fixes https://github.com/united-manufacturing-hub/MgmtIssues/issues/1163

Test "Connect Subscribe Scalar Arrays" was already failing before my changes