### PR TITLE
ENG-2209: configure pipeline to use fallbacks

### DIFF
--- a/.github/workflows/nodered-js.yml
+++ b/.github/workflows/nodered-js.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-name: main
+name: nodered-js
 
 on:
   push:
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.22.*'
+  GO_VERSION: '1.23.0'
 
 concurrency:
   group: nodered-js-test
@@ -46,4 +46,4 @@ jobs:
       - name: Install Ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
       - name: Test
-        run: TEST_NODERED_JS=1 make test 
+        run: TEST_NODERED_JS=1 make test

--- a/.github/workflows/opcua-plc.yml
+++ b/.github/workflows/opcua-plc.yml
@@ -99,19 +99,19 @@ jobs:
         run: |
           if [ "${{ steps.check_s7.outputs.available }}" == "true" ]; then
             echo "using s7 main"
-            TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI }}
+            export TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI }}
           elif  [ "${{ steps.check_s7_fallback.outputs.available }}" == "true" ]; then
             echo "using s7 fallback"
-            TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}
+            export TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}
           else
             exit 1
           fi
           if [ "${{ steps.check_wago.outputs.available }}" == "true" ]; then
             echo "using wago main"
-            TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI }}
+            export TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI }}
           elif [ "${{ steps.check_wago_fallback.outputs.available }}" == "true" ]; then
             echo "using wago fallback"
-            TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}
+            export TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}
           else
             exit 1
           fi

--- a/.github/workflows/opcua-plc.yml
+++ b/.github/workflows/opcua-plc.yml
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.22.*'
+  GO_VERSION: '1.23'
 
 concurrency:
   group: opcua-plc-test
@@ -45,5 +45,76 @@ jobs:
           go_version: ${{ env.GO_VERSION }}
       - name: Install Ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
+      - name: Install Tcping
+        run: go install github.com/cloverstd/tcping@latest
+      - name: Check S7 port availability
+        id: check_s7
+        run: |
+          set +x
+          URI="${{ secrets.TEST_S7_ENDPOINT_URI }}"
+          ENDPOINT="${URI#opc.tcp://}"
+          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check S7-falback port availability
+        id: check_s7_fallback
+        run: |
+          set +x
+          URI="${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}"
+          ENDPOINT="${URI#opc.tcp://}"
+          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check Wago port availability
+        id: check_wago
+        run: |
+          set +x
+          URI="${{ secrets.TEST_WAGO_ENDPOINT_URI }}"
+          ENDPOINT="${URI#opc.tcp://}"
+          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check Wago-fallback port availability
+        id: check_wago_fallback
+        run: |
+          set +x
+          URI="${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}"
+          ENDPOINT="${URI#opc.tcp://}"
+          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Test
-        run: TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI }} TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI }} TEST_WAGO_USERNAME=${{ secrets.TEST_WAGO_USERNAME }} TEST_WAGO_PASSWORD=${{ secrets.TEST_WAGO_PASSWORD }} make test
+        run: |
+          if [ "${{ steps.check_s7.outputs.available }}" == "true" ]; then
+            echo "using s7 main"
+            TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI }}
+          elif  [ "${{ steps.check_s7_fallback.outputs.available }}" == "true" ]; then
+            echo "using s7 fallback"
+            TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}
+          else
+            exit 1
+          fi
+          if [ "${{ steps.check_wago.outputs.available }}" == "true" ]; then
+            echo "using wago main"
+            TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI }}
+          elif [ "${{ steps.check_wago_fallback.outputs.available }}" == "true" ]; then
+            echo "using wago fallback"
+            TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}
+          else
+            exit 1
+          fi
+          TEST_WAGO_USERNAME=${{ secrets.TEST_WAGO_USERNAME }} \
+          TEST_WAGO_PASSWORD=${{ secrets.TEST_WAGO_PASSWORD }} \
+          make test

--- a/.github/workflows/opcua-plc.yml
+++ b/.github/workflows/opcua-plc.yml
@@ -54,9 +54,9 @@ jobs:
           URI="${{ secrets.TEST_S7_ENDPOINT_URI }}"
           ENDPOINT="${URI#opc.tcp://}"
           if tcping "$ENDPOINT" | grep -qi "Connected"; then
