### PR TITLE
ENG-2229: Investigate failure of sensorconnect-tests

### DIFF
--- a/.github/workflows/sensorconnect.yml
+++ b/.github/workflows/sensorconnect.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Install Ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
       - name: Test
-        run: TEST_DEBUG_IFM_ENDPOINT=${{ secrets.TEST_DEBUG_IFM_ENDPOINT }} make test
+        run: TEST_DEBUG_IFM_ENDPOINT=${{ secrets.TEST_DEBUG_IFM_ENDPOINT }} make test-serial

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,13 @@ update-benthos:
   go get github.com/redpanda-data/benthos/v4@latest && \
   go mod tidy
 
+## provides serial runners, which are needed to restrict data requests on sensor interface
+test-serial:
+	@ginkgo -r --output-interceptor-mode=none --github-output -vv -trace --procs 1 --randomize-all --cover --coverprofile=cover.profile --repeat=2 ./...
+
 # usage:
-# make test-sensorconnect TEST_DEBUG_IFM_ENDPOINT=10.13.37.176
-test-sensorconnect: test
+# make test-sensorconnect TEST_DEBUG_IFM_ENDPOINT=(IP of sensor interface)
+test-sensorconnect: test-serial
 	./tmp/bin/benthos -c ./config/sensorconnect-test.yaml
 
 # run the tests against the opc-plc simulator

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ update-benthos:
   go get github.com/redpanda-data/benthos/v4@latest && \
   go mod tidy
 
-## provides serial runners, which are needed to restrict data requests on sensor interface
+# provides serial runners, which are needed to restrict data requests on sensor interface
+# Note: Serial execution will increase test duration but ensures reliable results
 test-serial:
 	@ginkgo -r --output-interceptor-mode=none --github-output -vv -trace --procs 1 --randomize-all --cover --coverprofile=cover.profile --repeat=2 ./...
 


### PR DESCRIPTION
### Description:
Due to too many parallel-runners the workflow provided for testing the sensorconnect_plugin failed regularly.
Therefore the added method `make test-serial` should work fine for this since it only uses 1 runner.
Removal of the endpoint for `TEST_DEBUG_IFM_ENDPOINT` since it's not correct anymore and imo shouldn't be exposed.

### Testing:
- tested locally by makefile and by act with sensor interface AL1350 (onsite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated testing workflow to run sensor connection tests serially.
	- Modified test configuration to ensure precise data request management on sensor interfaces.
	- Introduced a new target for testing (`test-serial`) to enhance reliability of results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->