### PR TITLE
Cleanup: Remove qemu from build-binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -252,11 +252,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request && github.head_ref || github.ref_name }}
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: management.umh.app/oci/tonistiigi/binfmt:latest
-
       - name: Set up Build Environment
         run: |
           echo "GOOS=${{ matrix.goos }}" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,6 @@ jobs:
           done
 
           # Define architectures
-          #ARCHITECTURES=("amd64" "arm64" "arm/v7")
           ARCHITECTURES=("amd64" "arm64")
           # Create manifests for each base tag
           for TAG in "${TAG_ARRAY[@]}"; do


### PR DESCRIPTION
this one slipped through my fingers, it's not needed in the `build-binaries` job since it's only needed for `docker-buildx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined our automated build process by refining environment setup. The system now supports the primary architectures, contributing to a more efficient and reliable build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->