### PR TITLE
Added support for EIO404 Bluetooth Mesh IoT Base Station. (#78)

### DIFF
--- a/.idea/runConfigurations/TestSensorconnectPlugin_in_github_com_united_manufacturing_hub_benthos_umh_sensorconnect_plugin.xml
+++ b/.idea/runConfigurations/TestSensorconnectPlugin_in_github_com_united_manufacturing_hub_benthos_umh_sensorconnect_plugin.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TestSensorconnectPlugin in github.com/united-manufacturing-hub/benthos-umh/sensorconnect_plugin" type="GoTestRunConfiguration" factoryName="Go Test" nameIsGenerated="true">
+    <module name="benthos-umh" />
+    <working_directory value="$PROJECT_DIR$/sensorconnect_plugin" />
+    <envs>
+      <env name="TEST_DEBUG_IFM_ENDPOINT" value="10.13.37.178" />
+    </envs>
+    <root_directory value="$PROJECT_DIR$" />
+    <kind value="PACKAGE" />
+    <package value="github.com/united-manufacturing-hub/benthos-umh/sensorconnect_plugin" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$" />
+    <framework value="gotest" />
+    <pattern value="^\QTestSensorconnectPlugin\E$" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ update-benthos:
   go get github.com/redpanda-data/benthos/v4@latest && \
   go mod tidy
 
-test-sensorconnect:
+# usage:
+# make test-sensorconnect TEST_DEBUG_IFM_ENDPOINT=10.13.37.176
+test-sensorconnect: test
 	./tmp/bin/benthos -c ./config/sensorconnect-test.yaml
 
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,8 @@ input:
     ```
 
 ### ifm IO-Link Master / "sensorconnect"
-The SensorConnect plugin facilitates communication with ifm electronic’s IO-Link Masters devices, such as the AL1350 IO-Link Master.
+The SensorConnect plugin facilitates communication with ifm electronic’s IO-Link Masters devices, such as the AL1350 or AL1352 IO-Link Masters.
+It also supports EIO404 Bluetooth mesh base stations with EIO344 Bluetooth mesh IO-Link adapters.
 It enables the integration of sensor data into Benthos pipelines by connecting to the device over HTTP and processing data from connected sensors, including digital inputs and IO-Link devices.
 The plugin handles parsing and interpreting IO-Link data using IODD files, converting raw sensor outputs into human-readable data.
 

--- a/config/sensorconnect-test.yaml
+++ b/config/sensorconnect-test.yaml
@@ -1,7 +1,6 @@
 input:
   sensorconnect:
-    device_address: "${DEVICE_ADDRESS}"
-    iodd_api: "${IODD_API}"
+    device_address: "${TEST_DEBUG_IFM_ENDPOINT}"
 
 pipeline:
   processors:

--- a/sensorconnect_plugin/customIodd_test.go
+++ b/sensorconnect_plugin/customIodd_test.go
@@ -34,12 +34,12 @@ var _ = Describe("FetchAndStoreCustomIODD", func() {
 
 		// Initialize SensorConnectInput with necessary fields
 		input = &sensorconnect_plugin.SensorConnectInput{
-			IoDeviceMap:    sync.Map{},
-			UseOnlyRawData: false,
-			DeviceAddress:  "192.168.0.1",
-			IODDAPI:        "https://management.umh.app/iodd",
-			CurrentCid:     0,
-			CurrentPortMap: make(map[int]sensorconnect_plugin.ConnectedDeviceInfo),
+			IoDeviceMap:      sync.Map{},
+			UseOnlyRawData:   false,
+			DeviceAddress:    "192.168.0.1",
+			IODDAPI:          "https://management.umh.app/iodd",
+			CurrentCid:       0,
+			ConnectedDevices: []sensorconnect_plugin.ConnectedDeviceInfo{},
 		}
 
 		// Setup mock server to simulate IODD URL responses

--- a/sensorconnect_plugin/downloadPortModeData.go
+++ b/sensorconnect_plugin/downloadPortModeData.go
@@ -343,7 +343,7 @@ func extractPort(input string) (string, error) {
 // extractBluetoothAdapter extracts the bluetooth adapter id from the sensor uri.
 // to append it later to message metadata
 func extractBluetoothAdapter(input string) (string, error) {
-	rx := regexp.MustCompile("mesh_adapter\\[(\\d)\\]")
+	rx := regexp.MustCompile("mesh_adapter\\[(\\d+)\\]")
 	matches := rx.FindStringSubmatch(input)
 
 	if len(matches) > 1 {

--- a/sensorconnect_plugin/downloadPortModeData.go
+++ b/sensorconnect_plugin/downloadPortModeData.go
@@ -329,7 +329,7 @@ func extractUri(input string) (string, error) {
 // extractPort extracts the physical connected port id from the sensor uri
 // to append it later to message metadata
 func extractPort(input string) (string, error) {
-	rx := regexp.MustCompile("port\\[(\\d)\\]")
+	rx := regexp.MustCompile("port\\[(\\d+)\\]")
 	matches := rx.FindStringSubmatch(input)
 
 	if len(matches) > 1 {

--- a/sensorconnect_plugin/downloadPortModeData.go
+++ b/sensorconnect_plugin/downloadPortModeData.go
@@ -3,70 +3,98 @@ package sensorconnect_plugin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // ConnectedDeviceInfo represents information about a connected device on a port
 type ConnectedDeviceInfo struct {
+	Uri         string
 	Mode        uint
 	Connected   bool
 	DeviceID    uint
 	VendorID    uint
 	ProductName string
 	Serial      string
+	Port        string
 	UseRawData  bool // If true, the raw data will be used instead of the parsed data. This flag is automatically set if there is no IODD file available
+	BtAdapter   string
 }
 
-// GetUsedPortsAndMode returns a map of the IO-Link Master's ports with port numbers as keys and ConnectedDeviceInfo as values
-func (s *SensorConnectInput) GetUsedPortsAndMode(ctx context.Context) (map[int]ConnectedDeviceInfo, error) {
+// BadgeSize is Maximum possible size of the "/getdatamulti" request, determined for AL1352 and EIO404 Devices.
+const BadgeSize = 50
+
+// GetConnectedDevices returns a map of the IO-Link Master's ports with port numbers as keys and ConnectedDeviceInfo as values
+func (s *SensorConnectInput) GetConnectedDevices(ctx context.Context) ([]ConnectedDeviceInfo, error) {
 	response, err := s.getUsedPortsAndMode(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Group the response data by port
-	portData := make(map[int]map[string]UPAMDatum)
-	for key, value := range response.Data {
-		port, err := extractIntFromString(key)
+	// Group the response data by uri
+	uris := make(map[string]map[string]UPAMDatum)
+	for key, value := range response {
+		uri, err := extractUri(key)
 		if err != nil {
-			s.logger.Warnf("Failed to extract port number from key %s: %v", key, err)
+			s.logger.Warnf(err.Error())
 			continue
 		}
 
-		if _, exists := portData[port]; !exists {
-			portData[port] = make(map[string]UPAMDatum)
+		if _, exists := uris[uri]; !exists {
+			uris[uri] = make(map[string]UPAMDatum)
 		}
-		portData[port][key] = value
+		uris[uri][key] = value
 	}
 
-	portModeUsageMap := make(map[int]ConnectedDeviceInfo)
+	var connectedDevices []ConnectedDeviceInfo
 
-	// Process each port's data
-	for port, data := range portData {
-		deviceInfo := ConnectedDeviceInfo{}
+	//// Process each uri's data
+	for uri, data := range uris {
+		deviceInfo := ConnectedDeviceInfo{Uri: uri}
 		deviceInfo.Connected = true // Default to connected unless proven otherwise
 
+		btAdapter, err := extractBluetoothAdapter(uri)
+		if err != nil {
+			s.logger.Debugf(err.Error())
+			deviceInfo.BtAdapter = "none"
+		} else {
+			deviceInfo.BtAdapter = btAdapter
+		}
+
+		port, err := extractPort(uri)
+		if err != nil {
+			s.logger.Errorf(err.Error())
+		} else {
+			deviceInfo.Port = port
+		}
+
 		// Process the mode first
-		modeKey := fmt.Sprintf("/iolinkmaster/port[%d]/mode", port)
+		modeKey := uri + "/mode"
 		modeValue, modeExists := data[modeKey]
 		if !modeExists {
-			s.logger.Warnf("Mode not found for port %d", port)
+			s.logger.Warnf("Mode not found for %s", uri)
 			continue
 		}
 
 		if modeValue.Code == 200 && modeValue.Data != nil {
 			mode, err := parseUint(modeValue.Data)
 			if err != nil {
-				s.logger.Errorf("Failed to parse mode for port %d: %v", port, err)
+				s.logger.Errorf("Failed to parse mode for %s: %v", uri, err)
 				return nil, err
 			}
 			deviceInfo.Mode = uint(mode)
-			s.logger.Debugf("Port %d: Mode set to %d", port, mode)
+			s.logger.Debugf("%s: Mode set to %d", uri, mode)
 		} else {
-			s.logger.Warnf("Failed to get mode for port %d: %v", port, modeValue)
-			if modeValue.Code != 200 {
+			switch modeValue.Code {
+			case 503:
+				s.logger.Debugf("%s not paired", uri)
+			case 404:
+				s.logger.Debugf("%s does not exist on device", uri)
+			default:
 				diagnosticMessage := GetDiagnosticMessage(modeValue.Code)
 				s.logger.Warnf("Response Code: %s", diagnosticMessage)
 			}
@@ -77,128 +105,130 @@ func (s *SensorConnectInput) GetUsedPortsAndMode(ctx context.Context) (map[int]C
 		if deviceInfo.Mode == 3 { // IO-Link mode
 
 			// Process device ID
-			deviceIDKey := fmt.Sprintf("/iolinkmaster/port[%d]/iolinkdevice/deviceid", port)
+			deviceIDKey := uri + "/iolinkdevice/deviceid"
 			deviceIDValue, exists := data[deviceIDKey]
 			if !exists || deviceIDValue.Code != 200 || deviceIDValue.Data == nil {
 				if deviceIDValue.Code == 503 {
-					s.logger.Debugf("DeviceID not available for port %d (code 503), marking as disconnected", port)
+					s.logger.Debugf("DeviceID not available for %s (code 503), marking as disconnected", uri)
 					deviceInfo.Connected = false
-					portModeUsageMap[port] = deviceInfo
+					connectedDevices = append(connectedDevices, deviceInfo)
 					continue
 				}
 
-				s.logger.Warnf("Failed to get deviceID for port %d: %v", port, deviceIDValue)
+				s.logger.Warnf("Failed to get deviceID for %s: %v", uri, deviceIDValue)
 				deviceInfo.Connected = false
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue // Cannot proceed without device ID
 			}
 
 			deviceID, err := parseUint(deviceIDValue.Data)
 			if err != nil {
-				s.logger.Errorf("Failed to parse deviceID for port %d: %v", port, err)
+				s.logger.Errorf("Failed to parse deviceID for %s: %v", uri, err)
 				deviceInfo.Connected = false
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue // Cannot proceed without valid device ID
 			}
 			deviceInfo.DeviceID = uint(deviceID)
-			s.logger.Debugf("Port %d: DeviceID set to %d", port, deviceID)
+			s.logger.Debugf("%s: DeviceID set to %d", uri, deviceID)
 
 			// Process vendor ID
-			vendorIDKey := fmt.Sprintf("/iolinkmaster/port[%d]/iolinkdevice/vendorid", port)
+			vendorIDKey := uri + "/iolinkdevice/vendorid"
 			vendorIDValue, exists := data[vendorIDKey]
 			if !exists || vendorIDValue.Code != 200 || vendorIDValue.Data == nil {
 				if vendorIDValue.Code == 503 {
-					s.logger.Debugf("VendorID not available for port %d (code 503), marking as disconnected", port)
+					s.logger.Debugf("VendorID not available for %s (code 503), marking as disconnected", uri)
 					deviceInfo.Connected = false
-					portModeUsageMap[port] = deviceInfo
+					connectedDevices = append(connectedDevices, deviceInfo)
 					continue
 				}
 
-				s.logger.Warnf("Failed to get vendorID for port %d: %v", port, vendorIDValue)
+				s.logger.Warnf("Failed to get vendorID for port %s: %v", uri, vendorIDValue)
 				deviceInfo.Connected = false
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue // Cannot proceed without vendor ID
 			}
 
 			vendorID, err := parseUint(vendorIDValue.Data)
 			if err != nil {
-				s.logger.Errorf("Failed to parse vendorID for port %d: %v", port, err)
+				s.logger.Errorf("Failed to parse vendorID for %s: %v", uri, err)
 				deviceInfo.Connected = false
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue // Cannot proceed without valid vendor ID
 			}
 			deviceInfo.VendorID = uint(vendorID)
-			s.logger.Debugf("Port %d: VendorID set to %d", port, vendorID)
+			s.logger.Debugf("%s: VendorID set to %d", uri, vendorID)
 
 			// Process product name
-			productNameKey := fmt.Sprintf("/iolinkmaster/port[%d]/iolinkdevice/productname", port)
+			productNameKey := uri + "/iolinkdevice/productname"
 			productNameValue, exists := data[productNameKey]
 			if !exists || productNameValue.Data == nil || productNameValue.Code == 503 {
-				s.logger.Infof("ProductName not available for port %d", port)
+				s.logger.Infof("ProductName not available for %s", uri)
 			} else if productNameValue.Code == 200 {
 				productName, err := parseString(productNameValue.Data)
 				if err != nil {
-					s.logger.Errorf("Failed to parse productName for port %d: %v", port, err)
+					s.logger.Errorf("Failed to parse productName for %s: %v", uri, err)
 				} else {
 					deviceInfo.ProductName = productName
-					s.logger.Debugf("Port %d: ProductName set to %s", port, productName)
+					s.logger.Debugf("%s: ProductName set to %s", uri, productName)
 				}
 			} else {
-				s.logger.Warnf("Unexpected code for productName on port %d: %d", port, productNameValue.Code)
+				s.logger.Warnf("Unexpected code for productName on %s: %d", uri, productNameValue.Code)
 			}
 
 			// Process serial number
-			serialKey := fmt.Sprintf("/iolinkmaster/port[%d]/iolinkdevice/serial", port)
+			serialKey := uri + "/iolinkdevice/serial"
 			serialValue, exists := data[serialKey]
 			if !exists || serialValue.Data == nil || serialValue.Code == 503 {
-				s.logger.Infof("Serial number not available for port %d", port)
+				s.logger.Infof("Serial number not available for port %s", uri)
 			} else if serialValue.Code == 200 {
 				serial, err := parseString(serialValue.Data)
 				if err != nil {
-					s.logger.Errorf("Failed to parse serial number for port %d: %v", port, err)
+					s.logger.Errorf("Failed to parse serial number for %s: %v", uri, err)
 				} else {
 					deviceInfo.Serial = serial
-					s.logger.Debugf("Port %d: Serial number set to %s", port, serial)
+					s.logger.Debugf("%s: Serial number set to %s", uri, serial)
 				}
 			} else {
-				s.logger.Warnf("Unexpected code for serial number on port %d: %d", port, serialValue.Code)
+				s.logger.Warnf("Unexpected code for serial number on %s: %d", uri, serialValue.Code)
 			}
 
 		} else {
 			// For non-IO-Link modes, no product information is expected
-			s.logger.Debugf("Port %d is in mode %d, skipping product info", port, deviceInfo.Mode)
+			s.logger.Debugf("%s is in mode %d, skipping product info", uri, deviceInfo.Mode)
 		}
 
 		// Add the deviceInfo to the map
-		portModeUsageMap[port] = deviceInfo
+		connectedDevices = append(connectedDevices, deviceInfo)
 	}
 
 	// Check and fetch IODD files for IO-Link devices if necessary
-	for port, info := range portModeUsageMap {
-		if info.Mode == 3 && info.Connected && info.DeviceID != 0 && info.VendorID != 0 {
-			s.logger.Debugf("IO-Link device found on port %d, checking IODD files for Device ID: %d, Vendor ID: %d", port, info.DeviceID, info.VendorID)
+	for _, device := range connectedDevices {
+		if device.Mode == 3 && device.Connected && device.DeviceID != 0 && device.VendorID != 0 {
+			s.logger.Debugf("IO-Link device found %s, checking IODD files for Device ID: %d, Vendor ID: %d", device.Uri, device.DeviceID, device.VendorID)
 			ioddFilemapKey := IoddFilemapKey{
-				DeviceId: int(info.DeviceID),
-				VendorId: int64(info.VendorID),
+				DeviceId: int(device.DeviceID),
+				VendorId: int64(device.VendorID),
 			}
 			err := s.AddNewDeviceToIoddFilesAndMap(ctx, ioddFilemapKey)
 			if err != nil || s.UseOnlyRawData { // If there is an error or the plugin is set to use only raw data, set the port to use raw data
 				s.logger.Warnf("Failed to find iodd file: %v", err)
-				s.logger.Warnf("Setting port %d to use raw data", port)
-				deviceInfo := portModeUsageMap[port]
+				s.logger.Warnf("Setting device %s to use raw data", device.Uri)
+				deviceInfo := device
 				deviceInfo.UseRawData = true
-				portModeUsageMap[port] = deviceInfo
+				connectedDevices = append(connectedDevices, deviceInfo)
 				continue
 			}
 		}
 	}
 
-	return portModeUsageMap, nil
+	return connectedDevices, nil
 }
 
 // getUsedPortsAndMode sends a request to the device to get information about used ports and their modes
-func (s *SensorConnectInput) getUsedPortsAndMode(ctx context.Context) (RawUsedPortsAndMode, error) {
+func (s *SensorConnectInput) getUsedPortsAndMode(ctx context.Context) (map[string]UPAMDatum, error) {
 	// Define the data points to request for each port
+	// We also request the states of peripheral ports on EIO404, even though these models do not have any peripheral ports
+	// Devices return status code 404 for not existing peripheral ports
 	var dataPoints []string
 	for port := 1; port <= 8; port++ {
 		dataPoints = append(dataPoints,
@@ -210,33 +240,64 @@ func (s *SensorConnectInput) getUsedPortsAndMode(ctx context.Context) (RawUsedPo
 		)
 	}
 
-	requestData := map[string]interface{}{
-		"code": "request",
-		"adr":  "/getdatamulti",
-		"data": map[string]interface{}{
-			"datatosend": dataPoints,
-		},
+	// The EIO404 Bluetooth Mesh IoT Base Station supports up to 50 EIO344 Bluetooth Mesh IO-Link Adapters.
+	// Note that each EIO344 Bluetooth Mesh IO-Link Adapter is limited to a single IO-Link port.
+	// We also request the states of mesh adapters on the AL1350/AL1352, even though these models do not support bluetooth mesh adapters.
+	// Devices will return status code 503 for unprovisioned adapters and 404 for cases where no mesh adapters are supported.
+	for meshAdapter := 1; meshAdapter <= 50; meshAdapter++ {
+		dataPoints = append(dataPoints,
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/mode", meshAdapter),
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/iolinkdevice/deviceid", meshAdapter),
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/iolinkdevice/vendorid", meshAdapter),
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/iolinkdevice/productname", meshAdapter),
+			fmt.Sprintf("/meshnetwork/mesh_adapter[%d]/iolinkmaster/port[1]/iolinkdevice/serial", meshAdapter),
+		)
 	}
 
-	response, err := s.SendRequestToDevice(ctx, requestData)
-	if err != nil {
-		return RawUsedPortsAndMode{}, err
+	// To avoid HTTP 413 "Payload Too Large" or 507 "Insufficient Storage" errors, we need to request data in batches, splitting the payload into smaller, manageable chunks.
+	result := map[string]UPAMDatum{}
+	var errstrings []string
+
+	for offset := 0; offset < len(dataPoints); offset += BadgeSize {
+		limit := min(BadgeSize, len(dataPoints)-offset)
+		requestData := map[string]interface{}{
+			"code": "request",
+			"adr":  "/getdatamulti",
+			"data": map[string]interface{}{
+				"datatosend": dataPoints[offset : offset+limit],
+			},
+		}
+
+		response, err := s.SendRequestToDevice(ctx, requestData)
+		if err != nil {
+			s.logger.Errorf("Request data from device: %v", err)
+			errstrings = append(errstrings, err.Error())
+			continue
+		}
+
+		// Parse the response into RawUsedPortsAndMode struct
+		var rawData RawUsedPortsAndMode
+		responseBytes, err := json.Marshal(response)
+		if err != nil {
+			s.logger.Errorf("Failed to marshal response: %v", err)
+			errstrings = append(errstrings, err.Error())
+			continue
+		}
+		err = json.Unmarshal(responseBytes, &rawData)
+		if err != nil {
+			s.logger.Errorf("Failed to parse response: %v", err)
+			errstrings = append(errstrings, err.Error())
+			continue
+		}
+
+		maps.Copy(result, rawData.Data)
 	}
 
-	// Parse the response into RawUsedPortsAndMode struct
-	var rawData RawUsedPortsAndMode
-	responseBytes, err := json.Marshal(response)
-	if err != nil {
-		s.logger.Errorf("Failed to marshal response: %v", err)
-		return RawUsedPortsAndMode{}, err
-	}
-	err = json.Unmarshal(responseBytes, &rawData)
-	if err != nil {
-		s.logger.Errorf("Failed to parse response: %v", err)
-		return RawUsedPortsAndMode{}, err
+	if len(errstrings) > 0 {
+		return result, errors.New(strings.Join(errstrings, "\n"))
 	}
 
-	return rawData, nil
+	return result, nil
 }
 
 // RawUsedPortsAndMode represents the raw response from the device for used ports and modes
@@ -252,21 +313,43 @@ type UPAMDatum struct {
 	Code int         `json:"code"`
 }
 
-// extractIntFromString extracts exactly one integer from a given string.
-// If no integer or more than one integer is found, it returns an error.
-func extractIntFromString(input string) (int, error) {
-	re := regexp.MustCompile("[0-9]+")
-	outputSlice := re.FindAllString(input, -1)
-	if len(outputSlice) != 1 {
-		err := fmt.Errorf("not exactly one integer found in string: %s", input)
-		return -1, err
+// extractUri extracts the unique URI from a data request path.
+// The result is used as a unique identifier to identify a connected sensor.
+func extractUri(input string) (string, error) {
+	rx := regexp.MustCompile("(.*port\\[\\d*])(.*$)")
+	matches := rx.FindStringSubmatch(input)
+
+	if len(matches) > 1 {
+		return matches[1], nil
 	}
-	outputNumber, err := strconv.Atoi(outputSlice[0])
-	if err != nil {
-		err := fmt.Errorf("failed to convert string to integer: %s", outputSlice[0])
-		return -1, err
+
+	return "", fmt.Errorf("cannot find uri in %s", input)
+}
+
+// extractPort extracts the physical connected port id from the sensor uri
+// to append it later to message metadata
+func extractPort(input string) (string, error) {
+	rx := regexp.MustCompile("port\\[(\\d)\\]")
+	matches := rx.FindStringSubmatch(input)
+
+	if len(matches) > 1 {
+		return matches[1], nil
 	}
-	return outputNumber, nil
+
+	return "", fmt.Errorf("cannot find port in %s", input)
+}
+
+// extractBluetoothAdapter extracts the bluetooth adapter id from the sensor uri.
+// to append it later to message metadata
+func extractBluetoothAdapter(input string) (string, error) {
+	rx := regexp.MustCompile("mesh_adapter\\[(\\d)\\]")
+	matches := rx.FindStringSubmatch(input)
+
+	if len(matches) > 1 {
+		return matches[1], nil
+	}
+
+	return "", fmt.Errorf("cannot find bluetooth mesh adapter in %s", input)
 }
 
 // parseUint parses an interface{} into uint64, handling both float64 and string types

--- a/sensorconnect_plugin/downloadPortModeData_test.go
+++ b/sensorconnect_plugin/downloadPortModeData_test.go
@@ -36,7 +36,7 @@ var _ = Describe("DownloadPortModeData Integration Tests", func() {
 					CurrentCid:    0,
 				}
 
-				portMap, err := input.GetUsedPortsAndMode(context.Background())
+				portMap, err := input.GetConnectedDevices(context.Background())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(portMap[1].Mode).To(Equal(uint(3)))

--- a/sensorconnect_plugin/downloadSensorData_test.go
+++ b/sensorconnect_plugin/downloadSensorData_test.go
@@ -37,9 +37,9 @@ var _ = Describe("DownloadSensorData Integration Tests", func() {
 					CurrentCid:    0,
 				}
 
-				portMap, err := input.GetUsedPortsAndMode(context.Background())
+				portMap, err := input.GetConnectedDevices(context.Background())
 				Expect(err).NotTo(HaveOccurred())
-				input.CurrentPortMap = portMap
+				input.ConnectedDevices = portMap
 
 				dataMap, err := input.GetSensorDataMap(context.Background())
 				Expect(err).NotTo(HaveOccurred())

--- a/sensorconnect_plugin/processSensorData.go
+++ b/sensorconnect_plugin/processSensorData.go
@@ -79,8 +79,12 @@ func (s *SensorConnectInput) ProcessSensorData(ctx context.Context, connectedDev
 			if !device.UseRawData {
 				payload, err = s.GetProcessedSensorDataFromRawSensorOutput(string(rawSensorOutput), device)
 			}
-			if err != nil || device.UseRawData { // if above did not work or UseRawData is set
+
+			if err != nil {
 				s.logger.Errorf("Failed to process sensor data: %v", err)
+			}
+
+			if err != nil || device.UseRawData { // if above did not work or UseRawData is set
 				payload = make(map[string]interface{})
 				payload["raw_sensor_output"] = rawSensorOutput
 			}

--- a/sensorconnect_plugin/sensorconnect.go
+++ b/sensorconnect_plugin/sensorconnect.go
@@ -276,3 +276,7 @@ func init() {
 		panic(err)
 	}
 }
+
+func (s *SensorConnectInput) IsDeviceBluetoothMeshCompatible() bool {
+	return s.DeviceInfo.ProductCode == "EIO404"
+}


### PR DESCRIPTION
* Added support for EIO404 Bluetooth Mesh IoT Base Station. Changed device identification to use URI instead of por

* Apply Suggestions from PR

* Apply some suggestions from coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `README.md` with detailed descriptions of plugins and configuration options.
	- Added new sections for Modbus, SensorConnect, and Beckhoff ADS plugins.
	- Improved clarity on OPC UA and S7comm plugins with expanded functionality and configuration details.
	- Introduced a new method to check Bluetooth mesh compatibility for devices.

- **Bug Fixes**
	- Streamlined handling of connected devices across various methods, improving error reporting and data retrieval.

- **Documentation**
	- Comprehensive updates to the `README.md` to aid developers in understanding plugin functionalities and configurations.
	- Updated test cases to reflect changes in the handling of connected devices and methods.
	- Added usage comments in the Makefile for better guidance on test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->