### PR TITLE
[ENG-2203] Avoid browsing children for Variable Node class while discovering new nodes

### DIFF
--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -615,7 +615,6 @@ func (g *OPCUAInput) discoverNodes(ctx context.Context) ([]NodeDef, error) {
 	var wg TrackedWaitGroup
 	wgInfoTicker := time.NewTicker(10 * time.Second)
 	defer wgInfoTicker.Stop()
-	go logWaitGroupInfo(childCtx, g.Log, wgInfoTicker, done, nodeChan, &wg)
 
 	inputNodeIDs := g.NodeIDs
 	if len(inputNodeIDs) == 0 {
@@ -643,9 +642,11 @@ func (g *OPCUAInput) discoverNodes(ctx context.Context) ([]NodeDef, error) {
 		}
 
 		// Any code below this line needs browsing as it is not a varible node and we need to get the children nodes
-		wg.Add(1)
+		go logWaitGroupInfo(childCtx, g.Log, wgInfoTicker, done, nodeChan, &wg)
+
 		wrapperNodeID := NewOpcuaNodeWrapper(node)
 		go addBrowsedNodesToNodeList(childCtx, nodeChan, &nodeList)
+		wg.Add(1)
 		go browse(childCtx, wrapperNodeID, "", 0, g.Log, nodeId.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, opcuaBrowserChan)
 	}
 


### PR DESCRIPTION
## Description 

`discoverNodes` function is called before subscribing for node values. An attempt is made to browse the children for all the input node ids. 

The PR refactors the discoverNodes function so that if the input NodeID is found as of VariableNode type, then browsing is avoided. 