### PR TITLE
Eng 2008 benthos umh struggles to read out arrays in opc ua v2

### DIFF
--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -52,6 +52,7 @@ func sanitize(s string) string {
 
 type Logger interface {
 	Debugf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
 }
 
 // Browse is a public wrapper function for the browse function
@@ -118,6 +119,34 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		Path:   newPath,
 	}
 
+	// Let's check the AccessLevel first
+
+	switch err := attrs[3].Status; {
+	case errors.Is(err, ua.StatusOK):
+		if attrs[3].Value == nil {
+			errChan <- errors.New("access level is nil")
+			return
+		} else {
+			def.AccessLevel = ua.AccessLevelType(attrs[3].Value.Int())
+		}
+	case errors.Is(err, ua.StatusBadAttributeIDInvalid):
+		// ignore
+	case errors.Is(err, ua.StatusBadSecurityModeInsufficient):
+		return
+	case errors.Is(err, ua.StatusBadNotReadable): // fallback option to not throw an error (this is "normal" for some servers)
+		logger.Warnf("Tried to browse node: %s but got access denied on getting the AccessLevel, continuing...\n", path)
+		// no need to return here, as we can continue without the AccessLevel for browsing
+	default:
+		errChan <- err
+		return
+	}
+
+	if def.AccessLevel == ua.AccessLevelTypeNone {
+		logger.Warnf("Tried to browse node: %s but access level is None ('access denied'). Do not subscribe to it, continuing browsing its children...\n", path)
+		def.NodeClass = ua.NodeClassObject // by setting it as an object, we will not subscribe to it
+		// we need to continue here, as we still want to browse the children of this node
+	}
+
 	switch err := attrs[0].Status; {
 	case errors.Is(err, ua.StatusOK):
 		if attrs[0].Value == nil {
@@ -128,6 +157,10 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		}
 	case errors.Is(err, ua.StatusBadSecurityModeInsufficient):
 		return
+	case errors.Is(err, ua.StatusBadNotReadable): // fallback option to not throw an error (this is "normal" for some servers)
+		logger.Warnf("Tried to browse node: %s but got access denied on getting the NodeClass, do not subscribe to it, continuing browsing its children...\n", path)
+		def.NodeClass = ua.NodeClassObject // by setting it as an object, we will not subscribe to it
+		// no need to return here, as we can continue without the NodeClass for browsing
 	default:
 		errChan <- err
 		return
@@ -143,6 +176,9 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		}
 	case errors.Is(err, ua.StatusBadSecurityModeInsufficient):
 		return
+	case errors.Is(err, ua.StatusBadNotReadable): // fallback option to not throw an error (this is "normal" for some servers)
+		logger.Warnf("Tried to browse node: %s but got access denied on getting the BrowseName, skipping...\n", path)
+		return // We need to return here, as we can't continue without the BrowseName (we need it at least for the path when browsing the children)
 	default:
 		errChan <- err
 		return
@@ -159,23 +195,10 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		// ignore
 	case errors.Is(err, ua.StatusBadSecurityModeInsufficient):
 		return
