### PR TITLE
[ENG-1740] Fix ParentNodeIDs in the BrowsedNode List

### DIFF
--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -240,7 +240,7 @@ func browse(ctx context.Context, n *opcua.Node, path string, level int, logger *
 		logger.Debugf("found %d child refs\n", len(refs))
 		for _, rn := range refs {
 			wg.Add(1)
-			go browse(ctx, rn, def.Path, level+1, logger, parentNodeId, nodeChan, errChan, wg)
+			go browse(ctx, rn, def.Path, level+1, logger, def.NodeID.String(), nodeChan, errChan, wg)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Description

ParentNodeIDs were mistakenly assigned to the initial ParentNode value every time. For example, if you call the BrowseNodes function with i=84, all nodes would previously have been assigned i=84 as their ParentNodeID. This PR corrects the logic so that each ParentID is now properly assigned to the closest Parent of the current Node.


## Browsenode list after the change. 
Note the ParentNodeID property.
```json
 [
  {
    "NodeID": "i=2259",
    "NodeClass": 2,
    "BrowseName": "State",
    "Description": "",
    "AccessLevel": 0,
    "DataType": "i=852",
    "ParentNodeID": "i=2256",
    "Path": "Root.Objects.Server.ServerStatus.State"
  },
  {
    "NodeID": "i=2258",
    "NodeClass": 2,
    "BrowseName": "CurrentTime",
    "Description": "",
    "AccessLevel": 0,
    "DataType": "time.Time",
    "ParentNodeID": "i=2256",
    "Path": "Root.Objects.Server.ServerStatus.CurrentTime"
  },
  {
    "NodeID": "i=2992",
    "NodeClass": 2,
    "BrowseName": "SecondsTillShutdown",
    "Description": "",
    "AccessLevel": 0,
    "DataType": "uint32",
    "ParentNodeID": "i=2256",
    "Path": "Root.Objects.Server.ServerStatus.SecondsTillShutdown"
  },
  {
    "NodeID": "i=2993",
    "NodeClass": 2,
    "BrowseName": "ShutdownReason",
    "Description": "",
    "AccessLevel": 0,
    "DataType": "i=21",
    "ParentNodeID": "i=2256",
    "Path": "Root.Objects.Server.ServerStatus.ShutdownReason"
  },
  {
    "NodeID": "i=2257",
    "NodeClass": 2,
    "BrowseName": "StartTime",
    "Description": "",
    "AccessLevel": 0,
    "DataType": "time.Time",
    "ParentNodeID": "i=2256",
    "Path": "Root.Objects.Server.ServerStatus.StartTime"
  },
  {
    "NodeID": "ns=2;i=6423",
    "NodeClass": 2,
    "BrowseName": "Opc.Ua.Di",
    "Description": "",
    "AccessLevel": 0,
    "DataType": "i=15",
    "ParentNodeID": "i=92",
    "Path": "Root.Types.DataTypes.XML_Schema.Opc.Ua.Di"
  }
]
```

To view the full JSON, 
[newnodes.json](https://github.com/user-attachments/files/17381056/newnodes.json)
