### PR TITLE
[ENG-2364] Avoid Looping of nodes that are visited already while browsing OPCUA server

### DIFF
--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -97,6 +97,7 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 
 	// Check if the current node is already visited else proceed
 	if _, exists := visited.LoadOrStore(n.ID(), struct{}{}); exists {
+		logger.Debugf("node %s is visited already, hence doing an early exit from the browse routine", n.ID().String())
 		return
 	}
 

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -62,8 +62,8 @@ type Logger interface {
 
 // Browse is a public wrapper function for the browse function
 // Avoid using this function directly, use it only for testing
-func Browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef) {
-	browse(ctx, n, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan)
+func Browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef, visited *sync.Map) {
+	browse(ctx, n, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, visited)
 }
 
 // browse recursively explores OPC UA nodes to build a comprehensive list of NodeDefs.
@@ -92,8 +92,13 @@ func Browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 // - `wg` (`*sync.WaitGroup`): WaitGroup to synchronize the completion of goroutines.
 // **Returns:**
 // - `void`: Errors are sent through `errChan`, and discovered nodes are sent through `nodeChan`.
-func browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef) {
+func browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef, visited *sync.Map) {
 	defer wg.Done()
+
+	// Check if the current node is already visited else proceed
+	if _, exists := visited.LoadOrStore(n.ID(), struct{}{}); exists {
+		return
+	}
 
 	// Limits browsing depth to a maximum of 25 levels in the node hierarchy.
 	// Performance impact is minimized since most browse operations terminate earlier
@@ -287,7 +292,7 @@ func browse(ctx context.Context, n NodeBrowser, path string, level int, logger L
 		}
 		for _, child := range children {
 			wg.Add(1)
-			go browse(ctx, child, def.Path, level+1, logger, def.NodeID.String(), nodeChan, errChan, wg, opcuaBrowserChan)
+			go browse(ctx, child, def.Path, level+1, logger, def.NodeID.String(), nodeChan, errChan, wg, opcuaBrowserChan, visited)
 		}
 		return nil
 	}
@@ -403,7 +408,7 @@ func (g *OPCUAInput) discoverNodes(ctx context.Context) ([]NodeDef, map[string]s
 		g.Log.Debugf("Browsing nodeID: %s", nodeID.String())
 		wg.Add(1)
 		wrapperNodeID := NewOpcuaNodeWrapper(g.Client.Node(nodeID))
-		go browse(timeoutCtx, wrapperNodeID, "", 0, g.Log, nodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
+		go browse(timeoutCtx, wrapperNodeID, "", 0, g.Log, nodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
 	}
 
 	go func() {
@@ -479,7 +484,7 @@ func (g *OPCUAInput) BrowseAndSubscribeIfNeeded(ctx context.Context) error {
 
 			wgHeartbeat.Add(1)
 			wrapperNodeID := NewOpcuaNodeWrapper(g.Client.Node(heartbeatNodeID))
-			go browse(ctx, wrapperNodeID, "", 1, g.Log, heartbeatNodeID.String(), nodeHeartbeatChan, errChanHeartbeat, &wgHeartbeat, opcuaBrowserChanHeartbeat)
+			go browse(ctx, wrapperNodeID, "", 1, g.Log, heartbeatNodeID.String(), nodeHeartbeatChan, errChanHeartbeat, &wgHeartbeat, opcuaBrowserChanHeartbeat, &g.visited)
 
 			wgHeartbeat.Wait()
 			close(nodeHeartbeatChan)

--- a/opcua_plugin/browse_frontend.go
+++ b/opcua_plugin/browse_frontend.go
@@ -41,7 +41,7 @@ func (g *OPCUAInput) GetNodeTree(ctx context.Context, msgChan chan<- string, roo
 
 	var wg TrackedWaitGroup
 	wg.Add(1)
-	browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(rootNode.NodeId)), "", 0, g.Log, rootNode.NodeId.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
+	browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(rootNode.NodeId)), "", 0, g.Log, rootNode.NodeId.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
 	go logBrowseStatus(ctx, nodeChan, msgChan, &wg)
 	go logErrors(ctx, errChan, g.Log)
 	go collectNodes(ctx, opcuaBrowserChan, nodeIDMap, &nodes)

--- a/opcua_plugin/opcua.go
+++ b/opcua_plugin/opcua.go
@@ -213,6 +213,7 @@ type OPCUAInput struct {
 	browseErrorChan              chan error
 	AutoReconnect                bool
 	ReconnectIntervalInSeconds   int
+	visited                      sync.Map
 }
 
 // cleanupBrowsing ensures the browsing goroutine is properly stopped and cleaned up

--- a/opcua_plugin/opcua_opc-plc_test.go
+++ b/opcua_plugin/opcua_opc-plc_test.go
@@ -1425,11 +1425,12 @@ opcua:
 			errChan := make(chan error, 100)
 			opcuaBrowserChan := make(chan NodeDef, 100)
 			var wg TrackedWaitGroup
+			var visited sync.Map
 
 			// Browse the node
 			wg.Add(1)
 			wrapperNodeID := NewOpcuaNodeWrapper(input.Client.Node(parsedNodeIDs[0]))
-			go Browse(ctx, wrapperNodeID, "", 0, input.Log, parsedNodeIDs[0].String(), nodeChan, errChan, &wg, opcuaBrowserChan)
+			go Browse(ctx, wrapperNodeID, "", 0, input.Log, parsedNodeIDs[0].String(), nodeChan, errChan, &wg, opcuaBrowserChan, &visited)
 
 			wg.Wait()
 			close(nodeChan)

--- a/opcua_plugin/server_info.go
+++ b/opcua_plugin/server_info.go
@@ -37,9 +37,9 @@ func (g *OPCUAInput) GetOPCUAServerInformation(ctx context.Context) (ServerInfo,
 	var wg TrackedWaitGroup
 
 	wg.Add(3)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
+	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
 	wg.Wait()
 
 	close(nodeChan)


### PR DESCRIPTION
## Description 

OPC UA's address space allows for complex relationships between nodes, including circular references[1](https://www.re-digital.io/news/details/what-i-learned-from-20-months-with-opc-ua). This characteristic of OPC UA's architecture can lead to several implications for browsing and navigating the address space. Hence the browsing algorithm is improved by adding a `visited` map that keeps track of the visited node and avoids rebrowsing

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/4b19b2da-00de-4748-b6a9-dc75b395b3be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added node tracking mechanism using `sync.Map` to prevent revisiting nodes during OPC UA browsing
	- Enhanced browsing efficiency by avoiding redundant node processing

- **Bug Fixes**
	- Prevented potential infinite loops and performance issues in node traversal

- **Refactor**
	- Updated function signatures across multiple files to support node tracking
	- Integrated `visited` parameter in browsing-related functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->