### PR TITLE
Added support for EIO404 Bluetooth Mesh IoT Base Station.

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,8 @@ input:
     ```
 
 ### ifm IO-Link Master / "sensorconnect"
-The SensorConnect plugin facilitates communication with ifm electronic’s IO-Link Masters devices, such as the AL1350 IO-Link Master.
+The SensorConnect plugin facilitates communication with ifm electronic’s IO-Link Masters devices, such as the AL1350 or AL1352 IO-Link Masters.
+It also supports EIO404 Bluetooth mesh base stations with EIO344 Bluetooth mesh IO-Link adapters.
 It enables the integration of sensor data into Benthos pipelines by connecting to the device over HTTP and processing data from connected sensors, including digital inputs and IO-Link devices.
 The plugin handles parsing and interpreting IO-Link data using IODD files, converting raw sensor outputs into human-readable data.
 

--- a/sensorconnect_plugin/downloadPortModeData.go
+++ b/sensorconnect_plugin/downloadPortModeData.go
@@ -22,7 +22,7 @@ type ConnectedDeviceInfo struct {
 	Serial      string
 	Port        string
 	UseRawData  bool // If true, the raw data will be used instead of the parsed data. This flag is automatically set if there is no IODD file available
-	btAdapter   string
+	BtAdapter   string
 }
 
 // BadgeSize is Maximum possible size of the "/getdatamulti" request, determined for AL1352 and EIO404 Devices.
@@ -60,9 +60,9 @@ func (s *SensorConnectInput) GetConnectedDevices(ctx context.Context) ([]Connect
 		btAdapter, err := extractBluetoothAdapter(uri)
 		if err != nil {
 			s.logger.Debugf(err.Error())
-			deviceInfo.btAdapter = "none"
+			deviceInfo.BtAdapter = "none"
 		} else {
-			deviceInfo.btAdapter = btAdapter
+			deviceInfo.BtAdapter = btAdapter
 		}
 
 		port, err := extractPort(uri)
@@ -109,7 +109,7 @@ func (s *SensorConnectInput) GetConnectedDevices(ctx context.Context) ([]Connect
 			deviceIDValue, exists := data[deviceIDKey]
 			if !exists || deviceIDValue.Code != 200 || deviceIDValue.Data == nil {
 				if deviceIDValue.Code == 503 {
-					s.logger.Debugf("DeviceID not available for port %d (code 503), marking as disconnected", uri)
+					s.logger.Debugf("DeviceID not available for %s (code 503), marking as disconnected", uri)
 					deviceInfo.Connected = false
 					connectedDevices = append(connectedDevices, deviceInfo)
 					continue
@@ -179,7 +179,7 @@ func (s *SensorConnectInput) GetConnectedDevices(ctx context.Context) ([]Connect
 			serialKey := uri + "/iolinkdevice/serial"
 			serialValue, exists := data[serialKey]
 			if !exists || serialValue.Data == nil || serialValue.Code == 503 {
-				s.logger.Infof("Serial number not available for port %d", uri)
+				s.logger.Infof("Serial number not available for port %s", uri)
 			} else if serialValue.Code == 200 {
 				serial, err := parseString(serialValue.Data)
 				if err != nil {

--- a/sensorconnect_plugin/downloadPortModeData.go
+++ b/sensorconnect_plugin/downloadPortModeData.go
@@ -4,69 +4,92 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 )
 
 // ConnectedDeviceInfo represents information about a connected device on a port
 type ConnectedDeviceInfo struct {
+	Uri         string
 	Mode        uint
 	Connected   bool
 	DeviceID    uint
 	VendorID    uint
 	ProductName string
 	Serial      string
+	Port        string
 	UseRawData  bool // If true, the raw data will be used instead of the parsed data. This flag is automatically set if there is no IODD file available
+	btAdapter   string
 }
 
 // GetUsedPortsAndMode returns a map of the IO-Link Master's ports with port numbers as keys and ConnectedDeviceInfo as values
-func (s *SensorConnectInput) GetUsedPortsAndMode(ctx context.Context) (map[int]ConnectedDeviceInfo, error) {
+func (s *SensorConnectInput) GetConnectedDevices(ctx context.Context) ([]ConnectedDeviceInfo, error) {
 	response, err := s.getUsedPortsAndMode(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Group the response data by port
-	portData := make(map[int]map[string]UPAMDatum)
-	for key, value := range response.Data {
-		port, err := extractIntFromString(key)
+	// Group the response data by uri
+	uris := make(map[string]map[string]UPAMDatum)
+	for key, value := range response {
+		uri, err := extractUri(key)
 		if err != nil {
-			s.logger.Warnf("Failed to extract port number from key %s: %v", key, err)
+			s.logger.Warnf(err.Error())
 			continue
 		}
 
-		if _, exists := portData[port]; !exists {
-			portData[port] = make(map[string]UPAMDatum)
+		if _, exists := uris[uri]; !exists {
+			uris[uri] = make(map[string]UPAMDatum)
 		}
-		portData[port][key] = value
+		uris[uri][key] = value
 	}
 
-	portModeUsageMap := make(map[int]ConnectedDeviceInfo)
+	var connectedDevices []ConnectedDeviceInfo
 
-	// Process each port's data
-	for port, data := range portData {
-		deviceInfo := ConnectedDeviceInfo{}
+	//// Process each uri's data
+	for uri, data := range uris {
+		deviceInfo := ConnectedDeviceInfo{Uri: uri}
 		deviceInfo.Connected = true // Default to connected unless proven otherwise
 
+		btAdapter, err := extractBluetoothAdapter(uri)
+		if err != nil {
+			s.logger.Debugf(err.Error())
+			deviceInfo.btAdapter = "none"
+		} else {
+			deviceInfo.btAdapter = btAdapter
+		}
+
+		port, err := extractPort(uri)
+		if err != nil {
+			s.logger.Errorf(err.Error())
+		} else {
+			deviceInfo.Port = port
+		}
+
 		// Process the mode first
-		modeKey := fmt.Sprintf("/iolinkmaster/port[%d]/mode", port)
+		modeKey := uri + "/mode"
 		modeValue, modeExists := data[modeKey]
 		if !modeExists {
-			s.logger.Warnf("Mode not found for port %d", port)
+			s.logger.Warnf("Mode not found for %s", uri)
 			continue
 		}
 
 		if modeValue.Code == 200 && modeValue.Data != nil {
 			mode, err := parseUint(modeValue.Data)
 			if err != nil {
-				s.logger.Errorf("Failed to parse mode for port %d: %v", port, err)
+				s.logger.Errorf("Failed to parse mode for %s: %v", uri, err)
 				return nil, err
 			}
 			deviceInfo.Mode = uint(mode)
-			s.logger.Debugf("Port %d: Mode set to %d", port, mode)
+			s.logger.Debugf("%s: Mode set to %d", uri, mode)
 		} else {
-			s.logger.Warnf("Failed to get mode for port %d: %v", port, modeValue)
-			if modeValue.Code != 200 {
+			switch modeValue.Code {
+			case 503:
+				s.logger.Debugf("%s not paired", uri)
+			case 404:
+				s.logger.Debugf("%s does not exist on device", uri)
+			default:
 				diagnosticMessage := GetDiagnosticMessage(modeValue.Code)
 				s.logger.Warnf("Response Code: %s", diagnosticMessage)
 			}
@@ -77,127 +100,127 @@ func (s *SensorConnectInput) GetUsedPortsAndMode(ctx context.Context) (map[int]C
 		if deviceInfo.Mode == 3 { // IO-Link mode
 
 			// Process device ID
-			deviceIDKey := fmt.Sprintf("/iolinkmaster/port[%d]/iolinkdevice/deviceid", port)
+			deviceIDKey := uri + "/iolinkdevice/deviceid"
 			deviceIDValue, exists := data[deviceIDKey]
 			if !exists || deviceIDValue.Code != 200 || deviceIDValue.Data == nil {
 				if deviceIDValue.Code == 503 {
-					s.logger.Debugf("DeviceID not available for port %d (code 503), marking as disconnected", port)
+					s.logger.Debugf("DeviceID not available for port %d (code 503), marking as disconnected", uri)
 					deviceInfo.Connected = false
-					portModeUsageMap[port] = deviceInfo
+					connectedDevices = append(connectedDevices, deviceInfo)
 					continue
 				}
 
-				s.logger.Warnf("Failed to get deviceID for port %d: %v", port, deviceIDValue)
+				s.logger.Warnf("Failed to get deviceID for %s: %v", uri, deviceIDValue)
 				deviceInfo.Connected = false
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue // Cannot proceed without device ID
 			}
 
 			deviceID, err := parseUint(deviceIDValue.Data)
 			if err != nil {
-				s.logger.Errorf("Failed to parse deviceID for port %d: %v", port, err)
+				s.logger.Errorf("Failed to parse deviceID for %s: %v", uri, err)
 				deviceInfo.Connected = false
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue // Cannot proceed without valid device ID
 			}
 			deviceInfo.DeviceID = uint(deviceID)
-			s.logger.Debugf("Port %d: DeviceID set to %d", port, deviceID)
+			s.logger.Debugf("%s: DeviceID set to %d", uri, deviceID)
 
 			// Process vendor ID
-			vendorIDKey := fmt.Sprintf("/iolinkmaster/port[%d]/iolinkdevice/vendorid", port)
+			vendorIDKey := uri + "/iolinkdevice/vendorid"
 			vendorIDValue, exists := data[vendorIDKey]
 			if !exists || vendorIDValue.Code != 200 || vendorIDValue.Data == nil {
 				if vendorIDValue.Code == 503 {
-					s.logger.Debugf("VendorID not available for port %d (code 503), marking as disconnected", port)
+					s.logger.Debugf("VendorID not available for %s (code 503), marking as disconnected", uri)
 					deviceInfo.Connected = false
-					portModeUsageMap[port] = deviceInfo
+					connectedDevices = append(connectedDevices, deviceInfo)
 					continue
 				}
 
-				s.logger.Warnf("Failed to get vendorID for port %d: %v", port, vendorIDValue)
+				s.logger.Warnf("Failed to get vendorID for port %s: %v", uri, vendorIDValue)
 				deviceInfo.Connected = false
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue // Cannot proceed without vendor ID
 			}
 
 			vendorID, err := parseUint(vendorIDValue.Data)
 			if err != nil {
-				s.logger.Errorf("Failed to parse vendorID for port %d: %v", port, err)
+				s.logger.Errorf("Failed to parse vendorID for %s: %v", uri, err)
 				deviceInfo.Connected = false
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue // Cannot proceed without valid vendor ID
 			}
 			deviceInfo.VendorID = uint(vendorID)
-			s.logger.Debugf("Port %d: VendorID set to %d", port, vendorID)
+			s.logger.Debugf("%s: VendorID set to %d", uri, vendorID)
 
 			// Process product name
-			productNameKey := fmt.Sprintf("/iolinkmaster/port[%d]/iolinkdevice/productname", port)
+			productNameKey := uri + "/iolinkdevice/productname"
 			productNameValue, exists := data[productNameKey]
 			if !exists || productNameValue.Data == nil || productNameValue.Code == 503 {
-				s.logger.Infof("ProductName not available for port %d", port)
+				s.logger.Infof("ProductName not available for %s", uri)
 			} else if productNameValue.Code == 200 {
 				productName, err := parseString(productNameValue.Data)
 				if err != nil {
-					s.logger.Errorf("Failed to parse productName for port %d: %v", port, err)
+					s.logger.Errorf("Failed to parse productName for %s: %v", uri, err)
 				} else {
 					deviceInfo.ProductName = productName
-					s.logger.Debugf("Port %d: ProductName set to %s", port, productName)
+					s.logger.Debugf("%s: ProductName set to %s", uri, productName)
 				}
 			} else {
-				s.logger.Warnf("Unexpected code for productName on port %d: %d", port, productNameValue.Code)
+				s.logger.Warnf("Unexpected code for productName on %s: %d", uri, productNameValue.Code)
 			}
 
 			// Process serial number
-			serialKey := fmt.Sprintf("/iolinkmaster/port[%d]/iolinkdevice/serial", port)
+			serialKey := uri + "/iolinkdevice/serial"
 			serialValue, exists := data[serialKey]
 			if !exists || serialValue.Data == nil || serialValue.Code == 503 {
-				s.logger.Infof("Serial number not available for port %d", port)
+				s.logger.Infof("Serial number not available for port %d", uri)
 			} else if serialValue.Code == 200 {
 				serial, err := parseString(serialValue.Data)
 				if err != nil {
-					s.logger.Errorf("Failed to parse serial number for port %d: %v", port, err)
+					s.logger.Errorf("Failed to parse serial number for %s: %v", uri, err)
 				} else {
 					deviceInfo.Serial = serial
-					s.logger.Debugf("Port %d: Serial number set to %s", port, serial)
+					s.logger.Debugf("%s: Serial number set to %s", uri, serial)
 				}
 			} else {
-				s.logger.Warnf("Unexpected code for serial number on port %d: %d", port, serialValue.Code)
+				s.logger.Warnf("Unexpected code for serial number on %s: %d", uri, serialValue.Code)
 			}
 
 		} else {
 			// For non-IO-Link modes, no product information is expected
-			s.logger.Debugf("Port %d is in mode %d, skipping product info", port, deviceInfo.Mode)
+			s.logger.Debugf("%s is in mode %d, skipping product info", uri, deviceInfo.Mode)
 		}
 
 		// Add the deviceInfo to the map
-		portModeUsageMap[port] = deviceInfo
+		connectedDevices = append(connectedDevices, deviceInfo)
 	}
 
 	// Check and fetch IODD files for IO-Link devices if necessary
-	for port, info := range portModeUsageMap {
-		if info.Mode == 3 && info.Connected && info.DeviceID != 0 && info.VendorID != 0 {
-			s.logger.Debugf("IO-Link device found on port %d, checking IODD files for Device ID: %d, Vendor ID: %d", port, info.DeviceID, info.VendorID)
+	for _, device := range connectedDevices {
+		if device.Mode == 3 && device.Connected && device.DeviceID != 0 && device.VendorID != 0 {
+			s.logger.Debugf("IO-Link device found %s, checking IODD files for Device ID: %d, Vendor ID: %d", device.Uri, device.DeviceID, device.VendorID)
 			ioddFilemapKey := IoddFilemapKey{
-				DeviceId: int(info.DeviceID),
-				VendorId: int64(info.VendorID),
+				DeviceId: int(device.DeviceID),
+				VendorId: int64(device.VendorID),
 			}
 			err := s.AddNewDeviceToIoddFilesAndMap(ctx, ioddFilemapKey)
 			if err != nil || s.UseOnlyRawData { // If there is an error or the plugin is set to use only raw data, set the port to use raw data
 				s.logger.Warnf("Failed to find iodd file: %v", err)
-				s.logger.Warnf("Setting port %d to use raw data", port)
-				deviceInfo := portModeUsageMap[port]
+				s.logger.Warnf("Setting device %s to use raw data", device.Uri)
+				deviceInfo := device
 				deviceInfo.UseRawData = true
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue
 			}
 		}
 	}
 
-	return portModeUsageMap, nil
+	return connectedDevices, nil
 }
 
 // getUsedPortsAndMode sends a request to the device to get information about used ports and their modes
-func (s *SensorConnectInput) getUsedPortsAndMode(ctx context.Context) (RawUsedPortsAndMode, error) {
+func (s *SensorConnectInput) getUsedPortsAndMode(ctx context.Context) (map[string]UPAMDatum, error) {
 	// Define the data points to request for each port
 	var dataPoints []string
 	for port := 1; port <= 8; port++ {
@@ -210,33 +233,54 @@ func (s *SensorConnectInput) getUsedPortsAndMode(ctx context.Context) (RawUsedPo
 		)
 	}
 
-	requestData := map[string]interface{}{
-		"code": "request",
-		"adr":  "/getdatamulti",
-		"data": map[string]interface{}{
-			"datatosend": dataPoints,
-		},
+	// The EIO404 Bluetooth Mesh IoT Base Station supports up to 50 EIO344 Bluetooth Mesh IO-Link Adapters.
+	// Note that each EIO344 Bluetooth Mesh IO-Link Adapter is limited to a single IO-Link port.
+	for meshAdapter := 1; meshAdapter <= 50; meshAdapter++ {
+		dataPoints = append(dataPoints,
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/mode", meshAdapter),
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/iolinkdevice/deviceid", meshAdapter),
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/iolinkdevice/vendorid", meshAdapter),
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/iolinkdevice/productname", meshAdapter),
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/iolinkdevice/serial", meshAdapter),
+		)
 	}
 
-	response, err := s.SendRequestToDevice(ctx, requestData)
-	if err != nil {
-		return RawUsedPortsAndMode{}, err
+	// To avoid HTTP 413 "Payload Too Large" or 507 "Insufficient Storage" errors, we need to request data in batches, splitting the payload into smaller, manageable chunks.
+	badgeSize := 50
+	result := map[string]UPAMDatum{}
+
+	for offset := 0; offset < len(dataPoints); offset += badgeSize {
+		limit := min(badgeSize, len(dataPoints)-offset)
+		requestData := map[string]interface{}{
+			"code": "request",
+			"adr":  "/getdatamulti",
+			"data": map[string]interface{}{
+				"datatosend": dataPoints[offset : offset+limit],
+			},
+		}
+
+		response, err := s.SendRequestToDevice(ctx, requestData)
+		if err != nil {
+			return result, err
+		}
+
+		// Parse the response into RawUsedPortsAndMode struct
+		var rawData RawUsedPortsAndMode
+		responseBytes, err := json.Marshal(response)
+		if err != nil {
+			s.logger.Errorf("Failed to marshal response: %v", err)
+			return result, err
+		}
+		err = json.Unmarshal(responseBytes, &rawData)
+		if err != nil {
+			s.logger.Errorf("Failed to parse response: %v", err)
+			return result, err
+		}
+
+		maps.Copy(result, rawData.Data)
 	}
 
-	// Parse the response into RawUsedPortsAndMode struct
-	var rawData RawUsedPortsAndMode
-	responseBytes, err := json.Marshal(response)
-	if err != nil {
-		s.logger.Errorf("Failed to marshal response: %v", err)
-		return RawUsedPortsAndMode{}, err
-	}
-	err = json.Unmarshal(responseBytes, &rawData)
-	if err != nil {
-		s.logger.Errorf("Failed to parse response: %v", err)
-		return RawUsedPortsAndMode{}, err
-	}
-
-	return rawData, nil
+	return result, nil
 }
 
 // RawUsedPortsAndMode represents the raw response from the device for used ports and modes
@@ -252,21 +296,37 @@ type UPAMDatum struct {
 	Code int         `json:"code"`
 }
 
-// extractIntFromString extracts exactly one integer from a given string.
-// If no integer or more than one integer is found, it returns an error.
-func extractIntFromString(input string) (int, error) {
-	re := regexp.MustCompile("[0-9]+")
-	outputSlice := re.FindAllString(input, -1)
-	if len(outputSlice) != 1 {
-		err := fmt.Errorf("not exactly one integer found in string: %s", input)
-		return -1, err
+func extractUri(input string) (string, error) {
+	rx := regexp.MustCompile("(.*port\\[\\d*])(.*$)")
+	matches := rx.FindStringSubmatch(input)
+
+	if len(matches) > 1 {
+		return matches[1], nil
 	}
-	outputNumber, err := strconv.Atoi(outputSlice[0])
-	if err != nil {
-		err := fmt.Errorf("failed to convert string to integer: %s", outputSlice[0])
-		return -1, err
+
+	return "", fmt.Errorf("cannot find uri in %s", input)
+}
+
+func extractPort(input string) (string, error) {
+	rx := regexp.MustCompile("port\\[(\\d)\\]")
+	matches := rx.FindStringSubmatch(input)
+
+	if len(matches) > 1 {
+		return matches[1], nil
 	}
-	return outputNumber, nil
+
+	return "", fmt.Errorf("cannot find port in %s", input)
+}
+
+func extractBluetoothAdapter(input string) (string, error) {
+	rx := regexp.MustCompile("mesh_adapter\\[(\\d)\\]")
+	matches := rx.FindStringSubmatch(input)
+
+	if len(matches) > 1 {
+		return matches[1], nil
+	}
+
+	return "", fmt.Errorf("cannot find bluetooth mesh adapter in %s", input)
 }
 
 // parseUint parses an interface{} into uint64, handling both float64 and string types

--- a/sensorconnect_plugin/processSensorData.go
+++ b/sensorconnect_plugin/processSensorData.go
@@ -44,7 +44,7 @@ func (s *SensorConnectInput) ProcessSensorData(ctx context.Context, connectedDev
 			message.MetaSet("sensorconnect_device_url", s.DeviceInfo.URL)
 			message.MetaSet("sensorconnect_device_product_code", s.DeviceInfo.ProductCode)
 			message.MetaSet("sensorconnect_device_serial_number", s.DeviceInfo.SerialNumber)
-			message.MetaSet("sensorconnect_bluetooth_meshadapter", device.btAdapter)
+			message.MetaSet("sensorconnect_bluetooth_meshadapter", device.BtAdapter)
 
 			// Add message to batch
 			batch = append(batch, message)
@@ -107,7 +107,7 @@ func (s *SensorConnectInput) ProcessSensorData(ctx context.Context, connectedDev
 			message.MetaSet("sensorconnect_device_product_code", s.DeviceInfo.ProductCode)
 			message.MetaSet("sensorconnect_device_serial_number", s.DeviceInfo.SerialNumber)
 
-			message.MetaSet("sensorconnect_bluetooth_meshadapter", device.btAdapter)
+			message.MetaSet("sensorconnect_bluetooth_meshadapter", device.BtAdapter)
 
 			// Add message to batch
 			batch = append(batch, message)

--- a/sensorconnect_plugin/processSensorData.go
+++ b/sensorconnect_plugin/processSensorData.go
@@ -13,24 +13,22 @@ import (
 
 // ProcessSensorData processes the downloaded information from one IO-Link master
 // and returns a message batch with one message per sensor (active port).
-func (s *SensorConnectInput) ProcessSensorData(ctx context.Context, portModeMap map[int]ConnectedDeviceInfo, sensorDataMap map[string]interface{}) (service.MessageBatch, error) {
+func (s *SensorConnectInput) ProcessSensorData(ctx context.Context, connectedDevices []ConnectedDeviceInfo, sensorDataMap map[string]interface{}) (service.MessageBatch, error) {
 	// Initialize an empty MessageBatch to collect results from all ports
 	var batch service.MessageBatch
 
 	// Loop over the ports
-	for portNumber, portMode := range portModeMap {
-		if !portMode.Connected {
-			s.logger.Debugf("Port %v is not connected, skipping.", portNumber)
+	for _, device := range connectedDevices {
+		if !device.Connected {
+			s.logger.Debugf("%s is not connected, skipping.", device.Uri)
 			continue
 		}
 
 		// Process based on port mode
-		switch portMode.Mode {
+		switch device.Mode {
 		case 1: // Digital Input
-			s.logger.Debugf("Processing sensor data for port %v, mode %v", portNumber, portMode.Mode)
-			// Get value from sensorDataMap
-			portNumberString := strconv.Itoa(portNumber)
-			key := "/iolinkmaster/port[" + portNumberString + "]/pin2in"
+			s.logger.Debugf("Processing sensor data for port %v, mode %v", device.Uri, device.Mode)
+			key := device.Uri + "/pin2in"
 			dataPin2In, err := s.extractByteArrayFromSensorDataMap(key, "data", sensorDataMap)
 			if err != nil {
 				s.logger.Debugf("Error extracting dataPin2In from sensorDataMap: %v for key %s", err, key)
@@ -41,28 +39,28 @@ func (s *SensorConnectInput) ProcessSensorData(ctx context.Context, portModeMap 
 			message := service.NewMessage(dataPin2In)
 
 			message.MetaSet("sensorconnect_port_mode", "digital-input")
-			message.MetaSet("sensorconnect_port_number", portNumberString)
+			message.MetaSet("sensorconnect_port_number", device.Port)
 
 			message.MetaSet("sensorconnect_device_url", s.DeviceInfo.URL)
 			message.MetaSet("sensorconnect_device_product_code", s.DeviceInfo.ProductCode)
 			message.MetaSet("sensorconnect_device_serial_number", s.DeviceInfo.SerialNumber)
+			message.MetaSet("sensorconnect_bluetooth_meshadapter", device.btAdapter)
 
 			// Add message to batch
 			batch = append(batch, message)
 
 		case 3: // IO-Link
-			s.logger.Debugf("Processing IO-Link data for port %v, mode %v", portNumber, portMode.Mode)
+			s.logger.Debugf("Processing IO-Link data for port %v, mode %v", device.Uri, device.Mode)
 			// Get value from sensorDataMap
-			portNumberString := strconv.Itoa(portNumber)
-			keyPdin := "/iolinkmaster/port[" + portNumberString + "]/iolinkdevice/pdin"
+			keyPdin := device.Uri + "/iolinkdevice/pdin"
 			connectionCode, err := s.extractIntFromSensorDataMap(keyPdin, "code", sensorDataMap)
 			if err != nil {
-				s.logger.Warnf("Failed to extract connection code for port %v: %v", portNumber, err)
+				s.logger.Warnf("Failed to extract connection code %s: %v", device.Uri, err)
 				continue
 			}
 
 			if connectionCode != 200 {
-				s.logger.Debugf("Port %d is not connected", portNumber)
+				s.logger.Debugf("%s is not connected", device.Uri)
 				continue
 			}
 
@@ -72,12 +70,16 @@ func (s *SensorConnectInput) ProcessSensorData(ctx context.Context, portModeMap 
 				continue
 			}
 
+			// create IoddFilemapKey
+			var ioddFilemapKey IoddFilemapKey
+			ioddFilemapKey.DeviceId = int(device.DeviceID)
+			ioddFilemapKey.VendorId = int64(device.VendorID)
 			var payload map[string]interface{}
 
-			if !portMode.UseRawData {
-				payload, err = s.GetProcessedSensorDataFromRawSensorOutput(string(rawSensorOutput), portMode)
+			if !device.UseRawData {
+				payload, err = s.GetProcessedSensorDataFromRawSensorOutput(string(rawSensorOutput), device)
 			}
-			if err != nil || portMode.UseRawData { // if above did not work or UseRawData is set
+			if err != nil || device.UseRawData { // if above did not work or UseRawData is set
 				s.logger.Errorf("Failed to process sensor data: %v", err)
 				payload = make(map[string]interface{})
 				payload["raw_sensor_output"] = rawSensorOutput
@@ -95,20 +97,22 @@ func (s *SensorConnectInput) ProcessSensorData(ctx context.Context, portModeMap 
 			message := service.NewMessage(b)
 
 			message.MetaSet("sensorconnect_port_mode", "io-link")
-			message.MetaSet("sensorconnect_port_number", portNumberString)
-			message.MetaSet("sensorconnect_port_iolink_vendor_id", strconv.Itoa(int(portMode.VendorID)))
-			message.MetaSet("sensorconnect_port_iolink_device_id", strconv.Itoa(int(portMode.DeviceID)))
-			message.MetaSet("sensorconnect_port_iolink_product_name", portMode.ProductName)
-			message.MetaSet("sensorconnect_port_iolink_serial", portMode.Serial)
+			message.MetaSet("sensorconnect_port_number", device.Port)
+			message.MetaSet("sensorconnect_port_iolink_vendor_id", strconv.Itoa(int(device.VendorID)))
+			message.MetaSet("sensorconnect_port_iolink_device_id", strconv.Itoa(int(device.DeviceID)))
+			message.MetaSet("sensorconnect_port_iolink_product_name", device.ProductName)
+			message.MetaSet("sensorconnect_port_iolink_serial", device.Serial)
 
 			message.MetaSet("sensorconnect_device_url", s.DeviceInfo.URL)
 			message.MetaSet("sensorconnect_device_product_code", s.DeviceInfo.ProductCode)
 			message.MetaSet("sensorconnect_device_serial_number", s.DeviceInfo.SerialNumber)
 
+			message.MetaSet("sensorconnect_bluetooth_meshadapter", device.btAdapter)
+
 			// Add message to batch
 			batch = append(batch, message)
 		default:
-			s.logger.Warnf("Unsupported port mode %v on port %v", portMode.Mode, portNumber)
+			s.logger.Warnf("Unsupported port mode %v on port %v", device.Mode, device.Port)
 			continue
 		}
 	}

--- a/sensorconnect_plugin/sensorconnect.go
+++ b/sensorconnect_plugin/sensorconnect.go
@@ -177,7 +177,7 @@ func (s *SensorConnectInput) Connect(ctx context.Context) error {
 				"  VendorID    : %d\n"+
 				"  ProductName : %s\n"+
 				"  Serial      : %s\n",
-			device.btAdapter,
+			device.BtAdapter,
 			device.Port,
 			device.Mode,
 			device.Connected,
@@ -221,7 +221,7 @@ func (s *SensorConnectInput) ReadBatch(ctx context.Context) (service.MessageBatc
 							"  VendorID    : %d\n"+
 							"  ProductName : %s\n"+
 							"  Serial      : %s\n",
-						device.btAdapter,
+						device.BtAdapter,
 						device.Port,
 						device.Mode,
 						device.Connected,

--- a/sensorconnect_plugin/sensorconnect.go
+++ b/sensorconnect_plugin/sensorconnect.go
@@ -28,13 +28,13 @@ type SensorConnectInput struct {
 	IODDAPI       string
 
 	// Internal fields
-	DeviceInfo      DeviceInformation
-	CurrentPortMap  map[int]ConnectedDeviceInfo
-	lastPortMapTime time.Time
-	mu              sync.Mutex
-	logger          *service.Logger
-	CurrentCid      int16
-	UseOnlyRawData  bool // Use only raw data for sensor data. This is used for testing purposes and skips the iodd download
+	DeviceInfo       DeviceInformation
+	ConnectedDevices []ConnectedDeviceInfo
+	lastPortMapTime  time.Time
+	mu               sync.Mutex
+	logger           *service.Logger
+	CurrentCid       int16
+	UseOnlyRawData   bool // Use only raw data for sensor data. This is used for testing purposes and skips the iodd download
 
 	IoDeviceMap sync.Map // IoDeviceMap to store IoDevices
 }
@@ -155,34 +155,36 @@ func (s *SensorConnectInput) Connect(ctx context.Context) error {
 	s.logger.Infof("Connected to device at %s (SN: %s, PN: %s)", deviceInfo.URL, deviceInfo.SerialNumber, deviceInfo.ProductCode)
 
 	// Get Port Map and Print
-	portMap, err := s.GetUsedPortsAndMode(ctx)
+	devices, err := s.GetConnectedDevices(ctx)
 	if err != nil {
 		s.logger.Errorf("Failed to fetch port map %s: %v", s.DeviceAddress, err)
 		return err
 	}
 
 	s.mu.Lock()
-	s.CurrentPortMap = portMap
+	s.ConnectedDevices = devices
 	s.lastPortMapTime = time.Now()
 	s.mu.Unlock()
 
 	s.logger.Infof("Port Map for device at %s:", s.DeviceAddress)
-	for port, info := range portMap {
+	for _, device := range devices {
 		s.logger.Infof(
-			"Port %d:\n"+
+			"Bluetooth Adapter: %s \n"+
+				"  Port %s:\n"+
 				"  Mode        : %d\n"+
 				"  Connected   : %t\n"+
 				"  DeviceID    : %d\n"+
 				"  VendorID    : %d\n"+
 				"  ProductName : %s\n"+
 				"  Serial      : %s\n",
-			port,
-			info.Mode,
-			info.Connected,
-			info.DeviceID,
-			info.VendorID,
-			info.ProductName,
-			info.Serial,
+			device.btAdapter,
+			device.Port,
+			device.Mode,
+			device.Connected,
+			device.DeviceID,
+			device.VendorID,
+			device.ProductName,
+			device.Serial,
 		)
 	}
 
@@ -198,33 +200,35 @@ func (s *SensorConnectInput) ReadBatch(ctx context.Context) (service.MessageBatc
 
 		go func() {
 			// Attempt to fetch the updated port map
-			updatedPortMap, err := s.GetUsedPortsAndMode(ctx)
+			updatedDevices, err := s.GetConnectedDevices(ctx)
 			s.mu.Lock()
 
 			if err != nil {
 				s.logger.Errorf("Failed to update port map for device at %s: %v", s.DeviceAddress, err)
 				// Proceed with old port map
 			} else {
-				s.CurrentPortMap = updatedPortMap
+				s.ConnectedDevices = updatedDevices
 				s.lastPortMapTime = time.Now()
 
 				s.logger.Infof("Updated Port Map for device at %s:", s.DeviceAddress)
-				for port, info := range updatedPortMap {
+				for _, device := range updatedDevices {
 					s.logger.Infof(
-						"Port %d:\n"+
+						"  Bluetooth Adapter: %s \n"+
+							"  Port %s:\n"+
 							"  Mode        : %d\n"+
 							"  Connected   : %t\n"+
 							"  DeviceID    : %d\n"+
 							"  VendorID    : %d\n"+
 							"  ProductName : %s\n"+
 							"  Serial      : %s\n",
-						port,
-						info.Mode,
-						info.Connected,
-						info.DeviceID,
-						info.VendorID,
-						info.ProductName,
-						info.Serial,
+						device.btAdapter,
+						device.Port,
+						device.Mode,
+						device.Connected,
+						device.DeviceID,
+						device.VendorID,
+						device.ProductName,
+						device.Serial,
 					)
 				}
 			}
@@ -241,7 +245,7 @@ func (s *SensorConnectInput) ReadBatch(ctx context.Context) (service.MessageBatc
 	}
 
 	// Create a message batch
-	msgBatch, err := s.ProcessSensorData(ctx, s.CurrentPortMap, sensorData)
+	msgBatch, err := s.ProcessSensorData(ctx, s.ConnectedDevices, sensorData)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Reference implementation for suggested feature: #77

### Breaking Changes:

Instead of using only the port number as the unique identifier for connected devices, the entire URI will be used.

e.g. `string: /iolinkmaster/port[1]/` or `string: /meshnetwork/mesh_adapter[1]/iolinkmaster/port[1] `

This replaces the previous method of using eg. `int: 1` to identify a connected sensor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced documentation in the README, including detailed descriptions for OPC UA, S7comm, Modbus, and SensorConnect plugins.
  - Added support for additional devices in the SensorConnect plugin.
  - Introduced a new section for Beckhoff ADS protocol.

- **Improvements**
  - Streamlined handling of connected devices, shifting from a port-centric to a device-centric approach.
  - Improved error handling and logging for better clarity and troubleshooting.

- **Documentation**
  - Expanded sections on Modbus, SensorConnect, and testing requirements for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->