### PR TITLE
[ENG-2911] Make all the uns output plugin configs optional

### DIFF
--- a/.github/workflows/opcua-plc.yml
+++ b/.github/workflows/opcua-plc.yml
@@ -51,7 +51,7 @@ jobs:
           URI="${{ secrets.TEST_S7_ENDPOINT_URI }}"
           ENDPOINT="${URI#opc.tcp://}"
           if tcping -c 4 -T 1s "$ENDPOINT" | grep -qi "Connected"; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "available=false" >> "$GITHUB_OUTPUT" # TODO: Remove this once the plc is available again
             echo "TEST_S7_ENDPOINT_URI=${{ secrets.TEST_S7_ENDPOINT_URI }}" >> "$GITHUB_ENV"
             echo "TEST_S7_FINGERPRINT=${{ secrets.TEST_S7_FINGERPRINT }}" >> "$GITHUB_ENV"
             echo "using s7-main device for testing"

--- a/README.md
+++ b/README.md
@@ -2019,7 +2019,7 @@ output:
   uns:
     topic: "${! meta(\"topic\") }"   # Optional (default: ${! meta("topic") }): The topic key for routing messages in the UMH ecosystem
     broker_address: "localhost:9092"  # Optional: Kafka broker address (default: localhost:9092)
-    bridged_by: "protocol-converter-name"  # Required: Name of the bridge doing the data bridging
+    bridged_by: "protocol-converter-name"  # Optional: Name of the bridge doing the data bridging. (default: uns_default_bridge)
 ```
 
 #### Configuration Parameters

--- a/README.md
+++ b/README.md
@@ -2019,7 +2019,7 @@ output:
   uns:
     topic: "${! meta(\"topic\") }"   # Optional (default: ${! meta("topic") }): The topic key for routing messages in the UMH ecosystem
     broker_address: "localhost:9092"  # Optional: Kafka broker address (default: localhost:9092)
-    bridged_by: "protocol-converter-name"  # Optional: Name of the bridge doing the data bridging. (default: uns_default_bridge)
+    bridged_by: "protocol-converter-name"  # Required: Name of the bridge doing the data bridging
 ```
 
 #### Configuration Parameters

--- a/uns_plugin/uns_output.go
+++ b/uns_plugin/uns_output.go
@@ -35,7 +35,7 @@ const (
 	defaultOutputTopicPartitionCount = 1
 	defaultBrokerAddress             = "localhost:9092"
 	defaultClientID                  = "umh_core"
-	defaultBridgeName                = "uns_default_bridge"
+	defaultBridgeName                = "umh_core"
 	defaultTopic                     = "${! meta(\"topic\") }"
 )
 

--- a/uns_plugin/uns_output.go
+++ b/uns_plugin/uns_output.go
@@ -104,7 +104,7 @@ In most UMH deployments, the default value is sufficient as Kafka runs on the sa
 
 // Config holds the configuration for the UNS output plugin
 type unsConfig struct {
-	messageKey    *service.InterpolatedString
+	topic         *service.InterpolatedString
 	brokerAddress string
 	bridgedBy     string
 }
@@ -128,13 +128,13 @@ func newUnsOutput(conf *service.ParsedConfig, mgr *service.Resources) (service.B
 	config := unsConfig{}
 
 	// Parse topic
-	config.messageKey, _ = service.NewInterpolatedString(defaultTopic)
+	config.topic, _ = service.NewInterpolatedString(defaultTopic)
 	if conf.Contains("topic") {
 		messageKey, err := conf.FieldInterpolatedString("topic")
 		if err != nil {
 			return nil, batchPolicy, 0, fmt.Errorf("error while parsing topic field from the config: %v", err)
 		}
-		config.messageKey = messageKey
+		config.topic = messageKey
 	}
 
 	// Parse broker_address if provided
@@ -286,7 +286,7 @@ func (o *unsOutput) WriteBatch(ctx context.Context, msgs service.MessageBatch) e
 
 	records := make([]Record, 0, len(msgs))
 	for i, msg := range msgs {
-		key, err := o.config.messageKey.TryString(msg)
+		key, err := o.config.topic.TryString(msg)
 		if err != nil {
 			return fmt.Errorf("failed to resolve topic field in message %d: %v", i, err)
 		}

--- a/uns_plugin/uns_output_test.go
+++ b/uns_plugin/uns_output_test.go
@@ -149,8 +149,8 @@ var _ = Describe("Initializing uns output plugin", func() {
 		unsConf := unsConfig{
 			bridgedBy: "default-test-bridge",
 		}
-		messageKey, _ := service.NewInterpolatedString("${! meta(\"topic\") }")
-		unsConf.messageKey = messageKey
+		topic, _ := service.NewInterpolatedString("${! meta(\"topic\") }")
+		unsConf.topic = topic
 		outputPlugin = newUnsOutputWithClient(mockClient, unsConf, nil)
 		unsClient = outputPlugin.(*unsOutput)
 		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated configuration naming from "messageKey" to "topic" for improved clarity and consistency.

- **Chores**
  - Adjusted internal defaults and tests to align with the new "topic" configuration naming.

- **Chores**
  - Temporarily marked the S7 PLC endpoint as unavailable in the workflow to reflect its current status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->