### PR TITLE
fix: potentially stuck opc ua browsing

### DIFF
--- a/opcua_plugin/browse_frontend.go
+++ b/opcua_plugin/browse_frontend.go
@@ -1,0 +1,101 @@
+package opcua_plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/ua"
+)
+
+// GetNodeTree returns the tree structure of the OPC UA server nodes
+// GetNodeTree is currently used by united-manufacturing-hub/ManagementConsole repo for the BrowseOPCUA tags functionality
+func (g *OPCUAInput) GetNodeTree(ctx context.Context, msgChan chan<- string, rootNode *Node) (*Node, error) {
+	if g.Client == nil {
+		err := g.connect(ctx)
+		if err != nil {
+			g.Log.Infof("error setting up connection while getting the OPCUA nodes: %v", err)
+			return nil, err
+		}
+	}
+	defer func() {
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			// Create a new context to close the connection if the existing context is canceled or timed out
+			ctx = context.Background()
+		}
+		err := g.Client.Close(ctx)
+		if err != nil {
+			g.Log.Infof("error closing the connection while getting the OPCUA nodes: %v", err)
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	g.browseChildren(ctx, &wg, 0, rootNode, id.HierarchicalReferences, msgChan)
+	wg.Wait()
+	close(msgChan)
+	return rootNode, nil
+}
+
+// browseChildren recursively browses the OPC UA server nodes and builds a tree structure
+func (g *OPCUAInput) browseChildren(ctx context.Context, wg *sync.WaitGroup, level int, parent *Node, referenceType uint32, msgChan chan<- string) {
+	defer wg.Done()
+	// Recursion limit only goes up to 10 levels
+	if level >= 10 {
+		return
+	}
+
+	// Check if the context is cancelled
+	select {
+	case <-ctx.Done():
+		return
+	default:
+		// continue to do other operation
+	}
+
+	go func() {
+		msgChan <- fmt.Sprintf("Fetching result for node:  %s", parent.Name)
+	}()
+
+	node := g.Client.Node(parent.NodeId)
+	nodeClass, err := node.NodeClass(ctx)
+	if err != nil {
+		g.Log.Warnf("error getting nodeClass for node ID %s: %v", parent.NodeId, err)
+	}
+
+	refs, err := node.ReferencedNodes(ctx, referenceType, ua.BrowseDirectionForward, ua.NodeClassAll, true)
+	if err != nil {
+		g.Log.Warnf("error browsing children: %v", err)
+		return
+	}
+
+	for _, ref := range refs {
+		newNode := g.Client.Node(ref.ID)
+		newNodeName, err := newNode.BrowseName(ctx)
+		if err != nil {
+			g.Log.Warnf("error browsing children: %v", err)
+			continue
+
+		}
+		child := &Node{
+			NodeId:   ref.ID,
+			Name:     newNodeName.Name,
+			Children: make([]*Node, 0),
+		}
+		parent.Children = append(parent.Children, child)
+		if nodeClass == ua.NodeClassVariable {
+			wg.Add(1)
+			go g.browseChildren(ctx, wg, level+1, child, id.HasComponent, msgChan)
+		}
+
+		if nodeClass == ua.NodeClassObject {
+			wg.Add(4)
+			go g.browseChildren(ctx, wg, level+1, child, id.HasComponent, msgChan)
+			go g.browseChildren(ctx, wg, level+1, child, id.Organizes, msgChan)
+			go g.browseChildren(ctx, wg, level+1, child, id.FolderType, msgChan)
+			go g.browseChildren(ctx, wg, level+1, child, id.HasNotifier, msgChan)
+		}
+	}
+}

--- a/opcua_plugin/browse_frontend.go
+++ b/opcua_plugin/browse_frontend.go
@@ -63,6 +63,7 @@ func (g *OPCUAInput) browseChildren(ctx context.Context, wg *sync.WaitGroup, lev
 	nodeClass, err := node.NodeClass(ctx)
 	if err != nil {
 		g.Log.Warnf("error getting nodeClass for node ID %s: %v", parent.NodeId, err)
+		return
 	}
 
 	refs, err := node.ReferencedNodes(ctx, referenceType, ua.BrowseDirectionForward, ua.NodeClassAll, true)
@@ -78,6 +79,10 @@ func (g *OPCUAInput) browseChildren(ctx context.Context, wg *sync.WaitGroup, lev
 			g.Log.Warnf("error browsing children: %v", err)
 			continue
 
+		}
+		if newNodeName == nil {
+			g.Log.Warnf("newNodeName is nil for node ID %s", ref.ID)
+			continue
 		}
 		child := &Node{
 			NodeId:   ref.ID,

--- a/opcua_plugin/opcua.go
+++ b/opcua_plugin/opcua.go
@@ -229,7 +229,7 @@ func (g *OPCUAInput) Connect(ctx context.Context) (err error) {
 
 	// Create a subscription channel if needed
 	if g.SubscribeEnabled {
-		g.SubNotifyChan = make(chan *opcua.PublishNotificationData, 10000)
+		g.SubNotifyChan = make(chan *opcua.PublishNotificationData, MaxTagsToBrowse)
 	}
 	// Browse and subscribe to the nodes if needed
 	// Do this asynchronously so that the first messages can already arrive

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -64,7 +64,6 @@ var _ = Describe("Unit Tests", func() {
 			parentNodeId                 string
 			nodeChan                     chan NodeDef
 			errChan                      chan error
-			pathIDMapChan                chan map[string]string
 			wg                           *sync.WaitGroup
 			browseHierarchicalReferences bool
 		)
@@ -76,7 +75,6 @@ var _ = Describe("Unit Tests", func() {
 			parentNodeId = ""
 			nodeChan = make(chan NodeDef, 100)
 			errChan = make(chan error, 100)
-			pathIDMapChan = make(chan map[string]string, 100)
 			wg = &sync.WaitGroup{}
 			browseHierarchicalReferences = false
 		})
@@ -94,7 +92,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNodeWithNilNodeClass
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, pathIDMapChan, wg, browseHierarchicalReferences)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -121,7 +119,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, pathIDMapChan, wg, browseHierarchicalReferences)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -159,7 +157,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, pathIDMapChan, wg, browseHierarchicalReferences)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -201,7 +199,7 @@ var _ = Describe("Unit Tests", func() {
 				go func() {
 					// set browseHierarchicalReferences to true for reference nodes like id.HasChild
 					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, pathIDMapChan, wg, browseHierarchicalReferences)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -243,7 +241,7 @@ var _ = Describe("Unit Tests", func() {
 				go func() {
 					// set browseHierarchicalReferences to true for reference nodes like id.Organizes
 					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, pathIDMapChan, wg, browseHierarchicalReferences)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -287,7 +285,7 @@ var _ = Describe("Unit Tests", func() {
 				wg.Add(1)
 				go func() {
 					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, pathIDMapChan, wg, browseHierarchicalReferences)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences)
 				}()
 				wg.Wait()
 				close(nodeChan)

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
@@ -64,7 +63,7 @@ var _ = Describe("Unit Tests", func() {
 			parentNodeId                 string
 			nodeChan                     chan NodeDef
 			errChan                      chan error
-			wg                           *sync.WaitGroup
+			wg                           *TrackedWaitGroup
 			browseHierarchicalReferences bool
 		)
 		BeforeEach(func() {
@@ -75,7 +74,7 @@ var _ = Describe("Unit Tests", func() {
 			parentNodeId = ""
 			nodeChan = make(chan NodeDef, 100)
 			errChan = make(chan error, 100)
-			wg = &sync.WaitGroup{}
+			wg = &TrackedWaitGroup{}
 			browseHierarchicalReferences = false
 		})
 

--- a/opcua_plugin/server_info.go
+++ b/opcua_plugin/server_info.go
@@ -3,7 +3,6 @@ package opcua_plugin
 import (
 	"context"
 	"errors"
-	"sync"
 
 	"github.com/gopcua/opcua/ua"
 )
@@ -32,7 +31,7 @@ func (g *OPCUAInput) GetOPCUAServerInformation(ctx context.Context) (ServerInfo,
 	nodeChan := make(chan NodeDef, 3)
 	errChan := make(chan error, 3)
 	pathIDMapChan := make(chan map[string]string, 3)
-	var wg sync.WaitGroup
+	var wg TrackedWaitGroup
 
 	wg.Add(3)
 	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences)

--- a/opcua_plugin/server_info.go
+++ b/opcua_plugin/server_info.go
@@ -35,9 +35,9 @@ func (g *OPCUAInput) GetOPCUAServerInformation(ctx context.Context) (ServerInfo,
 	var wg sync.WaitGroup
 
 	wg.Add(3)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, pathIDMapChan, &wg, g.BrowseHierarchicalReferences)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, pathIDMapChan, &wg, g.BrowseHierarchicalReferences)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, pathIDMapChan, &wg, g.BrowseHierarchicalReferences)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences)
 	wg.Wait()
 
 	close(nodeChan)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced browsing functionality for OPC UA nodes, including a limit on the number of tags that can be browsed.
	- Added methods for browsing the node structure of an OPC UA server, allowing for efficient exploration of node hierarchies.

- **Bug Fixes**
	- Improved error handling and context cancellation checks during browsing operations.

- **Documentation**
	- Enhanced comments and descriptions in test cases for better clarity on the `Browse` function's behavior.

- **Refactor**
	- Streamlined method signatures by removing unnecessary parameters, improving the clarity of the browsing functions.
	- Transitioned to a custom `TrackedWaitGroup` for better management of concurrent operations.
	- Adjusted buffer size for subscription notifications to enhance dynamic handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->