### PR TITLE
[ENG-2586] Add User Certificate Based Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,26 @@ input:
     password: 'your-password'
 ```
 
+#### User Certificate and Private Key
+  - **Keys**: `userCertificate`, `userPrivateKey`
+  - **Description**: Credentials for User certificate-based authentication.
+  - `userCertificate`: Base64-encoded certificate in either PEM (.pem) or DER (.der) format.
+  - `userPrivateKey`: Base64-encoded private key in PEM (.pem) format only.
+  - Certificate-based authentication provides stronger security than username/password for high-security environments.
+  - Proper protection of the private key and certificate validation on both client and server are essential.
+  - **Configuration Example**:
+
+```yaml
+input:
+  opcua:
+    endpoint: 'opc.tcp://localhost:46010'
+    nodeIDs: ['ns=2;s=IoTSensors']
+    securityMode: SignAndEncrypt
+    securityPolicy: Basic256Sha256
+    userCertificate: 'base64-encoded certificate (.pem or .der)'
+    userPrivateKey: 'base64-encoded private key (.pem only)'
+```
+
 ##### Security Options
 
 > To ensure a fully secure connection, you must explicitly configure all of the following security options. However, if these settings seem overwhelming, you can leave them unspecified. In that case, **benthos-umh** will automatically scan for and connect to available endpoints until it succeeds—and then it will log the recommended security settings for your future configuration.
@@ -220,24 +240,6 @@ input:
     clientCertificate: 'your-fixed-base64-encoded-certificate' # optional but recommended
 ```
 
-- **User Certificate and Private Key**:
-  - **Keys**: `userCertificate`, `userPrivateKey`
-  - **Description**: Base64-encoded PEM certificate and private key for user authentication.
-  - When using certificate-based authentication, you must provide both a user certificate and its corresponding private key. These credentials should be provided as Base64-encoded PEM files.
-  - This approach offers stronger security than username/password authentication for scenarios requiring elevated security standards.
-  - For secure operation, ensure the private key is properly protected and that certificate validation is enabled on both client and server sides.
-  - **Configuration Example**:
-
-```yaml
-input:
-  opcua:
-    endpoint: 'opc.tcp://localhost:46010'
-    nodeIDs: ['ns=2;s=IoTSensors']
-    securityMode: SignAndEncrypt
-    securityPolicy: Basic256Sha256
-    userCertificate: 'base64-encoded-user-PEM-certificate'
-    userPrivateKey: 'base64-encoded-user-PEM-private-key'
-```
 
 ##### Insecure Mode
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ input:
     securityPolicy: None | Basic128Rsa15 | Basic256 | Basic256Sha256  # optional (default: unset)
     serverCertificateFingerprint: 'sha3-fingerprint-of-cert' # optional (default: unset)
     clientCertificate: 'your-fixed-base64-encoded-certificate' # optional (default: unset)
+    userCertificate: 'base64-encoded-user-PEM-certificate' # optional (default: unset)
+    userPrivateKey: 'base64-encoded-user-PEM-private-key' # optional (default: unset)
     subscribeEnabled: false | true # optional (default: false)
     useHeartbeat: false | true # optional (default: false)
     pollRate: 1000 # optional (default: 1000) The rate in milliseconds at which to poll the OPC UA server when not using subscriptions
