### PR TITLE
Fix concurrency group in tests

### DIFF
--- a/.github/workflows/ethernetip.yml
+++ b/.github/workflows/ethernetip.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: ethernetip-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/modbus-plc.yml
+++ b/.github/workflows/modbus-plc.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: modbus-plc-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nodered-js.yml
+++ b/.github/workflows/nodered-js.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: nodered-js-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/opcua-plc.yml
+++ b/.github/workflows/opcua-plc.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: opcua-plc-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/s7-plc.yml
+++ b/.github/workflows/s7-plc.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: s7-plc-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sensorconnect.yml
+++ b/.github/workflows/sensorconnect.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: sensorconnect-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tag-processor.yml
+++ b/.github/workflows/tag-processor.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: tag-processor-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/uns.yml
+++ b/.github/workflows/uns.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: uns-output-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Instead of using an hardcoded group, use group: ${{ github.workflow }}-${{ github.ref }}.

`github.workflow`: The name of the workflow. If the workflow file doesn't specify a name, the value of this property is the full path of the workflow file in the repository.

`github.ref`: The fully-formed ref of the branch or tag that triggered the workflow run. For workflows triggered by push, this is the branch or tag ref that was pushed. For workflows triggered by pull_request, this is the pull request merge branch. For workflows triggered by release, this is the release tag created. For other triggers, this is the branch or tag ref that triggered the workflow run. This is only set if a branch or tag is available for the event type. The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>, for pull requests it is refs/pull/<pr_number>/merge, and for tags it is refs/tags/<tag_name>. For example, refs/heads/feature-branch-1.