### PR TITLE
[ENG-2320] Handle directories while uploading aritifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -326,7 +326,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ github.ref_name }}
-          artifacts: "./artifacts/*"
+          artifacts: "./artifacts/artifact-*-${{ github.run_id }}-${{ github.run_attempt }}/*"
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}


### PR DESCRIPTION
Lets fix this warning

<img width="1477" alt="image" src="https://github.com/user-attachments/assets/65509aa9-2e8d-40a2-88e9-71b2a3855538" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the release automation configuration to selectively include intended build outputs. This change streamlines the deployment process by ensuring only specifically named artifacts are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->