### PR TITLE
fix: resolve aliases in DCMD messages before processing

### DIFF
--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -628,6 +628,9 @@ func (s *sparkplugInput) processCommandMessage(deviceKey, msgType string, payloa
 		}
 	}
 
+	// Resolve aliases in command message (same as data messages)
+	s.resolveAliases(deviceKey, payload.Metrics)
+
 	// Create batch from command metrics - always split for UMH-Core format
 	batch := s.createSplitMessages(payload, msgType, deviceKey, topicInfo, originalTopic)
 


### PR DESCRIPTION
## Summary
- Fixed DCMD messages showing 'alias_X' instead of actual metric names
- Added missing resolveAliases() call to match DDATA processing behavior
- Enables proper routing and processing of DCMD messages based on metric names

## Problem
DCMD (Device Command) messages were not having their aliases resolved to metric names, causing them to appear as 'alias_4' instead of the actual metric name like 'paint_booth:spray_gun:color:value'. This made it impossible to properly route or process commands based on metric names.

## Solution
Added s.resolveAliases(deviceKey, payload.Metrics) call in processCommandMessage() before creating the message batch, matching the behavior of DDATA message processing.

## Test Results
Tested with Sparkplug B setup:
- DBIRTH publishes alias 4 → 'paint_booth:spray_gun:color:value'
- Before fix: DCMD shows metric_name='alias_4'
- After fix: DCMD shows metric_name='paint_booth:spray_gun:color:value'

## Changes
- Added one line to resolve aliases in DCMD messages
- No breaking changes
- Improves Sparkplug B specification compliance

Co-Authored-By: Claude <noreply@anthropic.com>