### PR TITLE
[ENG-2320] Refactor browse method to use worker pattern

### DIFF
--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -91,8 +91,8 @@ func browse(
 	metrics := NewServerMetrics()
 	var taskWg TrackedWaitGroup
 	var workerWg TrackedWaitGroup
-	// Have sufficient buffer (currentWorkers * 1000) for taskChan to avoid blocking and the number of workers might grow dynamically down the line.
-	taskChan := make(chan NodeTask, metrics.currentWorkers*1000)
+	// Have sufficient buffer (minWorkers* 10_000) for taskChan to avoid blocking and the number of workers might grow dynamically down the line. The minWorkers is a constant of 3
+	taskChan := make(chan NodeTask, metrics.currentWorkers*10000)
 
 	workerID := make(map[uuid.UUID]struct{})
 	// Start worker pool manager

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -90,12 +90,13 @@ func browse(
 	metrics := NewServerMetrics()
 	var taskWg TrackedWaitGroup
 	var workerWg TrackedWaitGroup
-	taskChan := make(chan NodeTask, metrics.currentWorkers*10)
+	// Have sufficient buffer (currentWorkers * 1000) for taskChan to avoid blocking and the number of workers might grow dynamically down the line.
+	taskChan := make(chan NodeTask, metrics.currentWorkers*1000)
 
 	workerID := atomic.Int32{}
 	// Start worker pool manager
 	go func() {
-		ticker := time.NewTicker(10 * time.Second)
+		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 
 		for {

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -80,7 +80,7 @@ func browse(ctx context.Context, startNode NodeBrowser, startPath string, logger
 
 	var taskWg TrackedWaitGroup
 	var workerWg TrackedWaitGroup
-	const numWorkers = 10 // Adjust based on your needs
+	const numWorkers = 100 // Adjust based on your needs
 	taskChan := make(chan NodeTask, numWorkers*10)
 
 	// Start worker pool

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -353,7 +353,9 @@ func (twg *TrackedWaitGroup) Count() int64 {
 
 // Then modify the discoverNodes function to use TrackedWaitGroup
 func (g *OPCUAInput) discoverNodes(ctx context.Context) ([]NodeDef, map[string]string, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	// This was previously 5 minutes, but we need to increase it to 1 hour to avoid context cancellation
+	// when browsing a large number of nodes.
+	timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
 	nodeList := make([]NodeDef, 0)

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -179,10 +179,8 @@ func worker(
 				continue
 			}
 
-			logger.Debugf("\nWorker %d: level %d: def.Path:%s def.NodeClass:%s\n",
-				id, task.level, def.Path, def.NodeClass)
-			logger.Debugf("TrackedWaitGroup count: %d\n", taskWg.Count())
-			logger.Debugf("WorkerWg count: %d\n", workerWg.Count())
+			logger.Debugf("\nWorker %d: level %d: def.Path:%s def.NodeClass:%s TaskWaitGroup count: %d WorkerWaitGroup count: %d\n",
+				id, task.level, def.Path, def.NodeClass, taskWg.Count(), workerWg.Count())
 
 			// Handle browser channel
 			browserDef := def
@@ -243,7 +241,6 @@ func browseChildren(ctx context.Context, task NodeTask, def NodeDef, taskChan ch
 	// Queue child tasks
 	for _, child := range children {
 		wg.Add(1)
-		fmt.Printf("Adding child task to channel: %s", child.ID().String())
 		taskChan <- NodeTask{
 			node:         child,
 			path:         def.Path,

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -231,7 +231,17 @@ func sendError(ctx context.Context, err error, errChan chan<- error, logger Logg
 	}
 }
 
-// Add this helper function after the worker function
+// browseChildren browses the child nodes of the given node and queues them as tasks.
+// It only browses for variables and objects through hierarchical references.
+// The child tasks are queued with an incremented level and the current node's path and ID as parent.
+// Parameters:
+//   - ctx: Context for cancellation
+//   - task: The current node task being processed
+//   - def: Node definition containing path and ID information
+//   - taskChan: Channel to queue child tasks
+//   - taskWg: WaitGroup to track task completion
+//
+// Returns an error if browsing children fails
 func browseChildren(ctx context.Context, task NodeTask, def NodeDef, taskChan chan NodeTask, taskWg *TrackedWaitGroup) error {
 	children, err := task.node.Children(ctx, id.HierarchicalReferences,
 		ua.NodeClassVariable|ua.NodeClassObject)

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -136,6 +136,7 @@ func worker(
 			}
 
 			if task.level > 25 {
+				logger.Debugf("Skipping node %s at browse level %d", task.node.ID().String(), task.level)
 				taskWg.Done()
 				continue
 			}
@@ -231,7 +232,7 @@ func sendError(ctx context.Context, err error, errChan chan<- error, logger Logg
 }
 
 // Add this helper function after the worker function
-func browseChildren(ctx context.Context, task NodeTask, def NodeDef, taskChan chan NodeTask, wg *TrackedWaitGroup) error {
+func browseChildren(ctx context.Context, task NodeTask, def NodeDef, taskChan chan NodeTask, taskWg *TrackedWaitGroup) error {
 	children, err := task.node.Children(ctx, id.HierarchicalReferences,
 		ua.NodeClassVariable|ua.NodeClassObject)
 	if err != nil {
@@ -240,7 +241,7 @@ func browseChildren(ctx context.Context, task NodeTask, def NodeDef, taskChan ch
 
 	// Queue child tasks
 	for _, child := range children {
-		wg.Add(1)
+		taskWg.Add(1)
 		taskChan <- NodeTask{
 			node:         child,
 			path:         def.Path,

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -62,149 +62,168 @@ type Logger interface {
 
 // Browse is a public wrapper function for the browse function
 // Avoid using this function directly, use it only for testing
-func Browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef, visited *sync.Map) {
-	browse(ctx, n, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, visited)
+func Browse(ctx context.Context, n NodeBrowser, path string, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef, visited *sync.Map) {
+	browse(ctx, n, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, visited)
 }
 
-// browse recursively explores OPC UA nodes to build a comprehensive list of NodeDefs.
-//
-// The `browse` function is essential for discovering the structure and details of OPC UA nodes.
-// It performs the following operations:
-//   - Fetches essential attributes of a node, such as NodeClass, BrowseName, Description,
-//     AccessLevel, and DataType.
-//   - Determines if a node has child components (e.g., variables within an object) and recursively
-//     browses them if necessary, ensuring a complete traversal of the node hierarchy.
-//
-// **Why This Function is Needed:** s
-//   - To build a structured representation (`nodeList`) of all relevant nodes for further processing
-//     such as subscribing to data changes.
-//
-// **Parameters:**
-// - `ctx` (`context.Context`): Manages cancellation and timeouts for the browsing operations.
-// - `n` (`*opcua.Node`): The current OPC UA node to browse.
-// - `path` (`string`): The hierarchical path accumulated so far.
-// - `level` (`int`): The current depth level in the node hierarchy, used to prevent excessive recursion.
-// - `logger` (`*service.Logger`): Logs debug and error messages for monitoring and troubleshooting.
-// - `parentNodeId` (`string`): The NodeID of the parent node, used for reference tracking.
-// - `nodeChan` (`chan NodeDef`): Channel to send discovered NodeDefs for collection.
-// - `errChan` (`chan error`): Channel to send encountered errors for centralized handling.
-// - `pathIDMapChan` (`chan map[string]string`): Channel to send the mapping of node names to NodeIDs.
-// - `wg` (`*sync.WaitGroup`): WaitGroup to synchronize the completion of goroutines.
-// **Returns:**
-// - `void`: Errors are sent through `errChan`, and discovered nodes are sent through `nodeChan`.
-func browse(ctx context.Context, n NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef, visited *sync.Map) {
+// NodeTask represents a task for workers to process
+type NodeTask struct {
+	node         NodeBrowser
+	path         string
+	level        int
+	parentNodeId string
+}
+
+// browse uses a worker pool pattern to process nodes
+func browse(ctx context.Context, startNode NodeBrowser, startPath string, logger Logger, parentNodeId string,
+	nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef, visited *sync.Map) {
+
+	const numWorkers = 10 // Adjust based on your needs
+	taskChan := make(chan NodeTask, numWorkers*10)
+
+	// Start worker pool
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go worker(ctx, i, taskChan, nodeChan, errChan, opcuaBrowserChan, visited, logger, wg)
+	}
+
+	// Send initial task
+	taskChan <- NodeTask{
+		node:         startNode,
+		path:         startPath,
+		level:        0,
+		parentNodeId: parentNodeId,
+	}
+
+	// Close task channel when all tasks are processed
+	go func() {
+		wg.Wait()
+		close(taskChan)
+	}()
+}
+
+func worker(ctx context.Context, id int, taskChan chan NodeTask, nodeChan chan NodeDef,
+	errChan chan error, opcuaBrowserChan chan NodeDef, visited *sync.Map, logger Logger, wg *TrackedWaitGroup) {
+
 	defer wg.Done()
 
-	// Check if the current node is already visited else proceed
-	if _, exists := visited.LoadOrStore(n.ID(), struct{}{}); exists {
-		logger.Debugf("node %s is visited already, hence doing an early exit from the browse routine", n.ID().String())
-		return
-	}
+	for task := range taskChan {
+		// Skip if already visited or too deep
+		if _, exists := visited.LoadOrStore(task.node.ID(), struct{}{}); exists {
+			logger.Debugf("Worker %d: node %s already visited", id, task.node.ID().String())
+			continue
+		}
+		if task.level > 25 {
+			continue
+		}
 
-	// Limits browsing depth to a maximum of 25 levels in the node hierarchy.
-	// Performance impact is minimized since most browse operations terminate earlier
-	// due to other exit conditions before reaching this maximum depth.
-	if level > 25 {
-		return
-	}
+		// Err will be nil if the context is not done
+		if ctx.Err() != nil {
+			logger.Warnf("Worker %d: received cancellation signal", id)
+			return
+		}
 
-	select {
-	case <-ctx.Done():
-		logger.Warnf("browse function received cancellation signal")
-		return
-	default:
-		// Continue processing
-	}
-
-	attrs, err := n.Attributes(ctx, ua.AttributeIDNodeClass, ua.AttributeIDBrowseName, ua.AttributeIDDescription, ua.AttributeIDAccessLevel, ua.AttributeIDDataType)
-	if err != nil {
-		sendError(ctx, err, errChan, logger)
-		return
-	}
-
-	if len(attrs) != 5 {
-		sendError(ctx, errors.Errorf("only got %d attr, needed 5", len(attrs)), errChan, logger)
-		return
-	}
-
-	browseName, err := n.BrowseName(ctx)
-	if err != nil {
-		sendError(ctx, err, errChan, logger)
-		return
-	}
-
-	newPath := sanitize(browseName.Name)
-	if path != "" {
-		newPath = path + "." + newPath
-	}
-
-	var def = NodeDef{
-		NodeID:       n.ID(),
-		Path:         newPath,
-		ParentNodeID: parentNodeId,
-	}
-
-	// def.NodeClass, def.BrowseName, def.Description, def.AccessLevel, def.DataType are set in the processNodeAttributes function
-	if err := processNodeAttributes(attrs, &def, newPath, logger); err != nil {
-		sendError(ctx, err, errChan, logger)
-		return
-	}
-
-	logger.Debugf("%d: def.Path:%s def.NodeClass:%s\n", level, def.Path, def.NodeClass)
-
-	browseChildrenV2 := func(refType uint32) error {
-		children, err := n.Children(ctx, refType, ua.NodeClassVariable|ua.NodeClassObject)
+		// Get node attributes
+		attrs, err := task.node.Attributes(ctx, ua.AttributeIDNodeClass, ua.AttributeIDBrowseName,
+			ua.AttributeIDDescription, ua.AttributeIDAccessLevel, ua.AttributeIDDataType)
 		if err != nil {
-			sendError(ctx, errors.Errorf("Children: %d: %s", refType, err), errChan, logger)
-			return err
-		}
-		for _, child := range children {
-			wg.Add(1)
-			go browse(ctx, child, def.Path, level+1, logger, def.NodeID.String(), nodeChan, errChan, wg, opcuaBrowserChan, visited)
-		}
-		return nil
-	}
-
-	// Create a copy of the def(current Node). Do no modify the original nodeDef. This nodeDefForOPCUABrowser is used only for OPCUA browser operation
-	nodeDefForOPCUABrowser := def
-	nodeDefForOPCUABrowser.Path = join(path, nodeDefForOPCUABrowser.BrowseName)
-	select {
-	case opcuaBrowserChan <- nodeDefForOPCUABrowser:
-	// do nothing if message publish to the channel is successful
-	default:
-		logger.Debugf("opcuaBrowserChan is blocked, skipping nodeDefForOPCUABrowser send")
-	}
-	// In OPC Unified Architecture (UA), hierarchical references are a type of reference that establishes a containment relationship between nodes in the address space. They are used to model a hierarchical structure, such as a system composed of components, where each component may contain sub-components.
-	// Refer link: https://qiyuqi.gitbooks.io/opc-ua/content/Part3/Chapter7.html
-	// HasEventSource, HasChild, HasComponent, Organizes, FolderType, HasNotifier and all their sub-hierarchical references
-
-	switch def.NodeClass {
-
-	// If its a variable, we add it to the node list and browse all its children
-	case ua.NodeClassVariable:
-		if err := browseChildrenV2(id.HierarchicalReferences); err != nil {
 			sendError(ctx, err, errChan, logger)
-			return
+			continue
 		}
 
-		// adding it to the node list
-		def.Path = join(path, def.BrowseName)
+		if len(attrs) != 5 {
+			sendError(ctx, errors.Errorf("only got %d attr, needed 5", len(attrs)), errChan, logger)
+			continue
+		}
+
+		browseName, err := task.node.BrowseName(ctx)
+		if err != nil {
+			sendError(ctx, err, errChan, logger)
+			continue
+		}
+
+		newPath := sanitize(browseName.Name)
+		if task.path != "" {
+			newPath = task.path + "." + newPath
+		}
+
+		def := NodeDef{
+			NodeID:       task.node.ID(),
+			Path:         newPath,
+			ParentNodeID: task.parentNodeId,
+		}
+
+		if err := processNodeAttributes(attrs, &def, newPath, logger); err != nil {
+			sendError(ctx, err, errChan, logger)
+			continue
+		}
+
+		logger.Debugf("Worker %d: level %d: def.Path:%s def.NodeClass:%s\n",
+			id, task.level, def.Path, def.NodeClass)
+
+		// Handle browser channel
+		browserDef := def
+		browserDef.Path = join(task.path, browserDef.BrowseName)
 		select {
-		case nodeChan <- def:
-		case <-ctx.Done():
-			logger.Warnf("Failed to send node due to context cancellation")
-			return
+		case opcuaBrowserChan <- browserDef:
+		default:
+			logger.Debugf("Worker %d: opcuaBrowserChan blocked, skipping", id)
 		}
-		return
 
-		// If its an object, we browse all its children but DO NOT add it to the node list and therefore not subscribe
-	case ua.NodeClassObject:
-		if err := browseChildrenV2(id.HierarchicalReferences); err != nil {
-			sendError(ctx, err, errChan, logger)
-			return
+		// Process based on node class
+		switch def.NodeClass {
+		case ua.NodeClassVariable:
+			// Add to results
+			select {
+			case nodeChan <- def:
+			case <-ctx.Done():
+				logger.Warnf("Worker %d: Failed to send node due to cancellation", id)
+				return
+			}
+			// Browse children (common for both Variable and Object)
+			if err := browseChildren(ctx, task, def, taskChan, wg); err != nil {
+				sendError(ctx, err, errChan, logger)
+			}
+
+		case ua.NodeClassObject:
+			// Browse children
+			if err := browseChildren(ctx, task, def, taskChan, wg); err != nil {
+				sendError(ctx, err, errChan, logger)
+			}
 		}
-		return
 	}
+}
+
+// helper function to send an error to a channel, with logging if the channel is blocked or the context is done
+func sendError(ctx context.Context, err error, errChan chan<- error, logger Logger) {
+	select {
+	case errChan <- err:
+	case <-ctx.Done():
+		logger.Warnf("Failed to send error due to context cancellation: %v", err)
+	default:
+		logger.Warnf("Channel is blocked, skipping error send: %v", err)
+	}
+}
+
+// Add this helper function after the worker function
+func browseChildren(ctx context.Context, task NodeTask, def NodeDef, taskChan chan NodeTask, wg *TrackedWaitGroup) error {
+	children, err := task.node.Children(ctx, id.HierarchicalReferences,
+		ua.NodeClassVariable|ua.NodeClassObject)
+	if err != nil {
+		return errors.Errorf("Children: %s", err)
+	}
+
+	// Queue child tasks
+	for _, child := range children {
+		wg.Add(1)
+		taskChan <- NodeTask{
+			node:         child,
+			path:         def.Path,
+			level:        task.level + 1,
+			parentNodeId: def.NodeID.String(),
+		}
+	}
+	return nil
 }
 
 // Node represents a node in the tree structure
@@ -276,7 +295,7 @@ func (g *OPCUAInput) discoverNodes(ctx context.Context) ([]NodeDef, map[string]s
 		g.Log.Debugf("Browsing nodeID: %s", nodeID.String())
 		wg.Add(1)
 		wrapperNodeID := NewOpcuaNodeWrapper(g.Client.Node(nodeID))
-		go browse(timeoutCtx, wrapperNodeID, "", 0, g.Log, nodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
+		go browse(timeoutCtx, wrapperNodeID, "", g.Log, nodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
 	}
 
 	go func() {
@@ -352,7 +371,7 @@ func (g *OPCUAInput) BrowseAndSubscribeIfNeeded(ctx context.Context) error {
 
 			wgHeartbeat.Add(1)
 			wrapperNodeID := NewOpcuaNodeWrapper(g.Client.Node(heartbeatNodeID))
-			go browse(ctx, wrapperNodeID, "", 1, g.Log, heartbeatNodeID.String(), nodeHeartbeatChan, errChanHeartbeat, &wgHeartbeat, opcuaBrowserChanHeartbeat, &g.visited)
+			go browse(ctx, wrapperNodeID, "", g.Log, heartbeatNodeID.String(), nodeHeartbeatChan, errChanHeartbeat, &wgHeartbeat, opcuaBrowserChanHeartbeat, &g.visited)
 
 			wgHeartbeat.Wait()
 			close(nodeHeartbeatChan)
@@ -503,16 +522,5 @@ func UpdateNodePaths(nodes []NodeDef) {
 				nodes[j].Path = otherNodePath
 			}
 		}
-	}
-}
-
-// helper function to send an error to a channel, with logging if the channel is blocked or the context is done
-func sendError(ctx context.Context, err error, errChan chan<- error, logger Logger) {
-	select {
-	case errChan <- err:
-	case <-ctx.Done():
-		logger.Warnf("Failed to send error due to context cancellation: %v", err)
-	default:
-		logger.Warnf("Channel is blocked, skipping error send: %v", err)
 	}
 }

--- a/opcua_plugin/browse.go
+++ b/opcua_plugin/browse.go
@@ -92,6 +92,7 @@ func browse(
 	var taskWg TrackedWaitGroup
 	var workerWg TrackedWaitGroup
 	// Have sufficient buffer (minWorkers* 10_000) for taskChan to avoid blocking and the number of workers might grow dynamically down the line. The minWorkers is a constant of 3
+	// TODO: Introduce backpressure mechanism to avoid blocking the taskChan
 	taskChan := make(chan NodeTask, metrics.currentWorkers*10000)
 
 	workerID := make(map[uuid.UUID]struct{})

--- a/opcua_plugin/browse_frontend.go
+++ b/opcua_plugin/browse_frontend.go
@@ -41,7 +41,7 @@ func (g *OPCUAInput) GetNodeTree(ctx context.Context, msgChan chan<- string, roo
 
 	var wg TrackedWaitGroup
 	wg.Add(1)
-	browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(rootNode.NodeId)), "", 0, g.Log, rootNode.NodeId.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
+	Browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(rootNode.NodeId)), "", g.Log, rootNode.NodeId.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
 	go logBrowseStatus(ctx, nodeChan, msgChan, &wg)
 	go logErrors(ctx, errChan, g.Log)
 	go collectNodes(ctx, opcuaBrowserChan, nodeIDMap, &nodes)

--- a/opcua_plugin/browse_workers.go
+++ b/opcua_plugin/browse_workers.go
@@ -1,0 +1,94 @@
+package opcua_plugin
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	MaxWorkers     = 200
+	MinWorkers     = 2
+	InitialWorkers = 2
+	SampleSize     = 5 // Number of requsts to measure response time
+)
+
+// ServerMetrics is a struct that holds the metrics for the OPCUA server requests
+type ServerMetrics struct {
+	mu             sync.Mutex
+	responseTimes  []time.Duration
+	currentWorkers int
+	targetLatency  time.Duration
+	workerControls map[int]chan struct{} // Channel to signal workers to stop
+}
+
+func NewServerMetrics() *ServerMetrics {
+	return &ServerMetrics{
+		responseTimes:  make([]time.Duration, 0),
+		workerControls: make(map[int]chan struct{}),
+		targetLatency:  100 * time.Millisecond,
+		currentWorkers: InitialWorkers,
+	}
+}
+
+// addWorker adds new worker browser and registers the id to the workerControls map
+func (sm *ServerMetrics) addWorker(id int) chan struct{} {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	stopChan := make(chan struct{})
+	sm.workerControls[id] = stopChan
+	return stopChan
+}
+
+// removeWorker removes a worker from the workerControls map and
+// stops a worker by closing the channel for the worker
+func (sm *ServerMetrics) removeWorker(id int) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if stopChan, exists := sm.workerControls[id]; exists {
+		close(stopChan)
+		delete(sm.workerControls, id)
+	}
+}
+
+// adjustWorkers calculates the number of workers to adjust based on the response time of the last SampleSize requests
+func (sm *ServerMetrics) adjustWorkers(logger Logger) (toAdd, toRemove int) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if len(sm.responseTimes) < SampleSize {
+		return 0, 0
+	}
+
+	var totalTime time.Duration
+	for _, t := range sm.responseTimes {
+		totalTime += t
+	}
+	avgResponse := totalTime / time.Duration(len(sm.responseTimes))
+	oldWorkerCount := sm.currentWorkers
+
+	if avgResponse > sm.targetLatency {
+		// Response time is too high. Reduce workers
+		sm.currentWorkers = max(MinWorkers, sm.currentWorkers-10)
+		logger.Debugf("Response time is high (%v > %v target Latency), reducing workers from %d to %d", avgResponse, sm.targetLatency, oldWorkerCount, sm.currentWorkers)
+	}
+
+	if avgResponse < sm.targetLatency {
+		// Response time is too low. Increase workers
+		sm.currentWorkers = min(MaxWorkers, sm.currentWorkers+10)
+		logger.Debugf("Response time is low (%v < %v target Latency), increasing workers from %d to %d", avgResponse, sm.targetLatency, oldWorkerCount, sm.currentWorkers)
+	}
+
+	sm.responseTimes = sm.responseTimes[:0]
+	if sm.currentWorkers > oldWorkerCount {
+		return sm.currentWorkers - oldWorkerCount, 0
+	}
+
+	return 0, oldWorkerCount - sm.currentWorkers
+}
+
+// recordResponseTime records the response time of a request
+func (sm *ServerMetrics) recordResponseTime(duration time.Duration) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.responseTimes = append(sm.responseTimes, duration)
+}

--- a/opcua_plugin/opcua_opc-plc_test.go
+++ b/opcua_plugin/opcua_opc-plc_test.go
@@ -1430,7 +1430,7 @@ opcua:
 			// Browse the node
 			wg.Add(1)
 			wrapperNodeID := NewOpcuaNodeWrapper(input.Client.Node(parsedNodeIDs[0]))
-			go Browse(ctx, wrapperNodeID, "", 0, input.Log, parsedNodeIDs[0].String(), nodeChan, errChan, &wg, opcuaBrowserChan, &visited)
+			go Browse(ctx, wrapperNodeID, "", input.Log, parsedNodeIDs[0].String(), nodeChan, errChan, &wg, opcuaBrowserChan, &visited)
 
 			wg.Wait()
 			close(nodeChan)

--- a/opcua_plugin/opcua_unittest_test.go
+++ b/opcua_plugin/opcua_unittest_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNodeWithNilNodeClass
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
+					Browse(ctx, nodeBrowser, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -130,7 +130,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
+					Browse(ctx, nodeBrowser, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -168,7 +168,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
+					Browse(ctx, nodeBrowser, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -208,7 +208,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
+					Browse(ctx, nodeBrowser, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -248,7 +248,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
+					Browse(ctx, nodeBrowser, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -291,7 +291,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = rootNode
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
+					Browse(ctx, nodeBrowser, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -367,7 +367,7 @@ var _ = Describe("Unit Tests", func() {
 				nodeBrowser = abcFolder
 				wg.Add(1)
 				go func() {
-					Browse(ctx, nodeBrowser, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
+					Browse(ctx, nodeBrowser, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, &visited)
 				}()
 				wg.Wait()
 				close(nodeChan)
@@ -692,7 +692,7 @@ var _ NodeBrowser = &MockOpcuaNodeWraper{}
 func startBrowsing(ctx context.Context, rootNode NodeBrowser, path string, level int, logger Logger, parentNodeId string, nodeChan chan NodeDef, errChan chan error, wg *TrackedWaitGroup, opcuaBrowserChan chan NodeDef, visited *sync.Map) ([]NodeDef, []error) {
 	wg.Add(1)
 	go func() {
-		Browse(ctx, rootNode, path, level, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, visited)
+		Browse(ctx, rootNode, path, logger, parentNodeId, nodeChan, errChan, wg, opcuaBrowserChan, visited)
 	}()
 	wg.Wait()
 	close(nodeChan)

--- a/opcua_plugin/server_info.go
+++ b/opcua_plugin/server_info.go
@@ -37,9 +37,9 @@ func (g *OPCUAInput) GetOPCUAServerInformation(ctx context.Context) (ServerInfo,
 	var wg TrackedWaitGroup
 
 	wg.Add(3)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", 0, g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", 0, g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
-	go browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", 0, g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
+	go Browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(manufacturerNameNodeID)), "", g.Log, manufacturerNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
+	go Browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(productNameNodeID)), "", g.Log, productNameNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
+	go Browse(ctx, NewOpcuaNodeWrapper(g.Client.Node(softwareVersionNodeID)), "", g.Log, softwareVersionNodeID.String(), nodeChan, errChan, &wg, opcuaBrowserChan, &g.visited)
 	wg.Wait()
 
 	close(nodeChan)


### PR DESCRIPTION
## Description 

### Benchmark results for the old recursive approach

![image](https://github.com/user-attachments/assets/fbfff449-e50d-4759-bf90-dd056be88d5e)


### Benchmark results for the new worker pattern 

![image](https://github.com/user-attachments/assets/8073bf2d-7bbe-4d44-8454-9d68748d4ea3)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Implemented a worker pool pattern for node processing.
	- Removed `level` parameter from the `Browse` function.
	- Introduced a new `NodeTask` type for better node management.
	- Added `ServerMetrics` struct for monitoring OPCUA server performance.

- **Bug Fixes**
	- Improved concurrency and error handling in node browsing.
	- Enhanced node processing efficiency.

- **Chores**
	- Updated function signatures across multiple files.
	- Renamed `browse` function to `Browse` for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->