### PR TITLE
[ENG-2320] Use go-arch in  artifact names while uploading  binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ name: main
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
       - v*
 env:
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        architecture: ['amd64', 'arm64', 'arm/v7']
+        architecture: ["amd64", "arm64", "arm/v7"]
     runs-on:
       group: ${{ matrix.architecture == 'arm64' && 'arc-runners-small' || matrix.architecture == 'arm/v7' && 'arc-runners-small' || 'arc-runners-build' }}
     outputs:
@@ -305,7 +305,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-${{ github.run_id }}-${{ github.run_attempt }}
+          name: artifact-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ./dist/${{ env.OUTPUT_NAME }}
 
   release:
@@ -319,14 +319,14 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: artifact-${{ github.run_id }}-${{ github.run_attempt }}
+          pattern: "artifact-*-${{ github.run_id }}-${{ github.run_attempt }}"
           path: ./artifacts
 
       - name: Create or Update Release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ github.ref_name }}
-          artifacts: './artifacts/*'
+          artifacts: "./artifacts/*"
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced artifact naming and matching in the release workflow for improved traceability.
  - Standardized configuration formats to ensure consistent and clear artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->