-            echo "available=true" >> $GITHUB_OUTPUT
+            echo "available=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check S7-falback port availability
@@ -66,9 +66,9 @@ jobs:
           URI="${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}"
           ENDPOINT="${URI#opc.tcp://}"
           if tcping "$ENDPOINT" | grep -qi "Connected"; then
-            echo "available=true" >> $GITHUB_OUTPUT
+            echo "available=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check Wago port availability
@@ -78,9 +78,9 @@ jobs:
           URI="${{ secrets.TEST_WAGO_ENDPOINT_URI }}"
           ENDPOINT="${URI#opc.tcp://}"
           if tcping "$ENDPOINT" | grep -qi "Connected"; then
-            echo "available=true" >> $GITHUB_OUTPUT
+            echo "available=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check Wago-fallback port availability
@@ -90,31 +90,31 @@ jobs:
           URI="${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}"
           ENDPOINT="${URI#opc.tcp://}"
           if tcping "$ENDPOINT" | grep -qi "Connected"; then
-            echo "available=true" >> $GITHUB_OUTPUT
+            echo "available=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Test
         run: |
           if [ "${{ steps.check_s7.outputs.available }}" == "true" ]; then
             echo "using s7 main"
-            export TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI }}
+            export TEST_S7_ENDPOINT_URI="${{ secrets.TEST_S7_ENDPOINT_URI }}"
           elif  [ "${{ steps.check_s7_fallback.outputs.available }}" == "true" ]; then
             echo "using s7 fallback"
-            export TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}
+            export TEST_S7_ENDPOINT_URI="${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}"
           else
             exit 1
           fi
           if [ "${{ steps.check_wago.outputs.available }}" == "true" ]; then
             echo "using wago main"
-            export TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI }}
+            export TEST_WAGO_ENDPOINT_URI="${{ secrets.TEST_WAGO_ENDPOINT_URI }}"
           elif [ "${{ steps.check_wago_fallback.outputs.available }}" == "true" ]; then
             echo "using wago fallback"
-            export TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}
+            export TEST_WAGO_ENDPOINT_URI="${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}"
           else
             exit 1
           fi
-          TEST_WAGO_USERNAME=${{ secrets.TEST_WAGO_USERNAME }} \
-          TEST_WAGO_PASSWORD=${{ secrets.TEST_WAGO_PASSWORD }} \
+          TEST_WAGO_USERNAME="${{ secrets.TEST_WAGO_USERNAME }}" \
+          TEST_WAGO_PASSWORD="${{ secrets.TEST_WAGO_PASSWORD }}" \
           make test

--- a/.github/workflows/opcua-plc.yml
+++ b/.github/workflows/opcua-plc.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-name: main
+name: opcua-plc
 
 on:
   push:
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.23.0'
 
 concurrency:
   group: opcua-plc-test

--- a/.github/workflows/opcua-plc.yml
+++ b/.github/workflows/opcua-plc.yml
@@ -46,27 +46,32 @@ jobs:
       - name: Install Ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
       - name: Install Tcping
-        run: go install github.com/cloverstd/tcping@latest
+        run: go install github.com/cloverstd/tcping@v0.1.1
       - name: Check S7 port availability
         id: check_s7
         run: |
           set +x
           URI="${{ secrets.TEST_S7_ENDPOINT_URI }}"
           ENDPOINT="${URI#opc.tcp://}"
-          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+          if tcping -c 4 -T 1s "$ENDPOINT" | grep -qi "Connected"; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI }}" >> "$GITHUB_ENV"
+            echo "using s7-main device for testing"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check S7-falback port availability
+      - name: Check S7-fallback port availability
         id: check_s7_fallback
+        if: ${{ steps.check_s7.outputs.available == 'false' }}
         run: |
           set +x
           URI="${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}"
           ENDPOINT="${URI#opc.tcp://}"
-          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+          if tcping -c 4 -T 1s "$ENDPOINT" | grep -qi "Connected"; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}" >> "$GITHUB_ENV"
+            echo "using s7-fallback device for testing"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
@@ -77,44 +82,40 @@ jobs:
           set +x
           URI="${{ secrets.TEST_WAGO_ENDPOINT_URI }}"
           ENDPOINT="${URI#opc.tcp://}"
