### PR TITLE
ENG-2313: include testing modbus-plc-devices

### DIFF
--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -1028,7 +1028,7 @@ func (m *ModbusInput) gatherRequestsInput(requests []request) (service.MessageBa
 			//request.fields[i].value = field.converter(bytes[offset : offset+length])
 			m.Log.Debugf("  field %s with offset %d with len %d: %v --> %v", field.name, offset, length, bytes[offset:offset+length], request.fields[i].value)
 
-			message := m.createMessageFromValue(field, bytes[offset:offset+length], "holding")
+			message := m.createMessageFromValue(field, bytes[offset:offset+length], "input")
 			if message != nil {
 				msgs = append(msgs, message)
 			}

--- a/modbus_plugin/modbus_test.go
+++ b/modbus_plugin/modbus_test.go
@@ -233,6 +233,7 @@ var _ = Describe("Test Against Wago-PLC", func() {
 				GinkgoWriter.Printf("Skipping heartbeat message: %+v\n", message)
 				continue
 			}
+			Expect(tagName).To(Equal(tableEntry.Addresses[0].Name))
 
 			register, exists := message.MetaGet("modbus_tag_register")
 			Expect(exists).To(BeTrue())
@@ -244,9 +245,6 @@ var _ = Describe("Test Against Wago-PLC", func() {
 
 			messageStruct, err := message.AsStructuredMut()
 			Expect(err).NotTo(HaveOccurred())
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(tagName).To(Equal(tableEntry.Addresses[0].Name))
 
 			Expect(messageStruct).To(BeAssignableToTypeOf(tableEntry.ExpectedValue))
 			Expect(messageStruct).To(Equal(tableEntry.ExpectedValue))

--- a/modbus_plugin/modbus_test.go
+++ b/modbus_plugin/modbus_test.go
@@ -3,9 +3,11 @@ package modbus_plugin_test
 import (
 	"context"
 	"encoding/json"
-	"github.com/grid-x/modbus"
 	"os"
+	"strconv"
 	"time"
+
+	"github.com/grid-x/modbus"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -175,4 +177,135 @@ var _ = Describe("Test Against Docker Modbus Simulator", func() {
 		err = input.Close(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	})
+})
+
+var _ = Describe("Test Against Wago-PLC", func() {
+
+	var wagoModbusEndpoint string
+
+	BeforeEach(func() {
+		wagoModbusEndpoint = os.Getenv("TEST_WAGO_MODBUS_ENDPOINT")
+
+		// Check if environment variables are set
+		if wagoModbusEndpoint == "" {
+			Skip("Skipping test: environment variables not set")
+			return
+		}
+
+	})
+
+	type ModbusRegister struct {
+		Addresses     []ModbusDataItemWithAddress
+		ExpectedValue json.Number
+	}
+
+	DescribeTable("Read discrete/coil/input/holding", func(tableEntry ModbusRegister) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		input := &ModbusInput{
+			SlaveIDs:    []byte{1},
+			BusyRetries: 1,
+			Addresses:   tableEntry.Addresses,
+			Handler:     modbus.NewTCPClientHandler(wagoModbusEndpoint),
+		}
+		input.Client = modbus.NewClient(input.Handler)
+
+		var err error
+		input.RequestSet, err = input.CreateBatchesFromAddresses(input.Addresses)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = input.Connect(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		messageBatch, _, err := input.ReadBatch(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// increase the batch-length by 1 because of the heartbeat
+		Expect(messageBatch).To(HaveLen(len(tableEntry.Addresses) + 1))
+
+		for _, message := range messageBatch {
+
+			tagName, exists := message.MetaGet("modbus_tag_name")
+			Expect(exists).To(BeTrue())
+
+			// skip the heartbeat if processed
+			if tagName == "heartbeat" {
+				GinkgoWriter.Printf("Skipping heartbeat message: %+v\n", message)
+				continue
+			}
+
+			register, exists := message.MetaGet("modbus_tag_register")
+			Expect(exists).To(BeTrue())
+			Expect(register).To(Equal(tableEntry.Addresses[0].Register))
+
+			address, exists := message.MetaGet("modbus_tag_address")
+			Expect(exists).To(BeTrue())
+			Expect(address).To(Equal(strconv.FormatUint(uint64(tableEntry.Addresses[0].Address), 10)))
+
+			messageStruct, err := message.AsStructuredMut()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tagName).To(Equal(tableEntry.Addresses[0].Name))
+
+			Expect(messageStruct).To(BeAssignableToTypeOf(tableEntry.ExpectedValue))
+			Expect(messageStruct).To(Equal(tableEntry.ExpectedValue))
+
+			GinkgoWriter.Printf("Received message: %+v\n", messageStruct)
+		}
+
+		// Close connection
+		err = input.Close(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+	},
+		Entry("discrete (input)",
+			ModbusRegister{
+				Addresses: []ModbusDataItemWithAddress{
+					{
+						Name:     "modbusBoolIn",
+						Register: "discrete",
+						Address:  0,
+						Type:     "BOOL",
+					},
+				},
+				ExpectedValue: "1",
+			}),
+		Entry("coil (output)",
+			ModbusRegister{
+				Addresses: []ModbusDataItemWithAddress{
+					{
+						Name:     "modbusBoolOut",
+						Register: "coil",
+						Address:  1,
+						Type:     "BOOL",
+					},
+				},
+				ExpectedValue: "1",
+			}),
+		Entry("input (input)",
+			ModbusRegister{
+				Addresses: []ModbusDataItemWithAddress{
+					{
+						Name:     "modbusIntIn",
+						Register: "input",
+						Address:  1,
+						Type:     "INT16",
+					},
+				},
+				ExpectedValue: "1234",
+			}),
+		Entry("holding (output)",
+			ModbusRegister{
+				Addresses: []ModbusDataItemWithAddress{
+					{
+						Name:     "modbusIntOut",
+						Register: "holding",
+						Address:  2,
+						Type:     "INT16",
+					},
+				},
+				ExpectedValue: "1234",
+			}),
+	)
 })


### PR DESCRIPTION
### Description:
- fixed minor bug regarding the messageValue for `register` since it should be `input` for input-registers
- added modbus-testing for wago-plc's with a preset of variables which are included now in plc-software of main and fallback-wago
- should test a discrete (DI) / coil (DO) / input (AI) / register (AO)
- for testing purpose we have to skip the `heartbeat`-message here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added comprehensive test suite for Wago-PLC Modbus register reading.
	- Enhanced testing coverage for different register types (discrete, coil, input, holding).

- **Bug Fixes**
	- Corrected register name labeling when processing input registers.

- **Tests**
	- Introduced parameterized tests for Modbus register validation.
	- Added support for testing various Modbus register types with expected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->