-	default:
-		errChan <- err
-		return
-	}
-
-	switch err := attrs[3].Status; {
-	case errors.Is(err, ua.StatusOK):
-		if attrs[3].Value == nil {
-			errChan <- errors.New("access level is nil")
-			return
-		} else {
-			def.AccessLevel = ua.AccessLevelType(attrs[3].Value.Int())
-		}
-	case errors.Is(err, ua.StatusBadAttributeIDInvalid):
-		// ignore
-	case errors.Is(err, ua.StatusBadSecurityModeInsufficient):
-		return
+	case errors.Is(err, ua.StatusBadNotReadable): // fallback option to not throw an error (this is "normal" for some servers)
+		logger.Warnf("Tried to browse node: %s but got access denied on getting the Description, do not subscribe to it, continuing browsing its children...\n", path)
+		def.NodeClass = ua.NodeClassObject // by setting it as an object, we will not subscribe to it
+		// no need to return here, as we can continue without the Description
 	default:
 		errChan <- err
 		return
@@ -225,6 +248,10 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		// ignore
 	case errors.Is(err, ua.StatusBadSecurityModeInsufficient):
 		return
+	case errors.Is(err, ua.StatusBadNotReadable): // fallback option to not throw an error (this is "normal" for some servers)
+		logger.Warnf("Tried to browse node: %s but got access denied on getting the DataType, do not subscribe to it, continuing browsing its children...\n", path)
+		def.NodeClass = ua.NodeClassObject // by setting it as an object, we will not subscribe to it
+		// no need to return here, as we can continue without the DataType
 	default:
 		errChan <- err
 		return
@@ -273,6 +300,8 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 	// Setting browseHierarchicalReferences to true will be the new way to browse for tags and folders properly without any duplicate browsing
 	if browseHierarchicalReferences {
 		switch def.NodeClass {
+
+		// If its a variable, we add it to the node list and browse all its children
 		case ua.NodeClassVariable:
 			if hasNodeReferencedComponents() {
 				if err := browseChildrenV2(id.HierarchicalReferences); err != nil {
@@ -282,9 +311,12 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 				return
 			}
 
+			// adding it to the node list
 			def.Path = join(path, def.BrowseName)
 			nodeChan <- def
 			return
+
+			// If its an object, we browse all its children but DO NOT add it to the node list and therefore not subscribe
 		case ua.NodeClassObject:
 			if err := browseChildrenV2(id.HierarchicalReferences); err != nil {
 				errChan <- err

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -196,7 +196,8 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		return
 	}
 
-	if def.AccessLevel == ua.AccessLevelTypeNone {
+	// if AccessLevel exists and it is set to None
+	if def.AccessLevel == ua.AccessLevelTypeNone && errors.Is(err, ua.StatusOK) {
 		logger.Warnf("Tried to browse node: %s but access level is None ('access denied'). Do not subscribe to it, continuing browsing its children...\n", path)
 		def.NodeClass = ua.NodeClassObject // by setting it as an object, we will not subscribe to it
 		// we need to continue here, as we still want to browse the children of this node

--- a/opcua_plugin/opcua_plc_test.go
+++ b/opcua_plugin/opcua_plc_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Test Against Siemens S7", Serial, func() {
 			return
 		}
 
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 45*time.Second)
 	})
 
 	AfterEach(func() {

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -2,6 +2,7 @@ package opcua_plugin_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -113,9 +114,9 @@ var _ = Describe("Unit Tests", func() {
 				rootNode := createMockVariableNode(1234, "TestNode")
 				rootNode.attributes = append(rootNode.attributes, getDataValueForNodeClass(ua.NodeClassVariable))
 				rootNode.attributes = append(rootNode.attributes, getDataValueForBrowseName("TestNode"))
-				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("Test Description"))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("Test Description", ua.StatusOK))
 				rootNode.attributes = append(rootNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead|ua.AccessLevelTypeCurrentWrite))
-				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(ua.TypeIDInt32))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(ua.TypeIDInt32, ua.StatusOK))
 
 				nodeBrowser = rootNode
 				wg.Add(1)
@@ -144,15 +145,15 @@ var _ = Describe("Unit Tests", func() {
 				rootNode := createMockVariableNode(1234, "TestNode")
 				rootNode.attributes = append(rootNode.attributes, getDataValueForNodeClass(ua.NodeClassObject))
 				rootNode.attributes = append(rootNode.attributes, getDataValueForBrowseName("TestNode"))
-				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("Test Description"))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("Test Description", ua.StatusOK))
 				rootNode.attributes = append(rootNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead|ua.AccessLevelTypeCurrentWrite))
-				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(ua.TypeIDInt32))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(ua.TypeIDInt32, ua.StatusOK))
 				childNode := createMockVariableNode(1223, "TestChildNode")
 				childNode.attributes = append(childNode.attributes, getDataValueForNodeClass(ua.NodeClassVariable))
 				childNode.attributes = append(childNode.attributes, getDataValueForBrowseName("TestChildNode"))
-				childNode.attributes = append(childNode.attributes, getDataValueForDescription("Test Child Description"))
+				childNode.attributes = append(childNode.attributes, getDataValueForDescription("Test Child Description", ua.StatusOK))
 				childNode.attributes = append(childNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead|ua.AccessLevelTypeCurrentWrite))
-				childNode.attributes = append(childNode.attributes, getDataValueForDataType(ua.TypeIDInt32))
+				childNode.attributes = append(childNode.attributes, getDataValueForDataType(ua.TypeIDInt32, ua.StatusOK))
 				rootNode.AddReferenceNode(id.HasComponent, childNode)
 
 				nodeBrowser = rootNode
