### PR TITLE
[ENG-2175] Enhance OPCUA Browser functionality and improve node browsing depth

### DIFF
--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -29,6 +29,21 @@ type NodeDef struct {
 	DataType     string
 	ParentNodeID string // custom, not an official opcua attribute
 	Path         string // custom, not an official opcua attribute
+	// internalNodeIDPath is the list of parent nodeIDs that lead to this node and the current nodeID connected by a ::
+	internalNodeIDPath string // custom, not an official opcua attribute
+}
+
+// joinNodeID concatenates two nodeIDs with a :: separator.
+func joinNodeID(a, b string) string {
+	if a == "" {
+		return b
+	}
+
+	if b == "" {
+		return a
+	}
+
+	return a + "::" + b
 }
 
 // join concatenates two strings with a dot separator.
@@ -315,9 +330,10 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		return nil
 	}
 
-	// Create a copy of the def(current Node). Do no modify the original nodeDef. This nodeDefForOPCUABrowser is used only for OPCUA browser
+	// Create a copy of the def(current Node). Do no modify the original nodeDef. This nodeDefForOPCUABrowser is used only for OPCUA browser operation
 	nodeDefForOPCUABrowser := def
 	nodeDefForOPCUABrowser.Path = join(path, nodeDefForOPCUABrowser.BrowseName)
