### PR TITLE
Correct topic and keys for folders solution 3

### DIFF
--- a/plugin/opcua.go
+++ b/plugin/opcua.go
@@ -618,18 +618,19 @@ func (g *OPCUAInput) createMessageFromValue(variant *ua.Variant, nodeDef NodeDef
 	message := service.NewMessage(b)
 
 	re := regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+	// opcua_path is the sanitized nodeID
 	opcuaPath := re.ReplaceAllString(nodeDef.NodeID.String(), "_")
-	// In case the node is a child of a folder, we want to only keep the parent path
-	// opcuaPath = extractParentPath(opcuaPath, nodeDef.Path)
 	message.MetaSet("opcua_path", opcuaPath)
 
+	// opcua_parent_path is the sanitized parentNodeID, which is equal to the subscribed nodeID
 	parentPath := re.ReplaceAllString(nodeDef.ParentNodeID, "_")
 	message.MetaSet("opcua_parent_path", parentPath)
 
 	op, _ := message.MetaGet("opcua_path")
-	cp, _ := message.MetaGet("opcua_parent_path")
+	opp, _ := message.MetaGet("opcua_parent_path")
 	g.log.Debugf("Created message with opcua_path: %s", op)
-	g.log.Debugf("Created message with opcua_parent_path: %s", cp)
+	g.log.Debugf("Created message with opcua_parent_path: %s", opp)
 
 	return message
 }


### PR DESCRIPTION
Related to https://github.com/united-manufacturing-hub/MgmtIssues/issues/1621
This solution is the proper one for subscribing to a folder node. It handles tags and sub-folders as JSON objects, ignoring the parent folder (which is the one subscribed to)

For example, given the following folder structure:
```
parent
├─ child1
│  ├─ child2
│  │  ├─ leaf3
│  ├─ leaf4
├─ child3
│  ├─ leaf5
├─ leaf6
```
and subscribing to the `parent` folder, will result in events sent to the same topic as the images, but with the following payloads:

```json
{
  "child1": {
    "child2": {
      "leaf3":15.491058
    }
  }
  "timestamp_ms":1708094377545
}
{
  "child1": {
    "leaf4":15.491058
  }
  "timestamp_ms":1708094377545
}
{
  "child3": {
    "leaf5":15.491058
  }
  "timestamp_ms":1708094377545
}
{
  "leaf6":15.491058
  "timestamp_ms":1708094377545
}
```

Steps to test it out:
1. Build the docker image from this branch
2. Create a new connection to the WAGO PLC
3. Initialize the connection using this nodes. If you find a folder node that has more tags/subfolders, feel free to add it
   ```yaml
   nodes:
     - opcuaID: ns=4;s=|var|WAGO 750-8101 PFC100 CS 2ETH.Application.GVL
       enterprise: pharma-genix
       site: tokyo
       area: packaging
       line: packaging_1
       workcell: blister
       tagName: folder
       schema: _historian
     - opcuaID: ns=4;s=|vprop|WAGO 750-8101 PFC100 CS 2ETH.Application.RevisionCounter
       enterprise: pharma-genix
       site: tokyo
       area: packaging
       line: packaging_1
       workcell: blister
       tagName: tag
       schema: _historian
   ```
4. Update the benthos configmap of the new data source with the changes from https://github.com/united-manufacturing-hub/ManagementConsole/pull/417
5. Update the benthos deployment to use the correct docker image. You can also add this args to enable debug logging
   ```yaml
             args:
               - '--log.level=debug'
   ```

This is what you will end up with. 
![image](https://github.com/united-manufacturing-hub/benthos-umh/assets/92927530/c509b741-386d-4571-93d5-063bb8215cdf)
![image](https://github.com/united-manufacturing-hub/benthos-umh/assets/92927530/4dc4b06d-8ff2-468f-a310-4f12f7913fde)
![image](https://github.com/united-manufacturing-hub/benthos-umh/assets/92927530/bdc0d710-50e6-406b-8478-a13253e2eed3)


The only missing thing would be to fix the tests