### PR TITLE
ENG-2098: add kepware-tests incl. underlying plc's

### DIFF
--- a/.github/workflows/kepware-plc.yml
+++ b/.github/workflows/kepware-plc.yml
@@ -1,0 +1,83 @@
+# Copyright 2023 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: kepware-plc
+
+on:
+  push:
+    branches:
+      - '**'
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  GO_VERSION: '1.23.0'
+
+concurrency:
+  group: kepware-plc-test
+  cancel-in-progress: true
+
+jobs:
+  go-test-opcua-plc:
+    runs-on:
+      group: arc-runners-tests
+    permissions:
+      packages: write
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          go_version: ${{ env.GO_VERSION }}
+      - name: Install Ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
+      - name: Install Tcping
+        run: go install github.com/cloverstd/tcping@v0.1.1
+
+      - name: Check Kepware port availability
+        id: check_kepware
+        run: |
+          set +x
+          CURRENT_MINUTE=$(date +%M)
+          CURRENT_HOUR=$(date +%H)
+
+          # make timecheck since we restart kepware-runtime every 2 hours and
+          # don't want to unneccessaryly fail here
+          if [ "$CURRENT_MINUTE" -eq "00" ] && [ $((10#$CURRENT_HOUR % 2)) -eq 0 ]; then
+            sleep 60
+          fi
+
+          URI="${{ secrets.TEST_KEPWARE_ENDPOINT }}"
+          ENDPOINT="${URI#opc.tcp://}"
+          if tcping -c 4 -T 1s "$ENDPOINT" | grep -qi "Connected"; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "TEST_KEPWARE_ENDPOINT=${{ secrets.TEST_KEPWARE_ENDPOINT }}" >> "$GITHUB_ENV"
+            echo "using kepware for testing"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Test
+        env:
+          TEST_KEPWARE_USERNAME: ${{ secrets.TEST_KEPWARE_USERNAME }}
+          TEST_KEPWARE_PASSWORD: ${{ secrets.TEST_KEPWARE_PASSWORD }}
+        run: |
+          if [ -z "$TEST_KEPWARE_ENDPOINT" ]; then
+            echo "no kepware-endpoint available for testing"
+            exit 1
+          fi
+          make test

--- a/.github/workflows/kepware-plc.yml
+++ b/.github/workflows/kepware-plc.yml
@@ -22,7 +22,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.23.0'
+  GO_VERSION: '1.23'
 
 concurrency:
   group: kepware-plc-test

--- a/opcua_plugin/opcua_kepware_test.go
+++ b/opcua_plugin/opcua_kepware_test.go
@@ -1,0 +1,273 @@
+package opcua_plugin_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"reflect"
+	"time"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	. "github.com/united-manufacturing-hub/benthos-umh/opcua_plugin"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test against KepServer EX6", func() {
+	var endpoint string
+	var username string
+	var password string
+	var input *OPCUAInput
+	var ctx context.Context
+	var cancel context.CancelFunc
+
+	type KepwareWrapper struct {
+		Username                     string
+		Password                     string
+		NodeIDs                      []*ua.NodeID
+		SecurityMode                 string
+		SecurityPolicy               string
+		BrowseHierarchicalReferences bool
+		AutoReconnect                bool
+		ReconnectIntervalInSeconds   int
+		SubscribeEnabled             bool
+		ErrorOccured                 bool
+		ExpectedValue                interface{}
+	}
+
+	BeforeEach(func() {
+		endpoint = os.Getenv("TEST_KEPWARE_ENDPOINT")
+		username = os.Getenv("TEST_KEPWARE_USERNAME")
+		password = os.Getenv("TEST_KEPWARE_PASSWORD")
+
+		if endpoint == "" || username == "" || password == "" {
+			Skip("Skipping test: environmental variables are not set")
+			return
+		}
+
+		ctx, cancel = context.WithTimeout(context.Background(), 60*time.Second)
+	})
+
+	AfterEach(func() {
+		if input.Client != nil {
+			err := input.Client.Close(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		if cancel != nil {
+			cancel()
+		}
+	})
+
+	//TODO: proper var handling for tableEntries since this wouldn't work
+	DescribeTable("Connect", func(wrapper KepwareWrapper) {
+
+		input = &OPCUAInput{
+			Endpoint:                     endpoint,
+			Username:                     wrapper.Username,
+			Password:                     wrapper.Password,
+			NodeIDs:                      wrapper.NodeIDs,
+			SecurityMode:                 wrapper.SecurityMode,
+			SecurityPolicy:               wrapper.SecurityPolicy,
+			BrowseHierarchicalReferences: wrapper.BrowseHierarchicalReferences,
+			AutoReconnect:                wrapper.AutoReconnect,
+			ReconnectIntervalInSeconds:   wrapper.ReconnectIntervalInSeconds,
+			SubscribeEnabled:             wrapper.SubscribeEnabled,
+		}
+
+		err := input.Connect(ctx)
+		if wrapper.ErrorOccured {
+			Expect(err).To(HaveOccurred())
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		var messageBatch service.MessageBatch
+
+		switch len(input.NodeIDs) {
+		case 1:
+			Eventually(func() (int, error) {
+				messageBatch, _, err = input.ReadBatch(ctx)
+				return len(messageBatch), err
+			}, 30*time.Second, 100*time.Millisecond).WithContext(ctx).Should(Equal(len(input.NodeIDs)))
+
+			for _, message := range messageBatch {
+				message, err := message.AsStructuredMut()
+				Expect(err).NotTo(HaveOccurred())
+				var assignableNumber json.Number = "10.0"
+
+				Expect(message).To(BeAssignableToTypeOf(assignableNumber))
+			}
+			return
+		case 2:
+			Eventually(func() (int, error) {
+				messageBatch, _, err = input.ReadBatch(ctx)
+				return len(messageBatch), err
+			}, 30*time.Second, 100*time.Millisecond).WithContext(ctx).Should(Equal(len(input.NodeIDs)))
+
+			var storedMessage any
+
+			for _, message := range messageBatch {
+				message, err := message.AsStructuredMut()
+				Expect(err).NotTo(HaveOccurred())
+				var assignableNumber json.Number = "10.0"
+
+				Expect(message).To(BeAssignableToTypeOf(assignableNumber))
+				storedMessage = message
+			}
+
+			var messageBatch2 service.MessageBatch
+			Eventually(func() (int, error) {
+				messageBatch2, _, err = input.ReadBatch(ctx)
+				return len(messageBatch2), err
+			}, 30*time.Second, 100*time.Millisecond).WithContext(ctx).Should(Equal(len(input.NodeIDs) - 1))
+
+			for _, message := range messageBatch2 {
+				message, err := message.AsStructuredMut()
+				Expect(err).NotTo(HaveOccurred())
+				var assignableNumber json.Number = "10.0"
+
+				Expect(message).To(BeAssignableToTypeOf(assignableNumber))
+				Expect(message).NotTo(Equal(storedMessage))
+			}
+			return
+		default:
+			return
+		}
+
+	},
+		Entry("should connect", KepwareWrapper{
+			Username:                   "",
+			Password:                   "",
+			NodeIDs:                    nil,
+			SubscribeEnabled:           false,
+			AutoReconnect:              true,
+			ReconnectIntervalInSeconds: 5,
+			ErrorOccured:               false,
+		}),
+		Entry("should connect in no security mode", KepwareWrapper{
+			Username:         "",
+			Password:         "",
+			NodeIDs:          nil,
+			SubscribeEnabled: false,
+			SecurityMode:     "None",
+			SecurityPolicy:   "None",
+			ErrorOccured:     false,
+		}),
+		Entry("should connect with correct credentials", KepwareWrapper{
+			Username:     username,
+			Password:     password,
+			NodeIDs:      nil,
+			ErrorOccured: false,
+		}),
+		Entry("should fail to connect using incorrect credentials", KepwareWrapper{
+			Username:     "123",
+			Password:     "123",
+			NodeIDs:      nil,
+			ErrorOccured: true,
+		}),
+		Entry("should return a batch of messages", KepwareWrapper{
+			Username:                     "",
+			Password:                     "",
+			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=Tests.TestDevice.testChangingData"}),
+			BrowseHierarchicalReferences: true,
+			AutoReconnect:                true,
+			ReconnectIntervalInSeconds:   5,
+			ErrorOccured:                 false,
+		}),
+		Entry("should return data changes on subscribe", KepwareWrapper{
+			Username:                     "",
+			Password:                     "",
+			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=Tests.TestDevice.testChangingData", "ns=2;s=Tests.TestDevice.testConstData"}),
+			BrowseHierarchicalReferences: true,
+			SubscribeEnabled:             true,
+			ErrorOccured:                 false,
+		}),
+	)
+
+	//TODO: iterate over the message to check for the correct namespace here
+	DescribeTable("Check PLC-data", func(wrapper KepwareWrapper) {
+		//NOTE: namespaceArray consists at least of http://Server_interface_1
+		// check on isDiederikCool == true
+		// check on counter getting data changes
+
+		input = &OPCUAInput{
+			Endpoint:                     endpoint,
+			Username:                     wrapper.Username,
+			Password:                     wrapper.Password,
+			NodeIDs:                      wrapper.NodeIDs,
+			BrowseHierarchicalReferences: wrapper.BrowseHierarchicalReferences,
+			AutoReconnect:                wrapper.AutoReconnect,
+			ReconnectIntervalInSeconds:   wrapper.ReconnectIntervalInSeconds,
+		}
+
+		err := input.Connect(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		var messageBatch service.MessageBatch
+
+		Eventually(func() (int, error) {
+			messageBatch, _, err = input.ReadBatch(ctx)
+			return len(messageBatch), err
+		}, 30*time.Second, 100*time.Millisecond).WithContext(ctx).Should(Equal(len(input.NodeIDs)))
+
+		for _, message := range messageBatch {
+			message, err := message.AsStructuredMut()
+			test := reflect.TypeOf(message)
+
+			GinkgoWriter.Printf("type of message: %v\n", test)
+			GinkgoWriter.Printf("message from messageBatch:  %v\n", message)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			//	if reflect.TypeOf(wrapper.ExpectedValue).Kind() == reflect.Slice {
+			//		for _, messageEntry := range message {
+			//			if messageEntry == wrapper.ExpectedValue {
+			//				err = fmt.Errorf("namespace not found")
+			//			}
+			//		}
+
+			//	}
+			value := reflect.ValueOf(message)
+			GinkgoWriter.Printf("value of message: %v\n", value)
+
+			typeOf := reflect.TypeOf(wrapper.ExpectedValue).Kind()
+			GinkgoWriter.Printf("type of ExpectedValue: %v\n", typeOf)
+			Expect(message).To(BeAssignableToTypeOf(wrapper.ExpectedValue))
+			Expect(message).To(Equal(wrapper.ExpectedValue))
+		}
+
+	},
+		Entry("should return true for data-value", KepwareWrapper{
+			Username:                     "",
+			Password:                     "",
+			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server _interface_1.custom_struct.Is_Diederik_Cool"}),
+			BrowseHierarchicalReferences: true,
+			AutoReconnect:                true,
+			ReconnectIntervalInSeconds:   5,
+			ErrorOccured:                 false,
+			ExpectedValue:                true,
+		}),
+		//		Entry("should receive data changes", KepwareWrapper{
+		//			Username:                     "",
+		//			Password:                     "",
+		//			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server_interface_1.counter"}),
+		//			BrowseHierarchicalReferences: true,
+		//			AutoReconnect:                true,
+		//			ReconnectIntervalInSeconds:   5,
+		//			ErrorOccured:                 false,
+		//		}),
+		Entry("namespaceArray should consist of expected namespace", KepwareWrapper{
+			Username:                     "",
+			Password:                     "",
+			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.Server.NamespaceArray"}),
+			BrowseHierarchicalReferences: true,
+			AutoReconnect:                true,
+			ReconnectIntervalInSeconds:   5,
+			ErrorOccured:                 false,
+			ExpectedValue:                "http://Server _interface_1",
+		}),
+	)
+})

--- a/opcua_plugin/opcua_kepware_test.go
+++ b/opcua_plugin/opcua_kepware_test.go
@@ -137,19 +137,17 @@ var _ = Describe("Test against KepServer EX6", func() {
 			NodeIDs:  nil,
 		}, true, nil, false),
 		Entry("should check if message-value is 123", &OPCUAInput{
-			Username:                     "",
-			Password:                     "",
-			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=Tests.TestDevice.testConstData"}),
-			BrowseHierarchicalReferences: true,
-			AutoReconnect:                true,
-			ReconnectIntervalInSeconds:   5,
+			Username:                   "",
+			Password:                   "",
+			NodeIDs:                    ParseNodeIDs([]string{"ns=2;s=Tests.TestDevice.testConstData"}),
+			AutoReconnect:              true,
+			ReconnectIntervalInSeconds: 5,
 		}, false, json.Number("123"), false),
 		Entry("should return data changes on subscribe", &OPCUAInput{
-			Username:                     "",
-			Password:                     "",
-			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=Tests.TestDevice.testChangingData"}),
-			BrowseHierarchicalReferences: true,
-			SubscribeEnabled:             true,
+			Username:         "",
+			Password:         "",
+			NodeIDs:          ParseNodeIDs([]string{"ns=2;s=Tests.TestDevice.testChangingData"}),
+			SubscribeEnabled: true,
 		}, false, nil, true),
 	)
 })
@@ -299,19 +297,17 @@ var _ = Describe("Test underlying OPC-clients", func() {
 		}
 	},
 		Entry("should check if message-value is true", &OPCUAInput{
-			Username:                     "",
-			Password:                     "",
-			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server _interface_1.test"}),
-			BrowseHierarchicalReferences: true,
-			AutoReconnect:                true,
-			ReconnectIntervalInSeconds:   5,
+			Username:                   "",
+			Password:                   "",
+			NodeIDs:                    ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server _interface_1.test"}),
+			AutoReconnect:              true,
+			ReconnectIntervalInSeconds: 5,
 		}, true, false),
 		Entry("should return data changes on subscribe", &OPCUAInput{
-			Username:                     "",
-			Password:                     "",
-			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server _interface_1.counter"}),
-			BrowseHierarchicalReferences: true,
-			SubscribeEnabled:             true,
+			Username:         "",
+			Password:         "",
+			NodeIDs:          ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server _interface_1.counter"}),
+			SubscribeEnabled: true,
 		}, nil, true),
 	)
 

--- a/opcua_plugin/opcua_kepware_test.go
+++ b/opcua_plugin/opcua_kepware_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Test against KepServer EX6", func() {
 	})
 
 	AfterEach(func() {
-		if input.Client != nil {
+		if input != nil && input.Client != nil {
 			err := input.Client.Close(ctx)
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -133,7 +133,7 @@ var _ = Describe("Test underlying OPC-clients", func() {
 	})
 
 	AfterEach(func() {
-		if input.Client != nil {
+		if input != nil && input.Client != nil {
 			err := input.Client.Close(ctx)
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/opcua_plugin/opcua_kepware_test.go
+++ b/opcua_plugin/opcua_kepware_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Test underlying OPC-clients", func() {
 		}
 	})
 
-	DescribeTable("Test if Siemens-Namespace is available", func(namespace string, contains bool) {
+	DescribeTable("Test if PLC-Namespaces are available", func(namespace string, nodeID *ua.NodeID, contains bool) {
 		input = &OPCUAInput{
 			Endpoint:                   endpoint,
 			Username:                   username,
@@ -203,7 +203,7 @@ var _ = Describe("Test underlying OPC-clients", func() {
 		req := &ua.ReadRequest{
 			NodesToRead: []*ua.ReadValueID{
 				{
-					NodeID:      ua.NewStringNodeID(2, "SiemensPLC_main.main.Server.NamespaceArray"),
+					NodeID:      nodeID,
 					AttributeID: ua.AttributeIDValue,
 				},
 			},
@@ -221,8 +221,30 @@ var _ = Describe("Test underlying OPC-clients", func() {
 		}
 		Expect(namespaces).To(ContainElement(namespace))
 	},
-		Entry("should contain siemens-namespace", "http://Server _interface_1", true),
-		Entry("should fail due to incorrect namespace", "totally wrong namespace", false),
+		Entry(
+			"should contain siemens-namespace",
+			"http://Server _interface_1",
+			ua.NewStringNodeID(2, "SiemensPLC_main.main.Server.NamespaceArray"),
+			true,
+		),
+		Entry(
+			"should fail due to incorrect namespace",
+			"totally wrong namespace",
+			ua.NewStringNodeID(2, "SiemensPLC_main.main.Server.NamespaceArray"),
+			false,
+		),
+		Entry(
+			"should contain wago-namespace",
+			"urn:wago-com:codesys-provider",
+			ua.NewStringNodeID(2, "Wago.play.Server.NamespaceArray"),
+			true,
+		),
+		Entry(
+			"should fail due to incorrect namespace",
+			"totally wrong namespace",
+			ua.NewStringNodeID(2, "Wago.play.Server.NamespaceArray"),
+			false,
+		),
 	)
 
 	DescribeTable("check for correct values", func(opcInput *OPCUAInput, expectedValue interface{}, dynamic bool) {

--- a/opcua_plugin/opcua_kepware_test.go
+++ b/opcua_plugin/opcua_kepware_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"reflect"
 	"time"
 
 	"github.com/gopcua/opcua/ua"
@@ -22,20 +21,6 @@ var _ = Describe("Test against KepServer EX6", func() {
 	var input *OPCUAInput
 	var ctx context.Context
 	var cancel context.CancelFunc
-
-	type KepwareWrapper struct {
-		Username                     string
-		Password                     string
-		NodeIDs                      []*ua.NodeID
-		SecurityMode                 string
-		SecurityPolicy               string
-		BrowseHierarchicalReferences bool
-		AutoReconnect                bool
-		ReconnectIntervalInSeconds   int
-		SubscribeEnabled             bool
-		ErrorOccured                 bool
-		ExpectedValue                interface{}
-	}
 
 	BeforeEach(func() {
 		endpoint = os.Getenv("TEST_KEPWARE_ENDPOINT")
@@ -61,24 +46,13 @@ var _ = Describe("Test against KepServer EX6", func() {
 		}
 	})
 
-	//TODO: proper var handling for tableEntries since this wouldn't work
-	DescribeTable("Connect", func(wrapper KepwareWrapper) {
+	DescribeTable("Connect", func(opcInput *OPCUAInput, errorExpected bool) {
 
-		input = &OPCUAInput{
-			Endpoint:                     endpoint,
-			Username:                     wrapper.Username,
-			Password:                     wrapper.Password,
-			NodeIDs:                      wrapper.NodeIDs,
-			SecurityMode:                 wrapper.SecurityMode,
-			SecurityPolicy:               wrapper.SecurityPolicy,
-			BrowseHierarchicalReferences: wrapper.BrowseHierarchicalReferences,
-			AutoReconnect:                wrapper.AutoReconnect,
-			ReconnectIntervalInSeconds:   wrapper.ReconnectIntervalInSeconds,
-			SubscribeEnabled:             wrapper.SubscribeEnabled,
-		}
+		input = opcInput
+		input.Endpoint = endpoint
 
 		err := input.Connect(ctx)
-		if wrapper.ErrorOccured {
+		if errorExpected {
 			Expect(err).To(HaveOccurred())
 			return
 		}
@@ -138,136 +112,191 @@ var _ = Describe("Test against KepServer EX6", func() {
 		}
 
 	},
-		Entry("should connect", KepwareWrapper{
+		Entry("should connect", &OPCUAInput{
 			Username:                   "",
 			Password:                   "",
 			NodeIDs:                    nil,
 			SubscribeEnabled:           false,
 			AutoReconnect:              true,
 			ReconnectIntervalInSeconds: 5,
-			ErrorOccured:               false,
-		}),
-		Entry("should connect in no security mode", KepwareWrapper{
+		}, false),
+		Entry("should connect in no security mode", &OPCUAInput{
 			Username:         "",
 			Password:         "",
 			NodeIDs:          nil,
 			SubscribeEnabled: false,
 			SecurityMode:     "None",
 			SecurityPolicy:   "None",
-			ErrorOccured:     false,
-		}),
-		Entry("should connect with correct credentials", KepwareWrapper{
-			Username:     username,
-			Password:     password,
-			NodeIDs:      nil,
-			ErrorOccured: false,
-		}),
-		Entry("should fail to connect using incorrect credentials", KepwareWrapper{
-			Username:     "123",
-			Password:     "123",
-			NodeIDs:      nil,
-			ErrorOccured: true,
-		}),
-		Entry("should return a batch of messages", KepwareWrapper{
+		}, false),
+		Entry("should connect with correct credentials", &OPCUAInput{
+			Username: username,
+			Password: password,
+			NodeIDs:  nil,
+		}, false),
+		Entry("should fail to connect using incorrect credentials", &OPCUAInput{
+			Username: "123",
+			Password: "123",
+			NodeIDs:  nil,
+		}, true),
+		Entry("should return a batch of messages", &OPCUAInput{
 			Username:                     "",
 			Password:                     "",
 			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=Tests.TestDevice.testChangingData"}),
 			BrowseHierarchicalReferences: true,
 			AutoReconnect:                true,
 			ReconnectIntervalInSeconds:   5,
-			ErrorOccured:                 false,
-		}),
-		Entry("should return data changes on subscribe", KepwareWrapper{
+		}, false),
+		Entry("should return data changes on subscribe", &OPCUAInput{
 			Username:                     "",
 			Password:                     "",
 			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=Tests.TestDevice.testChangingData", "ns=2;s=Tests.TestDevice.testConstData"}),
 			BrowseHierarchicalReferences: true,
 			SubscribeEnabled:             true,
-			ErrorOccured:                 false,
-		}),
+		}, false),
+	)
+})
+
+var _ = Describe("Test underlying OPC-clients", func() {
+	var endpoint string
+	var username string
+	var password string
+	var input *OPCUAInput
+	var ctx context.Context
+	var cancel context.CancelFunc
+
+	BeforeEach(func() {
+		endpoint = os.Getenv("TEST_KEPWARE_ENDPOINT")
+		username = os.Getenv("TEST_KEPWARE_USERNAME")
+		password = os.Getenv("TEST_KEPWARE_PASSWORD")
+
+		if endpoint == "" || username == "" || password == "" {
+			Skip("Skipping test: environmental variables are not set")
+			return
+		}
+
+		ctx, cancel = context.WithTimeout(context.Background(), 60*time.Second)
+	})
+
+	AfterEach(func() {
+		if input.Client != nil {
+			err := input.Client.Close(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		if cancel != nil {
+			cancel()
+		}
+	})
+
+	DescribeTable("Test if Siemens-Namespace is available", func(namespace string, contains bool) {
+		input = &OPCUAInput{
+			Endpoint:                   endpoint,
+			Username:                   username,
+			Password:                   password,
+			AutoReconnect:              true,
+			ReconnectIntervalInSeconds: 5,
+		}
+
+		err := input.Connect(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		req := &ua.ReadRequest{
+			NodesToRead: []*ua.ReadValueID{
+				{
+					NodeID:      ua.NewStringNodeID(2, "SiemensPLC_main.main.Server.NamespaceArray"),
+					AttributeID: ua.AttributeIDValue,
+				},
+			},
+		}
+
+		resp, err := input.Read(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		namespaces, ok := resp.Results[0].Value.Value().([]string)
+		Expect(ok).To(Equal(true))
+
+		if !contains {
+			Expect(namespaces).NotTo(ContainElement(namespace))
+			return
+		}
+		Expect(namespaces).To(ContainElement(namespace))
+	},
+		Entry("should contain siemens-namespace", "http://Server _interface_1", true),
+		Entry("should fail due to incorrect namespace", "totally wrong namespace", false),
 	)
 
-	//TODO: iterate over the message to check for the correct namespace here
-	DescribeTable("Check PLC-data", func(wrapper KepwareWrapper) {
-		//NOTE: namespaceArray consists at least of http://Server_interface_1
-		// check on isDiederikCool == true
-		// check on counter getting data changes
+	DescribeTable("check for correct values", func(opcInput *OPCUAInput, expectedValue interface{}, dynamic bool) {
 
-		input = &OPCUAInput{
-			Endpoint:                     endpoint,
-			Username:                     wrapper.Username,
-			Password:                     wrapper.Password,
-			NodeIDs:                      wrapper.NodeIDs,
-			BrowseHierarchicalReferences: wrapper.BrowseHierarchicalReferences,
-			AutoReconnect:                wrapper.AutoReconnect,
-			ReconnectIntervalInSeconds:   wrapper.ReconnectIntervalInSeconds,
-		}
+		input = opcInput
+		input.Endpoint = endpoint
 
 		err := input.Connect(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		var messageBatch service.MessageBatch
 
+		if !dynamic {
+			Eventually(func() (int, error) {
+				messageBatch, _, err = input.ReadBatch(ctx)
+				return len(messageBatch), err
+			}, 30*time.Second, 100*time.Millisecond).WithContext(ctx).Should(Equal(len(input.NodeIDs)))
+
+			for _, message := range messageBatch {
+				message, err := message.AsStructuredMut()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(message).To(BeAssignableToTypeOf(expectedValue))
+				Expect(message).To(Equal(expectedValue))
+			}
+			return
+		}
 		Eventually(func() (int, error) {
 			messageBatch, _, err = input.ReadBatch(ctx)
 			return len(messageBatch), err
 		}, 30*time.Second, 100*time.Millisecond).WithContext(ctx).Should(Equal(len(input.NodeIDs)))
 
+		var storedMessage any
+
 		for _, message := range messageBatch {
 			message, err := message.AsStructuredMut()
-			test := reflect.TypeOf(message)
-
-			GinkgoWriter.Printf("type of message: %v\n", test)
-			GinkgoWriter.Printf("message from messageBatch:  %v\n", message)
-
 			Expect(err).NotTo(HaveOccurred())
+			var assignableNumber json.Number = "10.0"
 
-			//	if reflect.TypeOf(wrapper.ExpectedValue).Kind() == reflect.Slice {
-			//		for _, messageEntry := range message {
-			//			if messageEntry == wrapper.ExpectedValue {
-			//				err = fmt.Errorf("namespace not found")
-			//			}
-			//		}
+			Expect(message).To(BeAssignableToTypeOf(assignableNumber))
+			storedMessage = message
+		}
 
-			//	}
-			value := reflect.ValueOf(message)
-			GinkgoWriter.Printf("value of message: %v\n", value)
+		var messageBatch2 service.MessageBatch
+		Eventually(func() (int, error) {
+			messageBatch2, _, err = input.ReadBatch(ctx)
+			return len(messageBatch2), err
+		}, 30*time.Second, 100*time.Millisecond).WithContext(ctx).Should(Equal(len(input.NodeIDs)))
 
-			typeOf := reflect.TypeOf(wrapper.ExpectedValue).Kind()
-			GinkgoWriter.Printf("type of ExpectedValue: %v\n", typeOf)
-			Expect(message).To(BeAssignableToTypeOf(wrapper.ExpectedValue))
-			Expect(message).To(Equal(wrapper.ExpectedValue))
+		for _, message := range messageBatch2 {
+			message, err := message.AsStructuredMut()
+			Expect(err).NotTo(HaveOccurred())
+			var assignableNumber json.Number = "10.0"
+
+			Expect(message).To(BeAssignableToTypeOf(assignableNumber))
+			Expect(message).NotTo(Equal(storedMessage))
 		}
 
 	},
-		Entry("should return true for data-value", KepwareWrapper{
+		Entry("should return true", &OPCUAInput{
 			Username:                     "",
 			Password:                     "",
-			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server _interface_1.custom_struct.Is_Diederik_Cool"}),
+			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server _interface_1.test"}),
 			BrowseHierarchicalReferences: true,
 			AutoReconnect:                true,
 			ReconnectIntervalInSeconds:   5,
-			ErrorOccured:                 false,
-			ExpectedValue:                true,
-		}),
-		//		Entry("should receive data changes", KepwareWrapper{
-		//			Username:                     "",
-		//			Password:                     "",
-		//			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server_interface_1.counter"}),
-		//			BrowseHierarchicalReferences: true,
-		//			AutoReconnect:                true,
-		//			ReconnectIntervalInSeconds:   5,
-		//			ErrorOccured:                 false,
-		//		}),
-		Entry("namespaceArray should consist of expected namespace", KepwareWrapper{
+		}, true, false),
+		Entry("should return data changes on subscribe", &OPCUAInput{
 			Username:                     "",
 			Password:                     "",
-			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.Server.NamespaceArray"}),
+			NodeIDs:                      ParseNodeIDs([]string{"ns=2;s=SiemensPLC_main.main.ServerInterfaces.Server _interface_1.counter"}),
 			BrowseHierarchicalReferences: true,
-			AutoReconnect:                true,
-			ReconnectIntervalInSeconds:   5,
-			ErrorOccured:                 false,
-			ExpectedValue:                "http://Server _interface_1",
-		}),
+			SubscribeEnabled:             true,
+		}, nil, true),
 	)
+
 })


### PR DESCRIPTION
### Description:
- should add kepware to testing infrastructure
- also should get included in Ci
- should be able to test plc's connected as opc ua-client in kepware
    - via verifying Namespace from NamespaceArray (includes siemens and wago)
    - via checking against an set up Int and Bool (right now only available via siemens)


--- 
### Maybe:
- depending on customer information we may add some more test-cases here (e.g. tag-count/plc-devices connected as clients...)
- later on maybe just try to use some docker containers as opc-ua clients (if available) to increase client count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added GitHub Actions workflow for testing the Kepware PLC application.
	- Introduced a comprehensive OPC UA plugin test suite for KepServer EX6.

- **Tests**
	- Implemented detailed test cases for OPC UA connection and data reading.
	- Added test scenarios covering connection scenarios, PLC namespace availability, and value verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->