-          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+          if tcping -c 4 -T 1s "$ENDPOINT" | grep -qi "Connected"; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI }}" >> "$GITHUB_ENV"
+            echo "using wago-main device for testing"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check Wago-fallback port availability
         id: check_wago_fallback
+        if: ${{ steps.check_wago.outputs.available == 'false' }}
         run: |
           set +x
           URI="${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}"
           ENDPOINT="${URI#opc.tcp://}"
-          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+          if tcping -c 4 -T 1s "$ENDPOINT" | grep -qi "Connected"; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "TEST_WAGO_ENDPOINT_URI=${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}" >> "$GITHUB_ENV"
+            echo "using wago-fallback device for testing"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Test
+        env:
+          TEST_WAGO_USERNAME: ${{ secrets.TEST_WAGO_USERNAME }}
+          TEST_WAGO_PASSWORD: ${{ secrets.TEST_WAGO_PASSWORD }}
         run: |
-          if [ "${{ steps.check_s7.outputs.available }}" == "true" ]; then
-            echo "using s7 main"
-            export TEST_S7_ENDPOINT_URI="${{ secrets.TEST_S7_ENDPOINT_URI }}"
-          elif  [ "${{ steps.check_s7_fallback.outputs.available }}" == "true" ]; then
-            echo "using s7 fallback"
-            export TEST_S7_ENDPOINT_URI="${{ secrets.TEST_S7_ENDPOINT_URI_FALLBACK }}"
-          else
+          if [ -z "$TEST_S7_ENDPOINT_URI" ]; then
+            echo "no s7-endpoint available for testing"
             exit 1
           fi
-          if [ "${{ steps.check_wago.outputs.available }}" == "true" ]; then
-            echo "using wago main"
-            export TEST_WAGO_ENDPOINT_URI="${{ secrets.TEST_WAGO_ENDPOINT_URI }}"
-          elif [ "${{ steps.check_wago_fallback.outputs.available }}" == "true" ]; then
-            echo "using wago fallback"
-            export TEST_WAGO_ENDPOINT_URI="${{ secrets.TEST_WAGO_ENDPOINT_URI_FALLBACK }}"
-          else
+          if [ -z "$TEST_WAGO_ENDPOINT_URI" ]; then
+            echo "no wago-endpoint available for testing"
             exit 1
           fi
-          TEST_WAGO_USERNAME="${{ secrets.TEST_WAGO_USERNAME }}" \
-          TEST_WAGO_PASSWORD="${{ secrets.TEST_WAGO_PASSWORD }}" \
           make test

--- a/.github/workflows/s7-plc.yml
+++ b/.github/workflows/s7-plc.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-name: main
+name: s7-plc
 
 on:
   push:
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.23.0'
 
 concurrency:
   group: s7-plc-test

--- a/.github/workflows/s7-plc.yml
+++ b/.github/workflows/s7-plc.yml
@@ -51,9 +51,9 @@ jobs:
           set +x
           ENDPOINT="${{ secrets.TEST_S7_TCPDEVICE }}"
           if tcping "$ENDPOINT" | grep -qi "Connected"; then
-            echo "available=true" >> $GITHUB_OUTPUT
+            echo "available=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check S7-fallback port availability
@@ -62,19 +62,19 @@ jobs:
           set +x
           ENDPOINT="${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}"
           if tcping "$ENDPOINT" | grep -qi "Connected"; then
-            echo "available=true" >> $GITHUB_OUTPUT
+            echo "available=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Test
         run: |
           if [ "${{ steps.check_s7.outputs.available }}" == "true" ]; then
             echo "using s7 main"
-            export TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE }}
+            export TEST_S7_TCPDEVICE="${{ secrets.TEST_S7_TCPDEVICE }}"
           elif [ "${{ steps.check_s7_fallback.outputs.available }}" == "true" ]; then
             echo "using s7 fallback"
-            export TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}
+            export TEST_S7_TCPDEVICE="${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}"
           else
             exit 1
           fi