@@ -184,15 +185,15 @@ var _ = Describe("Unit Tests", func() {
 				rootNode := createMockVariableNode(1234, "TestNode")
 				rootNode.attributes = append(rootNode.attributes, getDataValueForNodeClass(ua.NodeClassObject))
 				rootNode.attributes = append(rootNode.attributes, getDataValueForBrowseName("TestNode"))
-				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("Test Description"))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("Test Description", ua.StatusOK))
 				rootNode.attributes = append(rootNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead|ua.AccessLevelTypeCurrentWrite))
-				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(ua.TypeIDInt32))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(ua.TypeIDInt32, ua.StatusOK))
 				childNode := createMockVariableNode(1223, "TestChildNode")
 				childNode.attributes = append(childNode.attributes, getDataValueForNodeClass(ua.NodeClassVariable))
 				childNode.attributes = append(childNode.attributes, getDataValueForBrowseName("TestChildNode"))
-				childNode.attributes = append(childNode.attributes, getDataValueForDescription("Test Child Description"))
+				childNode.attributes = append(childNode.attributes, getDataValueForDescription("Test Child Description", ua.StatusOK))
 				childNode.attributes = append(childNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead|ua.AccessLevelTypeCurrentWrite))
-				childNode.attributes = append(childNode.attributes, getDataValueForDataType(ua.TypeIDInt32))
+				childNode.attributes = append(childNode.attributes, getDataValueForDataType(ua.TypeIDInt32, ua.StatusOK))
 				rootNode.AddReferenceNode(id.HasChild, childNode)
 
 				nodeBrowser = rootNode
@@ -226,21 +227,65 @@ var _ = Describe("Unit Tests", func() {
 				rootNode := createMockVariableNode(1234, "TestNode")
 				rootNode.attributes = append(rootNode.attributes, getDataValueForNodeClass(ua.NodeClassObject))
 				rootNode.attributes = append(rootNode.attributes, getDataValueForBrowseName("TestNode"))
-				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("Test Description"))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("Test Description", ua.StatusOK))
 				rootNode.attributes = append(rootNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead|ua.AccessLevelTypeCurrentWrite))
-				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(ua.TypeIDInt32))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(ua.TypeIDInt32, ua.StatusOK))
 				childNode := createMockVariableNode(1223, "TestChildNode")
 				childNode.attributes = append(childNode.attributes, getDataValueForNodeClass(ua.NodeClassVariable))
 				childNode.attributes = append(childNode.attributes, getDataValueForBrowseName("TestChildNode"))
-				childNode.attributes = append(childNode.attributes, getDataValueForDescription("Test Child Description"))
+				childNode.attributes = append(childNode.attributes, getDataValueForDescription("Test Child Description", ua.StatusOK))
 				childNode.attributes = append(childNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead|ua.AccessLevelTypeCurrentWrite))
-				childNode.attributes = append(childNode.attributes, getDataValueForDataType(ua.TypeIDInt32))
+				childNode.attributes = append(childNode.attributes, getDataValueForDataType(ua.TypeIDInt32, ua.StatusOK))
 				rootNode.AddReferenceNode(id.HasChild, childNode)
 
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
 					// set browseHierarchicalReferences to true for reference nodes like id.Organizes
+					browseHierarchicalReferences := true
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, pathIDMapChan, wg, browseHierarchicalReferences)
+				}()
+				wg.Wait()
+				close(nodeChan)
+				close(errChan)
+
+				var nodes []NodeDef
+				for nodeDef := range nodeChan {
+					nodes = append(nodes, nodeDef)
+				}
+
+				var errs []error
+				for err := range errChan {
+					errs = append(errs, err)
+				}
+
+				Expect(errs).Should(BeEmpty())
+				Expect(nodes).Should(HaveLen(1))
+				Expect(nodes[0].NodeID.String()).To(Equal("i=1223"))
+				Expect(nodes[0].BrowseName).To(Equal("TestChildNode"))
+			})
+		})
+
+		Context("When browsing nodes where the folder has a PermissionDenied on its Value and ValueRank but one can still see the contents of its children, which is stupid but so is OPC UA. This edge case has been sponsored by Siemens S7-1500 and the community member Diederik", func() {
+			It("root node with PermissionDenied should return 1 child ", func() {
+				rootNode := createMockVariableNode(1234, "08DischargeCartGroup")
+				rootNode.attributes = append(rootNode.attributes, getDataValueForNodeClass(ua.NodeClassVariable))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForBrowseName("3:08DischargeCartGroup"))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDescription("", ua.StatusBadAttributeIDInvalid))
+				rootNode.attributes = append(rootNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeNone)) // PermissionDenied and therefore this node should be ignored in the node-list, but still subscribed to
+				rootNode.attributes = append(rootNode.attributes, getDataValueForDataType(0, ua.StatusBadNotReadable))
+
+				childNode := createMockVariableNode(1223, "TestChildNode")
+				childNode.attributes = append(childNode.attributes, getDataValueForNodeClass(ua.NodeClassVariable))
+				childNode.attributes = append(childNode.attributes, getDataValueForBrowseName("TestChildNode"))
+				childNode.attributes = append(childNode.attributes, getDataValueForDescription("Test Child Description", ua.StatusOK))
+				childNode.attributes = append(childNode.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead|ua.AccessLevelTypeCurrentWrite))
+				childNode.attributes = append(childNode.attributes, getDataValueForDataType(ua.TypeIDInt32, ua.StatusOK))
+				rootNode.AddReferenceNode(id.HasChild, childNode)
+
+				nodeBrowser = rootNode
+				wg.Add(1)
+				go func() {
 					browseHierarchicalReferences := true
 					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, pathIDMapChan, wg, browseHierarchicalReferences)
 				}()
