### PR TITLE
ENG-2276: fix for same Item.Start but different Item.Bit access

### DIFF
--- a/s7comm_plugin/s7comm.go
+++ b/s7comm_plugin/s7comm.go
@@ -179,7 +179,7 @@ func ParseAddresses(addresses []string, batchMaxSize int) ([][]S7DataItemWithAdd
 			if i == j {
 				continue
 			}
-			if a.Item.Area == b.Item.Area && a.Item.DBNumber == b.Item.DBNumber && a.Item.Start == b.Item.Start {
+			if a.Item.Area == b.Item.Area && a.Item.DBNumber == b.Item.DBNumber && a.Item.Start == b.Item.Start && a.Item.Bit == b.Item.Bit {
 				return nil, fmt.Errorf("duplicate address %v", a)
 			}
 		}

--- a/s7comm_plugin/s7comm.go
+++ b/s7comm_plugin/s7comm.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"time"
@@ -179,7 +180,7 @@ func ParseAddresses(addresses []string, batchMaxSize int) ([][]S7DataItemWithAdd
 			if i == j {
 				continue
 			}
-			if a.Item.Area == b.Item.Area && a.Item.DBNumber == b.Item.DBNumber && a.Item.Start == b.Item.Start && a.Item.Bit == b.Item.Bit {
+			if reflect.DeepEqual(a.Item, b.Item) {
 				return nil, fmt.Errorf("duplicate address %v", a)
 			}
 		}

--- a/s7comm_plugin/s7comm_test.go
+++ b/s7comm_plugin/s7comm_test.go
@@ -84,7 +84,7 @@ var _ = Describe("S7Comm Plugin Unittests", func() {
 				addresses:      []string{"DB2.W0", "DB2.W2"},
 				expectedErrMsg: nil,
 			}),
-		Entry("same DBNumber but differen Item.Bit",
+		Entry("same DBNumber but different Item.Bit",
 			S7Addresses{
 				addresses:      []string{"DB2.X0.0", "DB2.X0.1"},
 				expectedErrMsg: nil,


### PR DESCRIPTION
### Description:

- should check also on bit-wise access for duplicates since there are cases where you want to access the same `Item.Start` but a different `Item.Bit`
- if the `Item.WordLen` isn't set to bit-wise access the field `Bit` should contain the same value 
- added some tests, we could test everything against each other here, but i guess this should be fine

### Testing:

- had some local tests running with this input.yaml on both devices
```
input:
  s7comm:
    tcpDevice: <censored>
    rack: 0
    slot: 1
    addresses:
      - DB2.I0
      - DB2.X0.1
      - DB2.X2.0
      - DB2.X4.0
      - DB2.I6
      - MK0.X0.0
      - MK0.X0.1
      - MK0.X0.2
      - MK0.X0.3
      - MK0.X0.4
      - MK0.X0.5
      - MK0.X0.6
      - MK0.X0.7
      - DB2.X8.0
      - DB3.DW0
      - DB3.DW4
      - DB3.DW8
      - DB3.W12

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced duplicate address detection with more precise matching criteria.

- **Tests**
	- Added comprehensive test suite for parsing duplicate addresses.
	- Improved validation of address parsing logic with new test scenarios for various duplicate conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->