### PR TITLE
BugFix: Consider only variable and reference classes

### DIFF
--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -131,7 +131,6 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		sendError(ctx, err, errChan, logger)
 		return
 	}
-	logger.Debugf("browseName for node %s is %s", n.ID().String(), browseName.Name)
 
 	var newPath string
 	if path == "" {
@@ -146,7 +145,6 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 	}
 
 	logger.Debugf("NodeClass attr[0].Status for node %s is %s", n.ID().String(), attrs[0].Status)
-	logger.Debugf("NodeClass attr[0].Value for node %s is %s", n.ID().String(), attrs[0].Value.Int())
 	switch err := attrs[0].Status; {
 	case errors.Is(err, ua.StatusOK):
 		if attrs[0].Value == nil {
@@ -154,6 +152,7 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 			logger.Debugf("Sending error and returning from browse function after getting a Nil NodeClass for node %s", n.ID().String())
 			return
 		} else {
+			logger.Debugf("NodeClass attr[0].Value for node %s is %s", n.ID().String(), attrs[0].Value.Int())
 			def.NodeClass = ua.NodeClass(attrs[0].Value.Int())
 		}
 	case errors.Is(err, ua.StatusBadSecurityModeInsufficient):
@@ -170,7 +169,6 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 	}
 
 	logger.Debugf("BrowseName attr[1].Status for node %s is %s", n.ID().String(), attrs[1].Status)
-	logger.Debugf("BrowseName attr[1].Value for node %s is %s", n.ID().String(), attrs[1].Value.String())
 	switch err := attrs[1].Status; {
 	case errors.Is(err, ua.StatusOK):
 		if attrs[1].Value == nil {
@@ -178,6 +176,7 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 			logger.Debugf("Sending error and returning from browse function after getting a Nil BrowseName for node %s", n.ID().String())
 			return
 		} else {
+			logger.Debugf("BrowseName attr[1].Value for node %s is %s", n.ID().String(), attrs[1].Value.String())
 			def.BrowseName = attrs[1].Value.String()
 		}
 	case errors.Is(err, ua.StatusBadSecurityModeInsufficient):
@@ -193,12 +192,12 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 	}
 
 	logger.Debugf("Description attr[2].Status for node %s is %s", n.ID().String(), attrs[2].Status)
-	logger.Debugf("Description attr[2].Value for node %s is %s", n.ID().String(), attrs[2].Value.String())
 	switch err := attrs[2].Status; {
 	case errors.Is(err, ua.StatusOK):
 		if attrs[2].Value == nil {
 			def.Description = "" // this can happen for example in Kepware v6, where the description is OPCUAType_Null
 		} else {
+			logger.Debugf("Description attr[2].Value for node %s is %s", n.ID().String(), attrs[2].Value.String())
 			def.Description = attrs[2].Value.String()
 		}
 	case errors.Is(err, ua.StatusBadAttributeIDInvalid):
@@ -218,7 +217,6 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 	}
 
 	logger.Debugf("AccessLevel attr[3].Status for node %s is %s", n.ID().String(), attrs[3].Status)
-	logger.Debugf("AccessLevel attr[3].Value for node %s is %s", n.ID().String(), attrs[3].Value.Int())
 	switch err := attrs[3].Status; {
 	case errors.Is(err, ua.StatusOK):
 		if attrs[3].Value == nil {
@@ -226,6 +224,7 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 			logger.Debugf("Sending error and returning from browse function after getting a Nil AccessLevel for node %s", n.ID().String())
 			return
 		} else {
+			logger.Debugf("AccessLevel attr[3].Value for node %s is %s", n.ID().String(), attrs[3].Value.Int())
 			def.AccessLevel = ua.AccessLevelType(attrs[3].Value.Int())
 		}
 	case errors.Is(err, ua.StatusBadAttributeIDInvalid):
@@ -253,7 +252,6 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 	}
 
 	logger.Debugf("DataType attr[4].Status for node %s is %s", n.ID().String(), attrs[4].Status)
-	logger.Debugf("DataType attr[4].Value for node %s is %s", n.ID().String(), attrs[4].Value.NodeID().String())
 	switch err := attrs[4].Status; {
 	case errors.Is(err, ua.StatusOK):
 		if attrs[4].Value == nil {
@@ -264,6 +262,7 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 			logger.Debugf("ignoring node: %s as its datatype is nil...\n", path)
 			return
 		} else {
+			logger.Debugf("DataType attr[4].Value for node %s is %s", n.ID().String(), attrs[4].Value.NodeID().String())
 			switch v := attrs[4].Value.NodeID().IntID(); v {
 			case id.DateTime:
 				def.DataType = "time.Time"

--- a/opcua_plugin/opcua_node_wrapper.go
+++ b/opcua_plugin/opcua_node_wrapper.go
@@ -22,6 +22,8 @@ type NodeBrowser interface {
 
 	// ID returns the node identifier
 	ID() *ua.NodeID
+
+	Node() *opcua.Node
 }
 
 type OpcuaNodeWrapper struct {
@@ -66,4 +68,8 @@ func (n *OpcuaNodeWrapper) Children(ctx context.Context, refType uint32, nodeCla
 		result = append(result, NewOpcuaNodeWrapper(child))
 	}
 	return result, nil
+}
+
+func (n *OpcuaNodeWrapper) Node() *opcua.Node {
+	return n.n
 }

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
 	. "github.com/onsi/ginkgo/v2"
@@ -489,6 +490,7 @@ type MockOpcuaNodeWraper struct {
 	attributes     []*ua.DataValue
 	browseName     *ua.QualifiedName
 	referenceNodes map[uint32][]NodeBrowser
+	node           *opcua.Node
 }
 
 func getDataValueForNilNodeClass() *ua.DataValue {
@@ -566,6 +568,10 @@ func (m *MockOpcuaNodeWraper) BrowseName(ctx context.Context) (*ua.QualifiedName
 // ID implements NodeBrowser.
 func (m *MockOpcuaNodeWraper) ID() *ua.NodeID {
 	return m.id
+}
+
+func (m *MockOpcuaNodeWraper) Node() *opcua.Node {
+	return m.node
 }
 
 // Children returns all reference nodes of all refType. In real implementation, it will use id.HierarchicalReferences reference type


### PR DESCRIPTION
## Description 

- While browsing the child nodes, the nodeclass type is currently passed as `ua.NodeClassVariable | ua.NodeClassObject`. This leads to a bug since the code tries to do a `bitwise OR` operation resulting to the value of `0x03`. But if you look at the enums of `NodeClass` there is no nodeclass with the value of `3`.  (See the nodeclass image below). This results in an incorrect browsing when `BrowseHierarchicalReferences is true`

![image](https://github.com/user-attachments/assets/b252a892-a544-4ae8-9291-f80f67dfa415)

## Image showing the result of Bitwise OR operation `ua.NodeclassVariable | ua.NodeClassObject`

![image](https://github.com/user-attachments/assets/c67a9030-2c1c-4981-a6a1-01eaccc9306b)

## OPCUA Browser Records with the PR Change 

![image](https://github.com/user-attachments/assets/58eda5f3-1094-4f7b-a4a2-67ed64d38bb3)

## OPCUA Browser Records before the Change

![image](https://github.com/user-attachments/assets/8d110d7b-dcfd-47f3-84a1-5f67b7c55ed1)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced node browsing functionality with detailed logging for better observability.
	- Improved handling and logging of node attributes and references.
	- Added a new method for direct access to the underlying OPC UA node in the interface.
	- Extended mock structure to include a reference to the OPC UA node for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->