### PR TITLE
[ENG-2911] Fix the default topic name for uns plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2001,6 +2001,67 @@ This is not yet implemented and currently not set to a specific timeline, but wi
 
 </details>
 
+<details>
+<summary>
+UNS (Unified Namespace System)
+</summary>
+
+### UNS (Output)
+
+The UNS output plugin is a specialized output for the United Manufacturing Hub's Unified Namespace System. It acts as a wrapper around Redpanda (a Kafka-compatible message broker) that simplifies interaction with the UNS for OT technicians by handling many implementation details automatically.
+
+With this plugin, users only need to set the topic according to the UMH data model (https://umh.docs.umh.app/docs/datacontracts/), and it will automatically store the data in Redpanda for buffering, making it easy to publish data to the Unified Namespace.
+
+#### Configuration Options
+
+```yaml
+output:
+  uns:
+    topic: "${! meta(\"topic\") }"   # Optional (default: ${! meta("topic") }): The topic key for routing messages in the UMH ecosystem
+    broker_address: "localhost:9092"  # Optional: Kafka broker address (default: localhost:9092)
+    bridged_by: "protocol-converter-name"  # Required: Name of the bridge doing the data bridging
+```
+
+#### Configuration Parameters
+
+- **topic**: The topic key used for routing messages in the UMH ecosystem. This key becomes the Kafka message key and should follow the UMH naming convention: `umh.v1.enterprise.site.area.tag` (e.g., 'umh.v1.acme.berlin.assembly.temperature'). Supports interpolation, allowing you to set the key dynamically based on message content or metadata. Optional, defaults to `${! meta("topic") }`.
+
+- **broker_address**: The Kafka broker address to connect to (default: "localhost:9092"). This can be a single address or multiple addresses separated by commas.
+
+- **bridged_by**: (Required) The name of the bridge that does the bridging of the data. The format should be 'protocol-converter-{nodeName}-{protocol converter name}', for example "protocol-converter-plc-opcua".
+
+#### Example
+
+The following example demonstrates using the UNS output to send messages to the UMH Unified Namespace:
+
+```yaml
+pipeline:
+  processors:
+    - bloblang: |
+        # Prepare a proper topic following the UMH data model
+        meta topic = "umh.v1.enterprise.site.area._historian.temperature"
+        root = {
+          "temperature": this.value,
+          "timestamp_ms": timestamp_unix_nano() / 1000000
+        }
+
+output:
+  uns:
+    topic: "${! meta(\"topic\") }"
+    broker_address: "localhost:9092"
+    bridged_by: "protocol-converter-plc-opcua"
+```
+
+#### Notes
+
+- The UNS output always writes to a single default topic (`umh.messages`) in the Kafka broker, with the `topic` configuration parameter becoming the message key for proper routing.
+- **IMPORTANT**: Messages must contain the `topic` metadata field (accessible via `meta("topic")`) for the plugin to work correctly. If this field is missing or empty, the plugin will stop processing messages.
+- Messages are automatically validated and sanitized to ensure they follow UMH's requirements.
+- The plugin automatically handles Kafka connection details, topic creation, and metadata management.
+- All messages are sent with the `bridged_by` metadata field to indicate the source of the message.
+
+</details>
+
 ## Testing
 
 We execute automated tests and verify that benthos-umh works against various targets. All tests are started with `make test`, but might require environment parameters in order to not be skipped.

--- a/README.md
+++ b/README.md
@@ -2010,7 +2010,7 @@ UNS (Unified Namespace System)
 
 The UNS output plugin is a specialized output for the United Manufacturing Hub's Unified Namespace System. It acts as a wrapper around Redpanda (a Kafka-compatible message broker) that simplifies interaction with the UNS for OT technicians by handling many implementation details automatically.
 
-With this plugin, users only need to set the topic according to the UMH data model (https://umh.docs.umh.app/docs/datacontracts/), and it will automatically store the data in Redpanda for buffering, making it easy to publish data to the Unified Namespace.
+With this plugin, users only need to set the topic according to the [UMH data model](https://umh.docs.umh.app/docs/datacontracts/), and it will automatically store the data in Redpanda for buffering, making it easy to publish data to the Unified Namespace.
 
 #### Configuration Options
 

--- a/uns_plugin/uns_output.go
+++ b/uns_plugin/uns_output.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 const (
-	defaultOutputTopic               = "umh.v2.messages" // by the current state, the output topic must not be changed for this plugin
+	defaultOutputTopic               = "umh.messages" // by the current state, the output topic must not be changed for this plugin
 	defaultOutputTopicPartitionCount = 1
 	defaultBrokerAddress             = "localhost:9092"
 	defaultClientID                  = "umh_core"
@@ -48,7 +48,7 @@ The uns_plugin output sends messages to the United Manufacturing Hub's Kafka mes
 This output is optimized for communication with UMH core components and handles the complexities
 of Kafka configuration for you.
 
-All messages are written to a single topic (umh.v2.messages), with the key of each message
+All messages are written to a single topic (umh.messages), with the key of each message
 derived from the 'messageKey' field specified in this configuration. This key is crucial for
 proper routing within the UMH ecosystem.
 
@@ -62,20 +62,20 @@ Note: This output implements batch writing to Kafka for improved performance.`).
 Key used when sending messages to the UMH output topic. This value becomes the Kafka message key,
 which determines how messages are routed within the UMH ecosystem.
 
-The message_key should follow the UMH naming convention: enterprise.site.area.tag
-(e.g., 'acme.berlin.assembly.temperature')
+The message_key should follow the UMH naming convention: umh.v1.enterprise.site.area.tag
+(e.g., 'umh.v1.acme.berlin.assembly.temperature')
 
 This field supports interpolation, allowing you to set the key dynamically based on message
 content or metadata. Common patterns include:
 - Using metadata: ${! meta("topic") }
 - Using content: ${! json("device.location") }
-- Using a static value: enterprise.site.area.tag
+- Using a static value: umh.v1.enterprise.site.area.tag
 
 Note: The key will be sanitized to remove any characters that are not alphanumeric, dots,
 underscores, or hyphens. Invalid characters will be replaced with underscores.
             `).
 			Example("${! meta(\"topic\") }").
-			Example("enterprise.site.area.historian").
+			Example("umh.v1.enterprise.site.area.historian").
 			Default("${! meta(\"kafka_topic\") }")).
 		Field(service.NewStringField("broker_address").
 			Description(`

--- a/uns_plugin/uns_output_test.go
+++ b/uns_plugin/uns_output_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Initializing uns output plugin", func() {
 
 			It("should return an error regarding the partitionCount", func() {
 				err := outputPlugin.Connect(ctx)
-				Expect(err.Error()).To(BeEquivalentTo("default output topic 'umh.v2.messages' has a mismatched partition count: required 1, actual 15"))
+				Expect(err.Error()).To(BeEquivalentTo("default output topic 'umh.messages' has a mismatched partition count: required 1, actual 15"))
 			})
 		})
 	})
@@ -291,7 +291,7 @@ var _ = Describe("Initializing uns output plugin", func() {
 				var msgs service.MessageBatch
 				for range 10 {
 					msg := service.NewMessage(nil)
-					msg.MetaSet("kafka_topic", "umh.v2.messages")
+					msg.MetaSet("kafka_topic", "umh.v1.enterprise.messages")
 					msg.SetStructured(map[string]any{
 						"value": "mock message",
 					})

--- a/uns_plugin/uns_output_test.go
+++ b/uns_plugin/uns_output_test.go
@@ -146,8 +146,10 @@ var _ = Describe("Initializing uns output plugin", func() {
 			},
 		}
 
-		unsConf := unsConfig{}
-		messageKey, _ := service.NewInterpolatedString("${! meta(\"kafka_topic\") }")
+		unsConf := unsConfig{
+			bridgedBy: "default-test-bridge",
+		}
+		messageKey, _ := service.NewInterpolatedString("${! meta(\"topic\") }")
 		unsConf.messageKey = messageKey
 		outputPlugin = newUnsOutputWithClient(mockClient, unsConf, nil)
 		unsClient = outputPlugin.(*unsOutput)
@@ -250,7 +252,7 @@ var _ = Describe("Initializing uns output plugin", func() {
 				var msgs service.MessageBatch
 				for range 10 {
 					msg := service.NewMessage([]byte(`{"data": "test"}`))
-					msg.MetaSet("kafka_topic", "umh.v1.abc")
+					msg.MetaSet("topic", "umh.v1.abc")
 					msgs = append(msgs, msg)
 				}
 				err := outputPlugin.WriteBatch(ctx, msgs)
@@ -270,12 +272,12 @@ var _ = Describe("Initializing uns output plugin", func() {
 			})
 
 			It("should throw an error if the message does not have a topic key", Label("test"), func() {
-				// The meta key kafka_topic is not set
+				// The meta key topic is not set
 				msg := service.NewMessage([]byte(`{"data": "test"}`))
 				msgs := service.MessageBatch{msg}
 				err := outputPlugin.WriteBatch(ctx, msgs)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("message_key is not set or is empty in message 0, message_key is mandatory"))
+				Expect(err.Error()).To(ContainSubstring("topic is not set or is empty in message 0, topic is mandatory"))
 			})
 		})
 
@@ -291,7 +293,7 @@ var _ = Describe("Initializing uns output plugin", func() {
 				var msgs service.MessageBatch
 				for range 10 {
 					msg := service.NewMessage(nil)
-					msg.MetaSet("kafka_topic", "umh.v1.enterprise.messages")
+					msg.MetaSet("topic", "umh.v1.enterprise.messages")
 					msg.SetStructured(map[string]any{
 						"value": "mock message",
 					})


### PR DESCRIPTION

<img width="1465" alt="image" src="https://github.com/user-attachments/assets/33569252-0390-4b1d-8d1e-7b680841c5c8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed instructions and usage examples for the UNS output plugin, including configuration options and important operational notes.

- **New Features**
  - Introduced a new configuration field for specifying the bridge identifier, which is now included as a message header.

- **Refactor**
  - Renamed the main configuration field from "message_key" to "topic" to align with UMH naming conventions.
  - Updated the default output topic name to "umh.messages" and improved naming consistency throughout configuration and logs.

- **Tests**
  - Updated tests to reflect the new "topic" field, bridge identifier, and revised error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->