### PR TITLE
ENG-2301: fix: s7comm - not reconnecting 

### DIFF
--- a/s7comm_plugin/s7comm.go
+++ b/s7comm_plugin/s7comm.go
@@ -258,10 +258,8 @@ func (g *S7CommInput) ReadBatch(ctx context.Context) (service.MessageBatch, serv
 		if err := g.Client.AGReadMulti(batchToRead, len(batchToRead)); err != nil {
 			// Try to reconnect and skip this gather cycle to avoid hammering
 			// the network if the server is down or under load.
-			errMsg := fmt.Sprintf("Failed to read batch %d: %v. Reconnecting...", i+1, err)
-
-			// Return the error message so Benthos can handle it appropriately
-			return nil, nil, errors.New(errMsg)
+			g.Log.Errorf("Failed to read batch %d: %v", i+1, err)
+			return nil, nil, service.ErrNotConnected
 		}
 
 		// Read the data from the batch and convert it using the converter function


### PR DESCRIPTION
### Description:
- as Jeremy told me we need to provide Benthos with a specific error to achieve reconnecting 
[as you can see here](https://github.com/redpanda-data/benthos/blob/fb074b5eb048ea0a118033f656be4818c84a2f61/public/service/errors.go#L14-L32)

- additionally log the Error for better handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for batch read operations in the S7 communication plugin.
	- Standardized error responses when read operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->