### PR TITLE
ENG-2739: no nodes detected after reconnect/connection failure

### DIFF
--- a/opcua_plugin/core_browse.go
+++ b/opcua_plugin/core_browse.go
@@ -15,7 +15,9 @@ import (
 
 const (
 	MaxTagsToBrowse = 100_000
-	StaleAfter      = 15 * time.Minute
+	// StaleTime is used to define whether a node that was discovered is marked
+	// as stale to rediscover -> if maybe an attribute changed from the previous run
+	StaleTime = 15 * time.Minute
 )
 
 type NodeDef struct {
@@ -202,7 +204,7 @@ func worker(
 					vni = VisitedNodeInfo{}
 				}
 				// to skip nodes that are already FullyDiscovered and fresh
-				if vni.FullyDiscovered && time.Since(vni.LastSeen) < StaleAfter {
+				if vni.FullyDiscovered && time.Since(vni.LastSeen) < StaleTime {
 					logger.Debugf("Worker %s: node %s is fully discovered and fresh, skipping..", id, task.node.ID().String)
 					taskWg.Done()
 					continue

--- a/opcua_plugin/core_browse.go
+++ b/opcua_plugin/core_browse.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	MaxTagsToBrowse = 100_000
+	StaleAfter      = 15 * time.Minute
 )
 
 type NodeDef struct {
@@ -170,7 +171,6 @@ func worker(
 	metrics *ServerMetrics,
 	stopChan chan struct{},
 ) {
-	const StaleAfter = 15 * time.Minute
 
 	defer workerWg.Done()
 	for {

--- a/opcua_plugin/read_discover.go
+++ b/opcua_plugin/read_discover.go
@@ -316,7 +316,10 @@ func (g *OPCUAInput) canSkipDiscovery() bool {
 		if !found {
 			return false
 		}
-		vni := val.(VisitedNodeInfo)
+		vni, ok := val.(VisitedNodeInfo)
+		if !ok {
+			return false
+		}
 		if !vni.FullyDiscovered || time.Since(vni.LastSeen) > StaleTime {
 			return false
 		}

--- a/opcua_plugin/read_discover.go
+++ b/opcua_plugin/read_discover.go
@@ -97,12 +97,21 @@ func (g *OPCUAInput) discoverNodes(ctx context.Context) ([]NodeDef, map[string]s
 // 1. **Browse Nodes:** Iterates through `NodeIDs` and concurrently browses each node to detect available nodes.
 // 2. **Add Heartbeat Node:** If heartbeats are enabled, ensures the heartbeat node (`HeartbeatNodeId`) is included in the node list.
 // 3. **Subscribe to Nodes:** If subscriptions are enabled, creates a subscription and sets up monitoring for the detected nodes.
-func (g *OPCUAInput) BrowseAndSubscribeIfNeeded(ctx context.Context) error {
+func (g *OPCUAInput) BrowseAndSubscribeIfNeeded(ctx context.Context) (err error) {
+	var nodeList []NodeDef
 
-	nodeList, _, err := g.discoverNodes(ctx)
-	if err != nil {
-		g.Log.Infof("error while getting the node list: %v", err)
-		return err
+	// if all nodeIDs are fresh and fully discovered we can avoid spawning any
+	// goroutines here
+	if g.canSkipDiscovery() {
+		g.Log.Infof("All requested nodes are fresh, skipping rebrowse. Using chaced nodelist")
+		nodeList = g.buildNodeListFromCache()
+	} else {
+		nodeList, _, err = g.discoverNodes(ctx)
+		if err != nil {
+			g.Log.Infof("error while getting the node list: %v", err)
+			return err
+		}
+
 	}
 
 	// Now add i=2258 to the nodeList, which is the CurrentTime node, which is used for heartbeats
@@ -282,4 +291,35 @@ func UpdateNodePaths(nodes []NodeDef) {
 			}
 		}
 	}
+}
+
+// buildNodeListFromCache enumerates the visited map
+// and returns a slice of NodeDef from all cached nodes.
+func (g *OPCUAInput) buildNodeListFromCache() []NodeDef {
+	var nodeList []NodeDef
+	g.visited.Range(func(k, v any) bool {
+		vni, ok := v.(VisitedNodeInfo)
+		if !ok {
+			return true
+		}
+		// skip incomplete nodes, or include them anyway:
+		// if !vni.FullyDiscovered { ... }
+		nodeList = append(nodeList, vni.Def)
+		return true
+	})
+	return nodeList
+}
+
+func (g *OPCUAInput) canSkipDiscovery() bool {
+	for _, nodeID := range g.NodeIDs {
+		val, found := g.visited.Load(nodeID)
+		if !found {
+			return false
+		}
+		vni := val.(VisitedNodeInfo)
+		if !vni.FullyDiscovered || time.Since(vni.LastSeen) > 15*time.Minute {
+			return false
+		}
+	}
+	return true
 }

--- a/opcua_plugin/read_discover.go
+++ b/opcua_plugin/read_discover.go
@@ -317,7 +317,7 @@ func (g *OPCUAInput) canSkipDiscovery() bool {
 			return false
 		}
 		vni := val.(VisitedNodeInfo)
-		if !vni.FullyDiscovered || time.Since(vni.LastSeen) > 15*time.Minute {
+		if !vni.FullyDiscovered || time.Since(vni.LastSeen) > StaleAfter {
 			return false
 		}
 	}

--- a/opcua_plugin/read_discover.go
+++ b/opcua_plugin/read_discover.go
@@ -317,7 +317,7 @@ func (g *OPCUAInput) canSkipDiscovery() bool {
 			return false
 		}
 		vni := val.(VisitedNodeInfo)
-		if !vni.FullyDiscovered || time.Since(vni.LastSeen) > StaleAfter {
+		if !vni.FullyDiscovered || time.Since(vni.LastSeen) > StaleTime {
 			return false
 		}
 	}


### PR DESCRIPTION
- this should resolve the bug described in the linear issue
-> whenever you reconnect it previously didn't detect any nodes therefore it was simply stuck at this point
-> now it should reuse the previously stored nodes and `nodeDef` and check if it was `FullyDiscovered` and in a certain time period

- tested with opcsimv2 (since it was the only reliable source, which fails continuously) and worked 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved node discovery efficiency through enhanced tracking and caching mechanisms.
	- Streamlined processing now skips redundant operations for nodes that remain up-to-date, delivering a more responsive experience for users.
	- Introduced a mechanism to manage node freshness and discovery status, enhancing overall control flow.
	- Added a new constant for stale time management in node discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->