### PR TITLE
[ENG-2319] Remove browseHierarchicalReferences flags and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ input:
     securityPolicy: None | Basic256Sha256  # optional (default: unset)
     subscribeEnabled: false | true # optional (default: false)
     useHeartbeat: false | true # optional (default: false)
-    browseHierarchicalReferences: false | true # optional (default: false)
     pollRate: 1000 # optional (default: 1000) The rate in milliseconds at which to poll the OPC UA server when not using subscriptions
     autoReconnect: false | true # optional (default: false)
     reconnectIntervalInSeconds: 5 # optional (default: 5) The rate in seconds at which to reconnect to the OPC UA server when the connection is lost
@@ -221,7 +220,7 @@ input:
 
 ##### Browse Hierarchical References (Option until version 0.5.2)
 
-**NOTE**: This property is removed in version 0.5.3 and made as a standard way to browse OPCUA nodes. From version 0.5.3 onwards, opcua_plugin will browse all nodes with Hierarchical References.
+**NOTE**: This property is removed in version 0.6.0 and made as a standard way to browse OPCUA nodes. From version 0.6.0 onwards, opcua_plugin will browse all nodes with Hierarchical References.
 
 The plugin offers an option to browse OPCUA nodes by following Hierarchical References. By default, this feature is disabled (`false`), which means the plugin will only browse a limited subset of reference types, including:
 - `HasComponent`

