### PR TITLE
ENG-2738: s7comm reading strings returns wrong data

### DIFF
--- a/s7comm_plugin/s7comm.go
+++ b/s7comm_plugin/s7comm.go
@@ -263,8 +263,6 @@ func (g *S7CommInput) ReadBatch(ctx context.Context) (service.MessageBatch, serv
 		}
 
 		// Read the data from the batch and convert it using the converter function
-		buffer := make([]byte, 0)
-
 		for _, item := range b {
 			// Execute the converter function to get the converted data
 			convertedData := item.ConverterFunc(item.Item.Data)
@@ -276,13 +274,10 @@ func (g *S7CommInput) ReadBatch(ctx context.Context) (service.MessageBatch, serv
 			// Convert the string representation to a []byte
 			dataAsBytes := []byte(dataAsString)
 
-			// Append the converted data as bytes to the buffer
-			buffer = append(buffer, dataAsBytes...)
-
 			// Create a new message with the current state of the buffer
 			// Note: Depending on your requirements, you may want to reset the buffer
 			// after creating each message or keep accumulating data in it.
-			msg := service.NewMessage(buffer)
+			msg := service.NewMessage(dataAsBytes)
 			msg.MetaSet("s7_address", item.Address)
 
 			// Append the new message to the msgs slice


### PR DESCRIPTION
- i experienced that e.g. reading a string returned the previous buffers data
- this happens because the `buffer` was appended for each message instead of creating a message and appending the `messageBatch`
- therefore the values wore wrong for every item than the first one (as you can see in the ticket)

previously:

![image](https://github.com/user-attachments/assets/c0161ad7-4529-4b91-843e-93971c8254bc)


now:

![image](https://github.com/user-attachments/assets/49fedea5-03cc-41af-916e-5d8e051f3c2b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for converting and generating messages from batched data, eliminating unnecessary intermediate steps for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->