--- a/.github/workflows/s7-plc.yml
+++ b/.github/workflows/s7-plc.yml
@@ -71,10 +71,10 @@ jobs:
         run: |
           if [ "${{ steps.check_s7.outputs.available }}" == "true" ]; then
             echo "using s7 main"
-            TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE }}
+            export TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE }}
           elif [ "${{ steps.check_s7_fallback.outputs.available }}" == "true" ]; then
             echo "using s7 fallback"
-            TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}
+            export TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}
           else
             exit 1
           fi

--- a/.github/workflows/s7-plc.yml
+++ b/.github/workflows/s7-plc.yml
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.22.*'
+  GO_VERSION: '1.23'
 
 concurrency:
   group: s7-plc-test
@@ -42,5 +42,42 @@ jobs:
           go_version: ${{ env.GO_VERSION }}
       - name: Install Ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
+      - name: Install Tcping
+        run: go install github.com/cloverstd/tcping@latest
+
+      - name: Check S7 port availability
+        id: check_s7
+        run: |
+          set +x
+          ENDPOINT="${{ secrets.TEST_S7_TCPDEVICE }}"
+          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check S7-fallback port availability
+        id: check_s7_fallback
+        run: |
+          set +x
+          ENDPOINT="${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}"
+          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Test
-        run: TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE }} TEST_S7_RACK=0 TEST_S7_SLOT=1 make test
+        run: |
+          if [ "${{ steps.check_s7.outputs.available }}" == "true" ]; then
+            echo "using s7 main"
+            TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE }}
+          elif [ "${{ steps.check_s7_fallback.outputs.available }}" == "true" ]; then
+            echo "using s7 fallback"
+            TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}
+          else
+            exit 1
+          fi
+          TEST_S7_RACK=0 \
+          TEST_S7_SLOT=1 \
+          make test

--- a/.github/workflows/s7-plc.yml
+++ b/.github/workflows/s7-plc.yml
@@ -43,41 +43,43 @@ jobs:
       - name: Install Ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
       - name: Install Tcping
-        run: go install github.com/cloverstd/tcping@latest
+        run: go install github.com/cloverstd/tcping@v0.1.1
 
       - name: Check S7 port availability
         id: check_s7
         run: |
           set +x
           ENDPOINT="${{ secrets.TEST_S7_TCPDEVICE }}"
-          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+          if tcping -c 4 -T 1s "$ENDPOINT" | grep -qi "Connected"; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE }}" >> "$GITHUB_ENV"
+            echo "using S7-main device for testing"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check S7-fallback port availability
         id: check_s7_fallback
+        if: ${{ steps.check_s7.outputs.available  == 'false' }}
         run: |
           set +x
           ENDPOINT="${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}"
-          if tcping "$ENDPOINT" | grep -qi "Connected"; then
+          if tcping -c 4 -T 1s "$ENDPOINT" | grep -qi "Connected"; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "TEST_S7_TCPDEVICE=${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}" >> "$GITHUB_ENV"
+            echo "using s7-fallback device for testing"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Test
+        env:
+          TEST_S7_RACK: 0
+          TEST_S7_SLOT: 1
+          TEST_S7COMM_UNITTEST: true
         run: |
-          if [ "${{ steps.check_s7.outputs.available }}" == "true" ]; then
-            echo "using s7 main"
-            export TEST_S7_TCPDEVICE="${{ secrets.TEST_S7_TCPDEVICE }}"
-          elif [ "${{ steps.check_s7_fallback.outputs.available }}" == "true" ]; then
-            echo "using s7 fallback"
-            export TEST_S7_TCPDEVICE="${{ secrets.TEST_S7_TCPDEVICE_FALLBACK }}"
-          else
+          if [ -z "$TEST_S7_TCPDEVICE" ]; then
+            echo "no s7 device available for testing"
             exit 1
           fi
-          TEST_S7_RACK=0 \
-          TEST_S7_SLOT=1 \
           make test

--- a/.github/workflows/sensorconnect.yml
+++ b/.github/workflows/sensorconnect.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-name: main
+name: sensorconnect
 
 on:
   push:
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.22.*'
+  GO_VERSION: '1.23.0'
 
 concurrency:
   group: sensorconnect-test

