### PR TITLE
[ENG-2320] Use Unique artifact names while uploading and downloading binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,7 +319,7 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: binaries
+          name: artifact-${{ github.run_id }}-${{ github.run_attempt }}
           path: ./artifacts
 
       - name: Create or Update Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -305,7 +305,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: artifact-${{ github.run_id }}-${{ github.run_attempt }}
           path: ./dist/${{ env.OUTPUT_NAME }}
 
   release:


### PR DESCRIPTION
## Description 

Recently the actions/download-artifact@v4 is used the workflow files and this comes with a breaking change in the github actions with the following error 
```
Run actions/upload-artifact@v4
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```
Please refer https://github.com/simonw/shot-scraper/issues/141 for more context 

The PR sets unique names to the binaries built

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved deployment pipeline by updating artifact naming conventions to include unique, dynamic identifiers. This enhancement boosts traceability and clarity during build and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->