@@ -218,6 +220,25 @@ input:
     clientCertificate: 'your-fixed-base64-encoded-certificate' # optional but recommended
 ```
 
+- **User Certificate and Private Key**:
+  - **Keys**: `userCertificate`, `userPrivateKey`
+  - **Description**: Base64-encoded PEM certificate and private key for user authentication.
+  - When using certificate-based authentication, you must provide both a user certificate and its corresponding private key. These credentials should be provided as Base64-encoded PEM files.
+  - This approach offers stronger security than username/password authentication for scenarios requiring elevated security standards.
+  - For secure operation, ensure the private key is properly protected and that certificate validation is enabled on both client and server sides.
+  - **Configuration Example**:
+
+```yaml
+input:
+  opcua:
+    endpoint: 'opc.tcp://localhost:46010'
+    nodeIDs: ['ns=2;s=IoTSensors']
+    securityMode: SignAndEncrypt
+    securityPolicy: Basic256Sha256
+    userCertificate: 'base64-encoded-user-PEM-certificate'
+    userPrivateKey: 'base64-encoded-user-PEM-private-key'
+```
+
 ##### Insecure Mode
 
 This is now deprecated. By default, benthos-umh will now connect via SignAndEncrypt and Basic256Sha256 and if this fails it will fall back to insecure mode.
@@ -299,7 +320,7 @@ OPC UA Output
 
 The **OPC UA output** plugin writes data into an OPC UA server (e.g., a PLC). This plugin supports optional read-back (handshake) to confirm the write.
 
-> **Data Transformations**  
+> **Data Transformations**
 > It is recommended to perform JSON-to-field transformations _before_ this plugin (e.g., via [Node-RED JavaScript](#node-red-javascript-processor) or [Bloblang](https://www.benthos.dev/docs/guides/bloblang/about)). That way, you feed the final fields directly to this plugin without extra logic here.
 
 ---
@@ -407,7 +428,7 @@ If, for example, the `ns=2;s=MyEnableFlag` node is read-only or the server rejec
 
 By default, the plugin **reads back** each node it wrote to confirm the new value appears. This ensures:
 
-1. **Benthos Message ACK**: If the read-back fails or times out, the output plugin fails. Benthos will _not_ acknowledge the message upstream, and you can configure fallback or retry strategies.  
+1. **Benthos Message ACK**: If the read-back fails or times out, the output plugin fails. Benthos will _not_ acknowledge the message upstream, and you can configure fallback or retry strategies.
 2. **Consistent Setpoints**: If the OPC UA server discards or modifies the value, you’ll see an immediate error.
 
 > **Disable** the handshake by setting `handshake.enabled: false` if you prefer no read-back check (faster, but less safe).
@@ -425,16 +446,16 @@ The plugin will write to the OPC UA server but **not** confirm. It will “succe
 
 For many industrial use cases, you might need more than just writing a value and reading it back:
 
-1. **De-duplication**: If you re-send the same “command” multiple times, do you want the PLC to ignore duplicates?  
-   - *Now*: Implement a unique command ID (UUID) in your message and let the PLC store/ignore duplicates. Or handle it in your Benthos pipeline (e.g., a “dedupe” processor).  
+1. **De-duplication**: If you re-send the same “command” multiple times, do you want the PLC to ignore duplicates?
+   - *Now*: Implement a unique command ID (UUID) in your message and let the PLC store/ignore duplicates. Or handle it in your Benthos pipeline (e.g., a “dedupe” processor).
    - *Future*: We may add a built-in “ActionUUID” handshake, which compares a known ID in another read node.
 
-2. **Time-Window Checks**: Only accept a command if it arrives before a certain expiration.  
-   - *Now*: Use a preceding [nodered_js processor](#node-red-javascript-processor) or Bloblang to drop the message if `timestamp_now - msg.timestamp > threshold`.  
+2. **Time-Window Checks**: Only accept a command if it arrives before a certain expiration.
+   - *Now*: Use a preceding [nodered_js processor](#node-red-javascript-processor) or Bloblang to drop the message if `timestamp_now - msg.timestamp > threshold`.
    - *Future*: We might add plugin-level config like `rejectOlderThanMs` if demand arises.
 
-3. **Separate Acknowledgment Node**: Some PLCs use a separate ack node (e.g., `CommandAck`) that signals the command was _processed_.  
-   - *Now*: Implement in the PLC + a custom “double read” with a second plugin instance (or a separate input that waits for the ack).  
+3. **Separate Acknowledgment Node**: Some PLCs use a separate ack node (e.g., `CommandAck`) that signals the command was _processed_.
+   - *Now*: Implement in the PLC + a custom “double read” with a second plugin instance (or a separate input that waits for the ack).
    - *Future*: We may add an advanced handshake config that reads a different node (rather than the same node) and checks for a specific “ACK” value.
 
 With Benthos, the “at least once” acknowledgment ensures that if writing fails, the message can be retried or routed. This plugin’s minimal default handshake (read-back from the same node) is a strong start for safer OPC UA setpoints, and we’ll grow it over time if more advanced scenarios are needed.

--- a/opcua_plugin/core_authentication.go
+++ b/opcua_plugin/core_authentication.go
@@ -142,6 +142,8 @@ func (g *OPCUAConnection) getEndpointIfExists(
 func (g *OPCUAConnection) getUserAuthenticationType() ua.UserTokenType {
 	// Here we can add UserTokenTypeCertificate and UserTokenTypeIssuedToken later
 	switch {
+	case g.UserPrivateKey != "" && g.UserCertificate != "":
+		return ua.UserTokenTypeCertificate
 	case g.Username != "" && g.Password != "":
 		return ua.UserTokenTypeUserName
 	default:

--- a/opcua_plugin/core_connect.go
+++ b/opcua_plugin/core_connect.go
@@ -214,8 +214,6 @@ func (g *OPCUAConnection) parseUserCertificateOptions() ([]opcua.Option, error) 
 	}
 
 	return []opcua.Option{
-		opcua.SecurityPolicy(ua.SecurityPolicyURIBasic256Sha256),
-		opcua.SecurityMode(ua.MessageSecurityModeSignAndEncrypt),
 		opcua.AuthCertificate(cert.Raw),
 		opcua.AuthPrivateKey(privateKey),
 	}, nil

--- a/opcua_plugin/core_connection.go
+++ b/opcua_plugin/core_connection.go
@@ -48,11 +48,11 @@ var OPCUAConnectionConfigSpec = service.NewConfigSpec().
 		Default("").
 		Advanced()).
 	Field(service.NewStringField("userCertificate").
-		Description("User certificate in base64 PEM encoded format for certificate based authentication.").
+		Description("User certificate in base64 encoded format of either PEM or DER.").
 		Default("").
 		Advanced()).
 	Field(service.NewStringField("userPrivateKey").
-		Description("User private key in base64 PEM encoded format for certificate based authentication.").
+		Description("User private key in base64 format of PEM for user certificate based authentication.").
 		Default("").
 		Advanced()).
 	Field(service.NewBoolField("insecure").

--- a/opcua_plugin/core_connection.go
+++ b/opcua_plugin/core_connection.go
@@ -47,6 +47,14 @@ var OPCUAConnectionConfigSpec = service.NewConfigSpec().
 		Description("The server certificate fingerprint to verify, SHA3-512 hash.").
 		Default("").
 		Advanced()).
+	Field(service.NewStringField("userCertificate").
+		Description("User certificate in base64 PEM encoded format for certificate based authentication.").
+		Default("").
+		Advanced()).
+	Field(service.NewStringField("userPrivateKey").
+		Description("User private key in base64 PEM encoded format for certificate based authentication.").
+		Default("").
+		Advanced()).
 	Field(service.NewBoolField("insecure").
 		Description("Set to true to bypass secure connections, useful in case of SSL or certificate issues. Default is secure (false).").
 		Default(false).
@@ -72,6 +80,8 @@ type OPCUAConnection struct {
 	SecurityMode                 string
 	SecurityPolicy               string
 	ClientCertificate            string
+	UserCertificate              string
+	UserPrivateKey               string
 	ServerCertificateFingerprint string
 	Insecure                     bool
 	DirectConnect                bool
@@ -117,6 +127,13 @@ func ParseConnectionConfig(conf *service.ParsedConfig, mgr *service.Resources) (
 	if conn.ClientCertificate, err = conf.FieldString("clientCertificate"); err != nil {
 		return nil, err
 	}
+	if conn.UserCertificate, err = conf.FieldString("userCertificate"); err != nil {
+		return nil, err
+	}
+	if conn.UserPrivateKey, err = conf.FieldString("userPrivateKey"); err != nil {
+		return nil, err
+	}
+
 	if conn.ServerCertificateFingerprint, err = conf.FieldString("serverCertificateFingerprint"); err != nil {
 		return nil, err
 	}

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -44,13 +44,7 @@ var OPCUAConfigSpec = OPCUAConnectionConfigSpec.
 		Default(false)).
 	Field(service.NewIntField("pollRate").
 		Description("The rate in milliseconds at which to poll the OPC UA server when not using subscriptions. Defaults to 1000ms (1 second).").
-		Default(DefaultPollRate)).
-	Field(service.NewStringField("clientCertificate").
-		Description("Client certificate in base64 encoded format for certificate authentication.").
-		Default("")).
-	Field(service.NewStringField("clientPrivateKey").
-		Description("Client private key in base64 encoded format for certificate authentication.").
-		Default(""))
+		Default(DefaultPollRate))
 
 func ParseNodeIDs(incomingNodes []string) []*ua.NodeID {
 
@@ -153,8 +147,6 @@ type OPCUAInput struct {
 	Subscription                 *opcua.Subscription
 	ServerInfo                   ServerInfo
 	PollRate                     int
-	ClientCertificate            string
-	ClientPrivateKey             string
 }
 
 // unsubscribeAndResetHeartbeat unsubscribes from the OPC UA subscription and resets the heartbeat

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -44,7 +44,13 @@ var OPCUAConfigSpec = OPCUAConnectionConfigSpec.
 		Default(false)).
 	Field(service.NewIntField("pollRate").
 		Description("The rate in milliseconds at which to poll the OPC UA server when not using subscriptions. Defaults to 1000ms (1 second).").
-		Default(DefaultPollRate))
+		Default(DefaultPollRate)).
+	Field(service.NewStringField("clientCertificate").
+		Description("Client certificate in base64 encoded format for certificate authentication.").
+		Default("")).
+	Field(service.NewStringField("clientPrivateKey").
+		Description("Client private key in base64 encoded format for certificate authentication.").
+		Default(""))
 
 func ParseNodeIDs(incomingNodes []string) []*ua.NodeID {
 
@@ -147,6 +153,8 @@ type OPCUAInput struct {
 	Subscription                 *opcua.Subscription
 	ServerInfo                   ServerInfo
 	PollRate                     int
+	ClientCertificate            string
+	ClientPrivateKey             string
 }
 
 // unsubscribeAndResetHeartbeat unsubscribes from the OPC UA subscription and resets the heartbeat


### PR DESCRIPTION
## Description

Adds User certificate based authentication for opcua plugin type. OPCUA input supports two new fields called userCertificate and userPrivateKey which are base64 string of PEM files. 

## Sample config 
```
input:
  opcua:
    endpoint: opc.tcp://10.13.37.102:4998
    userPrivateKey: |   LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBMktxWlJweC9mK0k2SWY0ZkxnMi82TlY2bUW5Tc25QNmdjSVdHWER2dWVtV3ZCcVZEMzQxbmQvenRYOHc9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
    userCertificate: |
      LS0tLS1CRUdJTiBDRVJU==
    subscribeEnabled: true
    nodeIDs:
      - i=84
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced certificate-based authentication for OPC UA connections to enhance secure login.
	- Extended configuration settings now allow users to securely input certificate and private key data in a base64 PEM encoded format.
	- Improved error handling ensures that issues during certificate processing are managed reliably.
	- Updated documentation includes new configuration parameters for user certificate and private key, along with usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->