--- a/.github/workflows/tag-processor.yml
+++ b/.github/workflows/tag-processor.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-name: main
+name: tag-processor
 
 on:
   push:
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.22.*'
+  GO_VERSION: '1.23.0'
 
 concurrency:
   group: tag-processor-test
@@ -46,4 +46,4 @@ jobs:
       - name: Install Ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
       - name: Test
-        run: TEST_TAG_PROCESSOR=1 make test 
+        run: TEST_TAG_PROCESSOR=1 make test

--- a/README.md
+++ b/README.md
@@ -1500,7 +1500,9 @@ Some of these tests are executed with a local GitHub runner called "hercules", w
 
 ### Target: WAGO PFC100 (OPC UA)
 
-Model number: 750-8101
+Model number: 750-8101 PFC100 CS 2ETH
+Firmware: 03.10.08(22)
+OPC-UA-Server Version: 1.3.1
 
 Requires:
 - TEST_WAGO_ENDPOINT_URI
@@ -1526,6 +1528,7 @@ This requires additional to have the simulator setup somewhere (e.g., locally on
 ### Target: Siemens S7-1200 (OPC UA)
 
 Model number: SIMATIC S7-1200 6ES7211-1AE40-0XB0
+Firmware: v4.4
 
 Requires:
 - TEST_S7_ENDPOINT_URI
@@ -1538,6 +1541,7 @@ Requires:
 ### Target: Siemens S7-1200 (S7comm)
 
 Model number: SIMATIC S7-1200 6ES7211-1AE40-0XB0
+Firmware: v4.4
 
 Requires:
 - TEST_S7_TCPDEVICE

--- a/sensorconnect_plugin/connect_test.go
+++ b/sensorconnect_plugin/connect_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/united-manufacturing-hub/benthos-umh/sensorconnect_plugin"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/benthos-umh/sensorconnect_plugin"
 )
 
 var _ = Describe("SensorConnect Plugin Unittests", func() {

--- a/sensorconnect_plugin/downloadSensorData_test.go
+++ b/sensorconnect_plugin/downloadSensorData_test.go
@@ -3,9 +3,10 @@ package sensorconnect_plugin_test
 import (
 	"context"
 	"fmt"
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"os"
 
 	"github.com/united-manufacturing-hub/benthos-umh/sensorconnect_plugin"
 )

--- a/sensorconnect_plugin/sensorconnect_test.go
+++ b/sensorconnect_plugin/sensorconnect_test.go
@@ -3,12 +3,13 @@ package sensorconnect_plugin_test
 import (
 	"context"
 	"fmt"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/united-manufacturing-hub/benthos-umh/sensorconnect_plugin"
 	"os"
 	"sync/atomic"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/benthos-umh/sensorconnect_plugin"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 
@@ -16,7 +17,7 @@ import (
 	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
 )
 
-var _ = Describe("Sensorconnnect", func() {
+var _ = Describe("Sensorconnect", func() {
 
 	var endpoint string
 


### PR DESCRIPTION
### Description:
- changed to go-version 1.23 since benthos-umh runs on 1.23
- install [tcping](https://github.com/cloverstd/tcping) (go wrapper for ping) there's an alternative workflow for port-check but i don't trust that
- check with tcping for either s7-main availability or fallback -> set output to true/false
- check with tcping for either wago-main availability or fallback -> set output to true/false
- depending on the output set env variable for test -> of nothing is available just quickly exit with failure

### Testing:
- endpoints were tested locally with setting them and Makefile
- workflows were tested with act-environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Updates**
	- Updated workflow names from "main" to project-specific names.
	- Upgraded Go version from 1.22.* to 1.23.0 across multiple workflows.
	- Enhanced testing workflows with port availability checks for S7 and Wago endpoints.

- **Documentation**
	- Updated README with specific model and firmware details for testing targets.
	- Added precise version information for WAGO PFC100, OPC-UA Server, and Siemens S7-1200.

- **Testing**
	- Minor import statement adjustments in test files.
	- Corrected typographical errors in test suite descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->