@@ -385,11 +430,19 @@ func getDataValueForBrowseName(name string) *ua.DataValue {
 	}
 }
 
-func getDataValueForDescription(description string) *ua.DataValue {
-	return &ua.DataValue{
-		EncodingMask: ua.DataValueValue,
-		Value:        ua.MustVariant(description),
-		Status:       ua.StatusOK,
+func getDataValueForDescription(description string, statusCode ua.StatusCode) *ua.DataValue {
+	if errors.Is(statusCode, ua.StatusOK) {
+		return &ua.DataValue{
+			EncodingMask: ua.DataValueValue,
+			Value:        ua.MustVariant(description),
+			Status:       ua.StatusOK,
+		}
+	} else {
+		return &ua.DataValue{
+			EncodingMask: ua.DataValueValue,
+			Value:        nil,
+			Status:       ua.StatusBadNotReadable,
+		}
 	}
 }
 
@@ -401,14 +454,21 @@ func getDataValueForAccessLevel(accessLevel ua.AccessLevelType) *ua.DataValue {
 	}
 }
 
-func getDataValueForDataType(id ua.TypeID) *ua.DataValue {
-	return &ua.DataValue{
-		EncodingMask: ua.DataValueValue,
-		Value:        ua.MustVariant(ua.NewNumericNodeID(0, uint32(id))),
-		Status:       ua.StatusOK,
+func getDataValueForDataType(id ua.TypeID, statusCode ua.StatusCode) *ua.DataValue {
+	if errors.Is(statusCode, ua.StatusOK) {
+		return &ua.DataValue{
+			EncodingMask: ua.DataValueValue,
+			Value:        ua.MustVariant(ua.NewNumericNodeID(0, uint32(id))),
+			Status:       ua.StatusOK,
+		}
+	} else {
+		return &ua.DataValue{
+			EncodingMask: ua.DataValueValue,
+			Value:        nil,
+			Status:       ua.StatusBadNotReadable,
+		}
 	}
 }
-
 func (m *MockOpcuaNodeWraper) Attributes(ctx context.Context, attrs ...ua.AttributeID) ([]*ua.DataValue, error) {
 	return m.attributes, nil
 }
@@ -450,6 +510,10 @@ func (m *MockOpcuaNodeWraper) AddReferenceNode(refType uint32, node NodeBrowser)
 }
 
 func (m *MockLogger) Debugf(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
+}
+
+func (m *MockLogger) Warnf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -27,6 +27,10 @@ func (g *OPCUAInput) createMessageFromValue(dataValue *ua.DataValue, nodeDef Nod
 		return nil
 	}
 
+	if !errors.Is(dataValue.Status, ua.StatusOK) {
+		g.Log.Warnf("Received bad status %v for node %s", dataValue.Status, nodeDef.NodeID.String())
+	}
+
 	b := make([]byte, 0)
 
 	var tagType string


### PR DESCRIPTION
needs to be merged after https://github.com/united-manufacturing-hub/benthos-umh/pull/83

Fixes ENG-2008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and logging for browsing and reading data in the OPC UA plugin.
	- Introduced a new warning logging method for better traceability of issues.
  
- **Bug Fixes**
	- Improved handling of node attributes and access permissions, allowing continued browsing even when nodes are not fully accessible.

- **Tests**
	- Updated unit tests to cover new error handling scenarios and edge cases related to node browsing and attribute accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->