+	nodeDefForOPCUABrowser.internalNodeIDPath = joinNodeID(nodeDefForOPCUABrowser.ParentNodeID, nodeDefForOPCUABrowser.NodeID.String())
 	select {
 	case nodeIDChan <- OpcuaBrowserRecord{
 		BrowseName: browseName.Name,

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -96,7 +96,7 @@ func Browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 func browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, browseHierarchicalReferences bool, nodeIDChan chan []string) {
 	defer wg.Done()
 
-	if level > 10 {
+	if level > 500 {
 		return
 	}
 

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -322,7 +322,7 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 	case opcuaBrowserChan <- nodeDefForOPCUABrowser:
 	// do nothing if message publish to the channel is successful
 	default:
-		logger.Debugf("nodeIDChan is blocked, skipping nodeID send")
+		logger.Debugf("opcuaBrowserChan is blocked, skipping nodeDefForOPCUABrowser send")
 	}
 	// In OPC Unified Architecture (UA), hierarchical references are a type of reference that establishes a containment relationship between nodes in the address space. They are used to model a hierarchical structure, such as a system composed of components, where each component may contain sub-components.
 	// Refer link: https://qiyuqi.gitbooks.io/opc-ua/content/Part3/Chapter7.html
@@ -563,17 +563,17 @@ func (g *OPCUAInput) BrowseAndSubscribeIfNeeded(ctx context.Context) error {
 			// Copied and pasted from above, just for one node
 			nodeHeartbeatChan := make(chan NodeDef, 1)
 			errChanHeartbeat := make(chan error, 1)
-			nodeIDChanHeartbeat := make(chan NodeDef, 1)
+			opcuaBrowserChanHeartbeat := make(chan NodeDef, 1)
 			var wgHeartbeat TrackedWaitGroup
 
 			wgHeartbeat.Add(1)
 			wrapperNodeID := NewOpcuaNodeWrapper(g.Client.Node(heartbeatNodeID))
-			go browse(ctx, wrapperNodeID, "", 1, g.Log, heartbeatNodeID.String(), nodeHeartbeatChan, errChanHeartbeat, &wgHeartbeat, g.BrowseHierarchicalReferences, nodeIDChanHeartbeat)
+			go browse(ctx, wrapperNodeID, "", 1, g.Log, heartbeatNodeID.String(), nodeHeartbeatChan, errChanHeartbeat, &wgHeartbeat, g.BrowseHierarchicalReferences, opcuaBrowserChanHeartbeat)
 
 			wgHeartbeat.Wait()
 			close(nodeHeartbeatChan)
 			close(errChanHeartbeat)
-			close(nodeIDChanHeartbeat)
+			close(opcuaBrowserChanHeartbeat)
 
 			for node := range nodeHeartbeatChan {
 				nodeList = append(nodeList, node)

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -315,15 +315,13 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		return nil
 	}
 
-	// Send the node name and ID mapping to the nodeIDChan for showing intermediate results in the frontend
-	// Uses a non-blocking select to avoid deadlocks if the channel is full.
-	// Create a nodeDef copy. Do no modify the original nodeDef. This nodeCopy is used only for OPCUA browser
-	nodeCopy := def
-	nodeCopy.Path = join(path, nodeCopy.BrowseName)
+	// Create a copy of the def(current Node). Do no modify the original nodeDef. This nodeDefForOPCUABrowser is used only for OPCUA browser
+	nodeDefForOPCUABrowser := def
+	nodeDefForOPCUABrowser.Path = join(path, nodeDefForOPCUABrowser.BrowseName)
 	select {
 	case nodeIDChan <- OpcuaBrowserRecord{
 		BrowseName: browseName.Name,
-		Node:       nodeCopy,
+		Node:       nodeDefForOPCUABrowser,
 	}:
 	// do nothing if message publish to the channel is successful
 	default:

--- a/opcua_plugin/browse_frontend.go
+++ b/opcua_plugin/browse_frontend.go
@@ -71,6 +71,9 @@ func (g *OPCUAInput) GetNodeTree(ctx context.Context, msgChan chan<- string, roo
 	return rootNode, nil
 }
 
+// logBrowseStatus logs the status of the browse operation. It sends a message to the channel
+// every time a node is found, and the wait group counter status is sent to the channel
+// to indicate that the browse operation is still active.
 func logBrowseStatus(ctx context.Context, nodeChan chan NodeDef, msgChan chan<- string, wg *TrackedWaitGroup) {
 	for n := range nodeChan {
 		select {
@@ -84,6 +87,7 @@ func logBrowseStatus(ctx context.Context, nodeChan chan NodeDef, msgChan chan<- 
 	}
 }
 
+// logErrors logs errors from the error channel
 func logErrors(ctx context.Context, errChan chan error, logger *service.Logger) {
 	for err := range errChan {
 		select {
@@ -95,6 +99,7 @@ func logErrors(ctx context.Context, errChan chan error, logger *service.Logger) 
 	}
 }
 
+// collectNodes collects the NodeDefs from the channel and adds them to the list of NodeDefs
 func collectNodes(ctx context.Context, nodeIDChan chan OpcuaBrowserRecord, nodeIDMap map[string]string, nodes *[]NodeDef) {
 	for i := range nodeIDChan {
 		select {
@@ -108,6 +113,7 @@ func collectNodes(ctx context.Context, nodeIDChan chan OpcuaBrowserRecord, nodeI
 	}
 }
 
+// constructNodeHierarchy constructs a tree structure from the list of NodeDefs
 func constructNodeHierarchy(rootNode *Node, node NodeDef, nodeIDMap map[string]string) {
 	current := rootNode
 	if current.ChildIDMap == nil {

--- a/opcua_plugin/browse_frontend.go
+++ b/opcua_plugin/browse_frontend.go
@@ -145,10 +145,16 @@ func findNthParentNode(n int, node *NodeDef, nodeIDMap map[string]*NodeDef) *Nod
 	if n == 0 {
 		return node
 	}
+
 	for i := 0; i < n; i++ {
 		parentNodeID := node.ParentNodeID
 		parentNode := nodeIDMap[parentNodeID]
+
+		if parentNode == nil {
+			return node
+		}
 		node = parentNode
 	}
+
 	return node
 }

--- a/opcua_plugin/opcua_opc-plc_test.go
+++ b/opcua_plugin/opcua_opc-plc_test.go
@@ -1423,7 +1423,7 @@ opcua:
 			// Create channels for browsing
 			nodeChan := make(chan NodeDef, 100)
 			errChan := make(chan error, 100)
-			nodeIDChan := make(chan []string, 100)
+			nodeIDChan := make(chan OpcuaBrowserRecord, 100)
 			var wg TrackedWaitGroup
 
 			// Browse the node

--- a/opcua_plugin/opcua_opc-plc_test.go
+++ b/opcua_plugin/opcua_opc-plc_test.go
@@ -1423,7 +1423,7 @@ opcua:
 			// Create channels for browsing
 			nodeChan := make(chan NodeDef, 100)
 			errChan := make(chan error, 100)
-			nodeIDChan := make(chan OpcuaBrowserRecord, 100)
+			nodeIDChan := make(chan NodeDef, 100)
 			var wg TrackedWaitGroup
 
 			// Browse the node

--- a/opcua_plugin/opcua_opc-plc_test.go
+++ b/opcua_plugin/opcua_opc-plc_test.go
@@ -1423,18 +1423,18 @@ opcua:
 			// Create channels for browsing
 			nodeChan := make(chan NodeDef, 100)
 			errChan := make(chan error, 100)
-			nodeIDChan := make(chan NodeDef, 100)
+			opcuaBrowserChan := make(chan NodeDef, 100)
 			var wg TrackedWaitGroup
 
 			// Browse the node
 			wg.Add(1)
 			wrapperNodeID := NewOpcuaNodeWrapper(input.Client.Node(parsedNodeIDs[0]))
-			go Browse(ctx, wrapperNodeID, "", 0, input.Log, parsedNodeIDs[0].String(), nodeChan, errChan, &wg, true, nodeIDChan)
+			go Browse(ctx, wrapperNodeID, "", 0, input.Log, parsedNodeIDs[0].String(), nodeChan, errChan, &wg, true, opcuaBrowserChan)
 
 			wg.Wait()
 			close(nodeChan)
 			close(errChan)
-			close(nodeIDChan)
+			close(opcuaBrowserChan)
 
 			var nodes []NodeDef
 			for nodeDef := range nodeChan {

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Unit Tests", func() {
 			errChan                      chan error
 			wg                           *TrackedWaitGroup
 			browseHierarchicalReferences bool
-			nodeIDChan                   chan OpcuaBrowserRecord
+			nodeIDChan                   chan NodeDef
 		)
 		BeforeEach(func() {
 			ctx, cncl = context.WithTimeout(context.Background(), 180*time.Second)
@@ -78,7 +78,7 @@ var _ = Describe("Unit Tests", func() {
 			errChan = make(chan error, 100)
 			wg = &TrackedWaitGroup{}
 			browseHierarchicalReferences = false
-			nodeIDChan = make(chan OpcuaBrowserRecord, 100)
+			nodeIDChan = make(chan NodeDef, 100)
 		})
 		AfterEach(func() {
 			cncl()

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Unit Tests", func() {
 			errChan                      chan error
 			wg                           *TrackedWaitGroup
 			browseHierarchicalReferences bool
-			nodeIDChan                   chan NodeDef
+			opcuaBrowserChan             chan NodeDef
 		)
 		BeforeEach(func() {
 			ctx, cncl = context.WithTimeout(context.Background(), 180*time.Second)
@@ -78,7 +78,7 @@ var _ = Describe("Unit Tests", func() {
 			errChan = make(chan error, 100)
 			wg = &TrackedWaitGroup{}
 			browseHierarchicalReferences = false
-			nodeIDChan = make(chan NodeDef, 100)
+			opcuaBrowserChan = make(chan NodeDef, 100)
 		})
 		AfterEach(func() {
 			cncl()
@@ -102,7 +102,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNodeWithNilNodeClass
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, nodeIDChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -129,7 +129,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, nodeIDChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -167,7 +167,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, nodeIDChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -209,7 +209,7 @@ var _ = Describe("Unit Tests", func() {
 				go func() {
 					// set browseHierarchicalReferences to true for reference nodes like id.HasChild
 					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, nodeIDChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -251,7 +251,7 @@ var _ = Describe("Unit Tests", func() {
 				go func() {
 					// set browseHierarchicalReferences to true for reference nodes like id.Organizes
 					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, nodeIDChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -295,7 +295,7 @@ var _ = Describe("Unit Tests", func() {
 				wg.Add(1)
 				go func() {
 					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, nodeIDChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -372,7 +372,7 @@ var _ = Describe("Unit Tests", func() {
 				wg.Add(1)
 				go func() {
 					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, nodeIDChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Unit Tests", func() {
 			errChan                      chan error
 			wg                           *TrackedWaitGroup
 			browseHierarchicalReferences bool
-			nodeIDChan                   chan []string
+			nodeIDChan                   chan OpcuaBrowserRecord
 		)
 		BeforeEach(func() {
 			ctx, cncl = context.WithTimeout(context.Background(), 180*time.Second)
@@ -78,7 +78,7 @@ var _ = Describe("Unit Tests", func() {
 			errChan = make(chan error, 100)
 			wg = &TrackedWaitGroup{}
 			browseHierarchicalReferences = false
-			nodeIDChan = make(chan []string, 100)
+			nodeIDChan = make(chan OpcuaBrowserRecord, 100)
 		})
 		AfterEach(func() {
 			cncl()

--- a/opcua_plugin/server_info.go
+++ b/opcua_plugin/server_info.go
@@ -33,7 +33,7 @@ func (g *OPCUAInput) GetOPCUAServerInformation(ctx context.Context) (ServerInfo,
 	// nodeIDChan is declared to satisfy the browse function signature.
 	// The data inside nodeIDChan is not used for this function.
 	// It is more useful for the GetNodeTree function.
-	nodeIDChan := make(chan []string, 3)
+	nodeIDChan := make(chan OpcuaBrowserRecord, 3)
 	var wg TrackedWaitGroup
 
 	wg.Add(3)

--- a/opcua_plugin/server_info.go
+++ b/opcua_plugin/server_info.go
@@ -30,21 +30,21 @@ func (g *OPCUAInput) GetOPCUAServerInformation(ctx context.Context) (ServerInfo,
 
 	nodeChan := make(chan NodeDef, 3)
 	errChan := make(chan error, 3)
-	// nodeIDChan is declared to satisfy the browse function signature.
-	// The data inside nodeIDChan is not used for this function.
+	// opcuaBrowserChan is declared to satisfy the browse function signature.
+	// The data inside opcuaBrowserChan is not used for this function.
 	// It is more useful for the GetNodeTree function.
-	nodeIDChan := make(chan OpcuaBrowserRecord, 3)
+	opcuaBrowserChan := make(chan NodeDef, 3)
 	var wg TrackedWaitGroup
 
 	wg.Add(3)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, nodeIDChan)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, nodeIDChan)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, nodeIDChan)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, opcuaBrowserChan)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, opcuaBrowserChan)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, opcuaBrowserChan)
 	wg.Wait()
 
 	close(nodeChan)
 	close(errChan)
-	close(nodeIDChan)
+	close(opcuaBrowserChan)
 
 	if len(errChan) > 0 {
 		return ServerInfo{}, <-errChan


### PR DESCRIPTION
## Description:

![image](https://github.com/user-attachments/assets/675676da-a45a-4a4a-b15e-153b01998643)

This PR introduces several improvements to the OPCUA browsing functionality:

Key Changes:
- Increased maximum node browsing depth from 10 to 25 levels to support deeper hierarchies
- Introduced new `OpcuaBrowserRecord` struct to improve node information handling
- Modified node collection logic to preserve complete path information
- Restructured node browsing data flow for better reliability

Technical Details:
- Changed nodeIDChan type from `[]string` to `OpcuaBrowserRecord` for richer node information
- Added 3-second timeout in GetNodeTree to ensure proper collection of child nodes
- Moved node information collection to after variable validation for more accurate results
- Updated all related test files to accommodate the new OpcuaBrowserRecord structure

Testing:
- Updated unit tests to work with new OpcuaBrowserRecord type
- Existing functionality maintained with improved reliability
- Tested with deep node hierarchies to verify increased depth limit

Note: This change includes a temporary workaround (3-second timeout) that should be reviewed for a more permanent solution in future updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Increased browsing depth from 10 to 25 levels.
	- Introduced a new channel for more structured node information handling.

- **Refactor**
	- Updated channel types across multiple files to use a more complex data structure.
	- Improved node browsing mechanism with enhanced data transmission.
	- Renamed and restructured functions for better clarity and organization.

- **Bug Fixes**
	- Added a temporary workaround to ensure complete node collection during browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->