### PR TITLE
[ENG-2546] Improve opuca worker counts

### DIFF
--- a/opcua_plugin/browse_workers.go
+++ b/opcua_plugin/browse_workers.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	MaxWorkers     = 200
+	MaxWorkers     = 500
 	MinWorkers     = 5
 	InitialWorkers = 25
 	SampleSize     = 5 // Number of requests to measure response time

--- a/opcua_plugin/browse_workers.go
+++ b/opcua_plugin/browse_workers.go
@@ -10,9 +10,9 @@ import (
 const (
 	MaxWorkers     = 200
 	MinWorkers     = 5
-	InitialWorkers = 10
-	SampleSize     = 5 // Number of requsts to measure response time
-	TargetLatency  = 250 * time.Millisecond
+	InitialWorkers = 25
+	SampleSize     = 5 // Number of requests to measure response time
+	TargetLatency  = 500 * time.Millisecond
 )
 
 // ServerMetrics is a struct that holds the metrics for the OPCUA server requests
@@ -83,13 +83,13 @@ func (sm *ServerMetrics) adjustWorkers(logger Logger) (toAdd, toRemove int) {
 
 	if avgResponse > sm.targetLatency {
 		// Response time is too high. Reduce workers
-		sm.currentWorkers = max(MinWorkers, sm.currentWorkers-10)
+		sm.currentWorkers = max(MinWorkers, sm.currentWorkers-20)
 		logger.Debugf("Response time is high (%v > %v target Latency), reducing workers from %d to %d", avgResponse, sm.targetLatency, oldWorkerCount, sm.currentWorkers)
 	}
 
 	if avgResponse < sm.targetLatency {
 		// Response time is too low. Increase workers
-		sm.currentWorkers = min(MaxWorkers, sm.currentWorkers+10)
+		sm.currentWorkers = min(MaxWorkers, sm.currentWorkers+20)
 		logger.Debugf("Response time is low (%v < %v target Latency), increasing workers from %d to %d", avgResponse, sm.targetLatency, oldWorkerCount, sm.currentWorkers)
 	}
 


### PR DESCRIPTION
# OPC UA Plugin Performance Optimization

## Summary
This PR adjusts several key parameters in the OPC UA plugin's worker management system to optimize performance and throughput.

## Changes Made
- Increased maximum concurrent workers from 200 to 500
- Increased initial worker count from 10 to 25
- Extended target latency from 250ms to 500ms to allow more time for operations
- Adjusted worker scaling algorithm:
  - Now adds/removes 20 workers at a time (previously 10) for faster adaptation
- Fixed a typo in a comment ("requsts" → "requests")

## Motivation
These changes aim to improve the plugin's performance when dealing with OPC UA servers, particularly in environments with high latency or many concurrent operations. The higher initial worker count allows for faster startup performance, while the more aggressive scaling enables better adaptation to changing server conditions.

## Impact
These changes modify performance tuning parameters only and don't affect the functional behavior of the plugin. Users should experience better performance with OPC UA connections, particularly in high-load scenarios.