--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ input:
     useHeartbeat: true
 ```
 
-##### Browse Hierarchical References
+##### Browse Hierarchical References (Option until version 0.5.2)
+
+**NOTE**: This property is removed in version 0.5.3 and made as a standard way to browse OPCUA nodes. From version 0.5.3 onwards, opcua_plugin will browse all nodes with Hierarchical References.
 
 The plugin offers an option to browse OPCUA nodes by following Hierarchical References. By default, this feature is disabled (`false`), which means the plugin will only browse a limited subset of reference types, including:
 - `HasComponent`
@@ -1607,7 +1609,7 @@ Output:
       ],
       "notes": "Replace worn nozzle to prevent defects."
     }
-    
+
   },
   "timestamp_ms": 1733903611000
 }

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -90,7 +90,6 @@ func Browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 // - `errChan` (`chan error`): Channel to send encountered errors for centralized handling.
 // - `pathIDMapChan` (`chan map[string]string`): Channel to send the mapping of node names to NodeIDs.
 // - `wg` (`*sync.WaitGroup`): WaitGroup to synchronize the completion of goroutines.
-// - `browseHierarchicalReferences` (`bool`): Indicates whether to browse hierarchical references.
 // **Returns:**
 // - `void`: Errors are sent through `errChan`, and discovered nodes are sent through `nodeChan`.
 func browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef) {
@@ -304,9 +303,7 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 	}
 	// In OPC Unified Architecture (UA), hierarchical references are a type of reference that establishes a containment relationship between nodes in the address space. They are used to model a hierarchical structure, such as a system composed of components, where each component may contain sub-components.
 	// Refer link: https://qiyuqi.gitbooks.io/opc-ua/content/Part3/Chapter7.html
-	// With browseHierarchicalReferences set to true, we can browse the hierarchical references of a node which will check for references of type
 	// HasEventSource, HasChild, HasComponent, Organizes, FolderType, HasNotifier and all their sub-hierarchical references
-	// Setting browseHierarchicalReferences to true will be the new way to browse for tags and folders properly without any duplicate browsing
 
 	switch def.NodeClass {
 

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -62,7 +62,7 @@ type Logger interface {
 
 // Browse is a public wrapper function for the browse function
 // Avoid using this function directly, use it only for testing
-func Browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, browseHierarchicalReferences bool, opcuaBrowserChan chan NodeDef) {
+func Browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef) {
 	browse(ctx, n, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
 }
 

--- a/opcua_plugin/browse_frontend.go
+++ b/opcua_plugin/browse_frontend.go
@@ -41,7 +41,7 @@ func (g *OPCUAInput) GetNodeTree(ctx context.Context, msgChan chan<- string, roo
 
 	var wg TrackedWaitGroup
 	wg.Add(1)
-	browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(rootNode.NodeId)), "", 0, g.Log, rootNode.NodeId.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, opcuaBrowserChan)
+	browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(rootNode.NodeId)), "", 0, g.Log, rootNode.NodeId.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
 	go logBrowseStatus(ctx, nodeChan, msgChan, &wg)
 	go logErrors(ctx, errChan, g.Log)
 	go collectNodes(ctx, opcuaBrowserChan, nodeIDMap, &nodes)

--- a/opcua_plugin/opcua.go
+++ b/opcua_plugin/opcua.go
@@ -44,7 +44,6 @@ var OPCUAConfigSpec = service.NewConfigSpec().
 	Field(service.NewBoolField("subscribeEnabled").Description("Set to true to subscribe to OPC UA nodes instead of fetching them every seconds. Default is pulling messages every second (false).").Default(false)).
 	Field(service.NewBoolField("directConnect").Description("Set this to true to directly connect to an OPC UA endpoint. This can be necessary in cases where the OPC UA server does not allow 'endpoint discovery'. This requires having the full endpoint name in endpoint, and securityMode and securityPolicy set. Defaults to 'false'").Default(false)).
 	Field(service.NewBoolField("useHeartbeat").Description("Set to true to provide an extra message with the servers timestamp as a heartbeat").Default(false)).
-	Field(service.NewBoolField("browseHierarchicalReferences").Description("Set to true to browse hierarchical references. This is the new way to browse for tags and folders references properly without any duplicates. Defaults to 'false'").Default(false)).
 	Field(service.NewIntField("pollRate").Description("The rate in milliseconds at which to poll the OPC UA server when not using subscriptions. Defaults to 1000ms (1 second).").Default(DefaultPollRate)).
 	Field(service.NewBoolField("autoReconnect").Description("Set to true to automatically reconnect to the OPC UA server when the connection is lost. Defaults to 'false'").Default(false)).
 	Field(service.NewIntField("reconnectIntervalInSeconds").Description("The interval in seconds at which to reconnect to the OPC UA server when the connection is lost. This is only used if `autoReconnect` is set to true. Defaults to 5 seconds.").Default(5))
@@ -123,11 +122,6 @@ func newOPCUAInput(conf *service.ParsedConfig, mgr *service.Resources) (service.
 		return nil, err
 	}
 
-	browseHierarchicalReferences, err := conf.FieldBool("browseHierarchicalReferences")
-	if err != nil {
-		return nil, err
-	}
-
 	pollRate, err := conf.FieldInt("pollRate")
 	if err != nil {
 		return nil, err
@@ -163,7 +157,6 @@ func newOPCUAInput(conf *service.ParsedConfig, mgr *service.Resources) (service.
 		SessionTimeout:               sessionTimeout,
 		DirectConnect:                directConnect,
 		UseHeartbeat:                 useHeartbeat,
-		BrowseHierarchicalReferences: browseHierarchicalReferences,
 		LastHeartbeatMessageReceived: atomic.Uint32{},
 		LastMessageReceived:          atomic.Uint32{},
 		HeartbeatManualSubscribed:    false,
@@ -214,7 +207,6 @@ type OPCUAInput struct {
 	HeartbeatNodeId              *ua.NodeID
 	Subscription                 *opcua.Subscription
 	ServerInfo                   ServerInfo
-	BrowseHierarchicalReferences bool
 	PollRate                     int
 	browseCancel                 context.CancelFunc
 	browseWaitGroup              sync.WaitGroup

--- a/opcua_plugin/opcua_opc-plc_test.go
+++ b/opcua_plugin/opcua_opc-plc_test.go
@@ -1429,7 +1429,7 @@ opcua:
 			// Browse the node
 			wg.Add(1)
 			wrapperNodeID := NewOpcuaNodeWrapper(input.Client.Node(parsedNodeIDs[0]))
-			go Browse(ctx, wrapperNodeID, "", 0, input.Log, parsedNodeIDs[0].String(), nodeChan, errChan, &wg, true, opcuaBrowserChan)
+			go Browse(ctx, wrapperNodeID, "", 0, input.Log, parsedNodeIDs[0].String(), nodeChan, errChan, &wg, opcuaBrowserChan)
 
 			wg.Wait()
 			close(nodeChan)

--- a/opcua_plugin/opcua_plc_test.go
+++ b/opcua_plugin/opcua_plc_test.go
@@ -316,13 +316,12 @@ var _ = Describe("Test Against WAGO PLC", Serial, func() {
 			parsedNodeIDs := ParseNodeIDs(nodeIDStrings)
 
 			input = &OPCUAInput{
-				Endpoint:                     endpoint,
-				Username:                     "",
-				Password:                     "",
-				NodeIDs:                      parsedNodeIDs,
-				BrowseHierarchicalReferences: true,
-				AutoReconnect:                true,
-				ReconnectIntervalInSeconds:   5,
+				Endpoint:                   endpoint,
+				Username:                   "",
+				Password:                   "",
+				NodeIDs:                    parsedNodeIDs,
+				AutoReconnect:              true,
+				ReconnectIntervalInSeconds: 5,
 			}
 			// Attempt to connect
 			err = input.Connect(ctx)
@@ -355,12 +354,11 @@ var _ = Describe("Test Against WAGO PLC", Serial, func() {
 			parsedNodeIDs := ParseNodeIDs(nodeIDStrings)
 
 			input = &OPCUAInput{
-				Endpoint:                     endpoint,
-				Username:                     "",
-				Password:                     "",
-				NodeIDs:                      parsedNodeIDs,
-				SubscribeEnabled:             true,
-				BrowseHierarchicalReferences: true,
+				Endpoint:         endpoint,
+				Username:         "",
+				Password:         "",
+				NodeIDs:          parsedNodeIDs,
+				SubscribeEnabled: true,
 			}
 			ctx := context.Background()
 			err = input.Connect(ctx)

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -55,18 +55,17 @@ var _ = Describe("Unit Tests", func() {
 	var _ = Describe("Unit Tests for browse function", Label("browse_test"), func() {
 
 		var (
-			ctx                          context.Context
-			cncl                         context.CancelFunc
-			nodeBrowser                  NodeBrowser
-			path                         string
-			level                        int
-			logger                       Logger
-			parentNodeId                 string
-			nodeChan                     chan NodeDef
-			errChan                      chan error
-			wg                           *TrackedWaitGroup
-			browseHierarchicalReferences bool
-			opcuaBrowserChan             chan NodeDef
+			ctx              context.Context
+			cncl             context.CancelFunc
+			nodeBrowser      NodeBrowser
+			path             string
+			level            int
+			logger           Logger
+			parentNodeId     string
+			nodeChan         chan NodeDef
+			errChan          chan error
+			wg               *TrackedWaitGroup
+			opcuaBrowserChan chan NodeDef
 		)
 		BeforeEach(func() {
 			ctx, cncl = context.WithTimeout(context.Background(), 180*time.Second)
@@ -77,7 +76,6 @@ var _ = Describe("Unit Tests", func() {
 			nodeChan = make(chan NodeDef, 100)
 			errChan = make(chan error, 100)
 			wg = &TrackedWaitGroup{}
-			browseHierarchicalReferences = false
 			opcuaBrowserChan = make(chan NodeDef, 100)
 		})
 		AfterEach(func() {
@@ -102,7 +100,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNodeWithNilNodeClass
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -129,7 +127,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -167,7 +165,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -207,9 +205,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					// set browseHierarchicalReferences to true for reference nodes like id.HasChild
-					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -249,9 +245,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					// set browseHierarchicalReferences to true for reference nodes like id.Organizes
-					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -294,8 +288,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -371,8 +364,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = abcFolder
 				wg.Add(1)
 				go func() {
-					browseHierarchicalReferences := true
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, browseHierarchicalReferences, opcuaBrowserChan)
+					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -392,6 +384,69 @@ var _ = Describe("Unit Tests", func() {
 				Expect(nodes).Should(HaveLen(1))
 				Expect(nodes[0].NodeID.String()).To(Equal("ns=3;s=0:645645645.ProcessValue"))
 				Expect(nodes[0].BrowseName).To(Equal("ProcessValue"))
+			})
+		})
+
+		Context("After setting BrowseHierarchicalReferences as a standard way of browsing nodes", Label("BrowseHierarchicalReferences"), func() {
+			It("should return all children with HasChild reference type", func() {
+				rootNode := createMockNode(84, "root", ua.NodeClassObject)
+				childNode := createMockNode(85, "child", ua.NodeClassVariable)
+				rootNode.AddReferenceNode(id.HasChild, childNode)
+
+				nodes, errs := startBrowsing(ctx, rootNode, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
+
+				Expect(errs).Should(BeEmpty())
+				Expect(nodes).Should(HaveLen(1))
+				Expect(nodes[0].NodeID.String()).To(Equal("i=85"))
+				Expect(nodes[0].BrowseName).To(Equal("child"))
+			})
+
+			It("should return all nodes with HasComponent reference type", func() {
+				rootNode := createMockNode(84, "root", ua.NodeClassObject)
+				childNode := createMockNode(85, "child", ua.NodeClassVariable)
+				rootNode.AddReferenceNode(id.HasComponent, childNode)
+
+				nodes, errs := startBrowsing(ctx, rootNode, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
+				Expect(errs).Should(BeEmpty())
+				Expect(nodes).Should(HaveLen(1))
+				Expect(nodes[0].NodeID.String()).To(Equal("i=85"))
+				Expect(nodes[0].BrowseName).To(Equal("child"))
+			})
+
+			It("should return all nodes with Organizes reference type", func() {
+				rootNode := createMockNode(84, "root", ua.NodeClassObject)
+				childNode := createMockNode(85, "child", ua.NodeClassVariable)
+				rootNode.AddReferenceNode(id.Organizes, childNode)
+
+				nodes, errs := startBrowsing(ctx, rootNode, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
+				Expect(errs).Should(BeEmpty())
+				Expect(nodes).Should(HaveLen(1))
+				Expect(nodes[0].NodeID.String()).To(Equal("i=85"))
+				Expect(nodes[0].BrowseName).To(Equal("child"))
+			})
+
+			It("should return all nodes with FolderType reference type", func() {
+				rootNode := createMockNode(84, "root", ua.NodeClassObject)
+				childNode := createMockNode(85, "child", ua.NodeClassVariable)
+				rootNode.AddReferenceNode(id.FolderType, childNode)
+
+				nodes, errs := startBrowsing(ctx, rootNode, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
+				Expect(errs).Should(BeEmpty())
+				Expect(nodes).Should(HaveLen(1))
+				Expect(nodes[0].NodeID.String()).To(Equal("i=85"))
+				Expect(nodes[0].BrowseName).To(Equal("child"))
+			})
+
+			It("should return all nodes with HasNotifier reference type", func() {
+				rootNode := createMockNode(84, "root", ua.NodeClassObject)
+				childNode := createMockNode(85, "child", ua.NodeClassVariable)
+				rootNode.AddReferenceNode(id.HasNotifier, childNode)
+
+				nodes, errs := startBrowsing(ctx, rootNode, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
+				Expect(errs).Should(BeEmpty())
+				Expect(nodes).Should(HaveLen(1))
+				Expect(nodes[0].NodeID.String()).To(Equal("i=85"))
+				Expect(nodes[0].BrowseName).To(Equal("child"))
 			})
 		})
 	})
@@ -614,5 +669,41 @@ func createMockVariableNode(id uint32, name string) *MockOpcuaNodeWraper {
 	}
 }
 
+func createMockNode(id uint32, name string, nodeClass ua.NodeClass) *MockOpcuaNodeWraper {
+	node := &MockOpcuaNodeWraper{
+		id:             ua.NewNumericNodeID(0, id),
+		browseName:     &ua.QualifiedName{NamespaceIndex: 0, Name: name},
+		referenceNodes: make(map[uint32][]NodeBrowser),
+	}
+	node.attributes = append(node.attributes, getDataValueForNodeClass(nodeClass))
+	node.attributes = append(node.attributes, getDataValueForBrowseName(name))
+	node.attributes = append(node.attributes, getDataValueForDescription(name, ua.StatusOK))
+	node.attributes = append(node.attributes, getDataValueForAccessLevel(ua.AccessLevelTypeCurrentRead))
+	node.attributes = append(node.attributes, getDataValueForDataType(ua.TypeIDString, ua.StatusOK))
+	return node
+}
+
 // Ensure that the MockOpcuaNodeWraper implements the NodeBrowser interface
 var _ NodeBrowser = &MockOpcuaNodeWraper{}
+
+func startBrowsing(ctx context.Context, rootNode NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef) ([]NodeDef, []error) {
+	wg.Add(1)
+	go func() {
+		Browse(ctx, rootNode, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
+	}()
+	wg.Wait()
+	close(nodeChan)
+	close(errChan)
+
+	var nodes []NodeDef
+	for nodeDef := range nodeChan {
+		nodes = append(nodes, nodeDef)
+	}
+
+	var errs []error
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+
+	return nodes, errs
+}

--- a/opcua_plugin/server_info.go
+++ b/opcua_plugin/server_info.go
@@ -37,9 +37,9 @@ func (g *OPCUAInput) GetOPCUAServerInformation(ctx context.Context) (ServerInfo,
 	var wg TrackedWaitGroup
 
 	wg.Add(3)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, opcuaBrowserChan)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, opcuaBrowserChan)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, g.BrowseHierarchicalReferences, opcuaBrowserChan)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
 	wg.Wait()
 
 	close(nodeChan)


### PR DESCRIPTION
## Description 

The PR makes browseHierarchicalReferences as a standard way of browsing nodes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for OPC UA Plugin v0.6.0

- **New Features**
  - Default browsing of all nodes with Hierarchical References.
  - Simplified node browsing configuration.

- **Documentation**
  - Updated README to clarify changes in browsing functionality and the removal of specific options.

- **Improvements**
  - Streamlined node browsing logic.
  - Enhanced node processing for variables and objects.
  - Removed deprecated browsing parameters.

- **Breaking Changes**
  - Removed `browseHierarchicalReferences` parameter from browsing functions.
  - The `BrowseHierarchicalReferences` field has been removed from the configuration and input struct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->