### PR TITLE
[ENG-3403]: fix(opcua): bad-status due to server overflow

### DIFF
--- a/docs/input/opc-ua-input.md
+++ b/docs/input/opc-ua-input.md
@@ -298,7 +298,7 @@ input:
 
 **Advanced Configuration Options**
 
-> **WARNING**: The following options are for advanced users only. Modifying these settings without understanding your OPC UA server's behavior and limitations can lead to performance issues, memory problems, or connection failures. **Leave these at their default values unless you have specific performance requirements and understand the implications.**
+> **WARNING**: The following options are for advanced users only. Modifying these settings without understanding your OPC UA server's behavior and limitations can lead to performance issues, memory problems, or connection failures. Setting those configuration options, does **not** mean that the server will respect that settings. **Leave these at their default values unless you have specific performance requirements and understand the implications.**
 
 **Queue Size**
 
@@ -306,22 +306,16 @@ The `queueSize` parameter controls how many subscription notifications are buffe
 
 * **Key**: `queueSize`
 * **Default**: `10`
-* **Range**: Positive integer (≥ 1). Upper bound depends on server limits and available memory.
 * **Description**: This parameter determines the internal buffer size for handling subscription notifications from the OPC UA server. A larger queue can handle burst notifications but uses more memory.
-
-**When to modify**:
-- Your OPC UA server sends notifications in bursts and you're experiencing data loss
-- You have a high-frequency server that sends thousands of notifications per second
-- You need to balance memory usage vs. notification handling capacity
 
 **Risks of incorrect configuration**:
 - **Too small**: May cause notification loss during high-frequency periods
-- **Too large**: Excessive memory usage that could impact system performance 
+- **Too large**: Excessive memory usage that could impact system performance t 
 
 ```yaml
 input:
   opcua:
-    queueSize: 50  # Only increase if you experience notification loss
+    queueSize: 20  # Only increase if you experience notification loss
 ```
 
 **Sampling Interval**
@@ -331,27 +325,14 @@ The `samplingInterval` parameter controls how frequently the OPC UA server sampl
 * **Key**: `samplingInterval`
 * **Default**: `0.0` (fastest possible sampling)
 * **Unit**: Milliseconds
-* **Range**: Must be non-negative (≥ 0.0)
 * **Description**: Defines the rate at which the server samples the data source. A value of `0.0` means "as fast as possible" according to the server's capabilities. Higher values reduce sampling frequency.
-
-**When to modify**:
-- You want to reduce the frequency of notifications to avoid overwhelming your system
-- Your data source doesn't change frequently and high-frequency sampling is unnecessary
-- You need to optimize network bandwidth or server resources
 
 **Server behavior dependency**:
 - Some servers ignore this parameter and use their own internal sampling rates
 - The actual sampling rate depends on the server's implementation and capabilities
-- Setting this value doesn't guarantee the specified sampling rate—it's a hint to the server
 
 ```yaml
 input:
   opcua:
     samplingInterval: 1000.0  # Sample every 1 second instead of as fast as possible
 ```
-
-**Important Notes**:
-1. **Test thoroughly**: Always test configuration changes in a development environment before production
-2. **Monitor performance**: Watch for memory usage, CPU consumption, and data loss after changes
-3. **Server-specific behavior**: Each OPC UA server implementation may handle these parameters differently
-4. **Start conservative**: Begin with small changes and monitor the impact before making larger adjustments

--- a/docs/input/opc-ua-input.md
+++ b/docs/input/opc-ua-input.md
@@ -310,7 +310,7 @@ The `queueSize` parameter controls how many subscription notifications are buffe
 
 **Risks of incorrect configuration**:
 - **Too small**: May cause notification loss during high-frequency periods
-- **Too large**: Excessive memory usage that could impact system performance t 
+- **Too large**: Excessive memory usage that could impact system performance
 
 ```yaml
 input:

--- a/opcua_plugin/core_browse_workers.go
+++ b/opcua_plugin/core_browse_workers.go
@@ -26,7 +26,7 @@ const (
 	MinWorkers     = 5
 	InitialWorkers = 10
 	SampleSize     = 5 // Number of requsts to measure response time
-	TargetLatency  = 5 * time.Millisecond
+	TargetLatency  = 250 * time.Millisecond
 )
 
 // ServerMetrics is a struct that holds the metrics for the OPCUA server requests

--- a/opcua_plugin/core_browse_workers.go
+++ b/opcua_plugin/core_browse_workers.go
@@ -26,7 +26,7 @@ const (
 	MinWorkers     = 5
 	InitialWorkers = 10
 	SampleSize     = 5 // Number of requsts to measure response time
-	TargetLatency  = 250 * time.Millisecond
+	TargetLatency  = 5 * time.Millisecond
 )
 
 // ServerMetrics is a struct that holds the metrics for the OPCUA server requests

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -28,8 +28,10 @@ import (
 	"github.com/gopcua/opcua/ua"
 )
 
-const SubscribeTimeoutContext = 3 * time.Second
-const DefaultPollRate = 1000
+const (
+	SubscribeTimeoutContext = 3 * time.Second
+	DefaultPollRate         = 1000
+)
 
 var OPCUAConfigSpec = OPCUAConnectionConfigSpec.
 	Summary("OPC UA input plugin").
@@ -47,7 +49,6 @@ var OPCUAConfigSpec = OPCUAConnectionConfigSpec.
 		Default(DefaultPollRate))
 
 func ParseNodeIDs(incomingNodes []string) []*ua.NodeID {
-
 	// Parse all nodeIDs to validate them.
 	// loop through all nodeIDs, parse them and put them into a slice
 	var parsedNodeIDs []*ua.NodeID
@@ -119,7 +120,6 @@ func newOPCUAInput(conf *service.ParsedConfig, mgr *service.Resources) (service.
 }
 
 func init() {
-
 	err := service.RegisterBatchInput(
 		"opcua", OPCUAConfigSpec,
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
@@ -179,6 +179,10 @@ func (g *OPCUAInput) startBrowsing(ctx context.Context) {
 			g.Close(ctx) // Safe to call Close here as we're in a separate goroutine
 			return
 		}
+		g.Log.Infof("Subscription revised: publishInterval=%v keepAlive=%d lifetime=%d",
+			g.Subscription.RevisedPublishingInterval,
+			g.Subscription.RevisedMaxKeepAliveCount,
+			g.Subscription.RevisedLifetimeCount)
 
 		g.LastHeartbeatMessageReceived.Store(uint32(time.Now().Unix()))
 	}()
@@ -439,7 +443,6 @@ func (g *OPCUAInput) ReadBatchSubscribe(ctx context.Context) (service.MessageBat
 // accurately represents the OPC UA node's current value. Additionally, it marks heartbeat messages
 // when applicable, facilitating heartbeat monitoring within the system.
 func (g *OPCUAInput) createMessageFromValue(dataValue *ua.DataValue, nodeDef NodeDef) *service.Message {
-
 	b, tagType := g.getBytesFromValue(dataValue, nodeDef)
 	message := service.NewMessage(b)
 

--- a/opcua_plugin/read_discover.go
+++ b/opcua_plugin/read_discover.go
@@ -44,7 +44,7 @@ func (g *OPCUAInput) discoverNodes(ctx context.Context) ([]NodeDef, map[string]s
 	done := make(chan struct{})
 
 	go func() {
-		ticker := time.NewTicker(1 * time.Second)
+		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
@@ -246,8 +246,8 @@ func (g *OPCUAInput) MonitorBatched(ctx context.Context, nodes []NodeDef) (int, 
 					ClientHandle:     uint32(startIdx + pos),
 					DiscardOldest:    true,
 					Filter:           nil,
-					QueueSize:        10,
-					SamplingInterval: 250.0,
+					QueueSize:        g.QueueSize,
+					SamplingInterval: g.SamplingInterval,
 				},
 			}
 			monitoredRequests = append(monitoredRequests, request)
@@ -276,9 +276,9 @@ func (g *OPCUAInput) MonitorBatched(ctx context.Context, nodes []NodeDef) (int, 
 				g.Log.Errorf("Failed to monitor node %s: %v", failedNode, result.StatusCode)
 				// Depending on requirements, you might choose to continue monitoring other nodes
 				// instead of aborting. Here, we abort on the first failure.
-				g.Log.Debugf("MonitoredItem OK ns=%d;id=%s -> revisedSampling=%.0fms revisedQueue=%d itemID=%d",
-					batch[i].NodeID.Namespace(), batch[i].NodeID.String(),
-					result.RevisedSamplingInterval, result.RevisedQueueSize, result.MonitoredItemID)
+				// g.Log.Debugf("MonitoredItem OK ns=%d;id=%s -> revisedSampling=%.0fms revisedQueue=%d itemID=%d",
+				//	batch[i].NodeID.Namespace(), batch[i].NodeID.String(),
+				//	result.RevisedSamplingInterval, result.RevisedQueueSize, result.MonitoredItemID)
 				if closeErr := g.Close(ctx); closeErr != nil {
 					g.Log.Errorf("Failed to close OPC UA connection: %v", closeErr)
 				}

--- a/opcua_plugin/read_discover.go
+++ b/opcua_plugin/read_discover.go
@@ -44,7 +44,7 @@ func (g *OPCUAInput) discoverNodes(ctx context.Context) ([]NodeDef, map[string]s
 	done := make(chan struct{})
 
 	go func() {
-		ticker := time.NewTicker(10 * time.Second)
+		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
@@ -235,11 +235,21 @@ func (g *OPCUAInput) MonitorBatched(ctx context.Context, nodes []NodeDef) (int, 
 		monitoredRequests := make([]*ua.MonitoredItemCreateRequest, 0, len(batch))
 
 		for pos, nodeDef := range batch {
-			request := opcua.NewMonitoredItemCreateRequestWithDefaults(
-				nodeDef.NodeID,
-				ua.AttributeIDValue,
-				uint32(startIdx+pos),
-			)
+			request := &ua.MonitoredItemCreateRequest{
+				ItemToMonitor: &ua.ReadValueID{
+					NodeID:       nodeDef.NodeID,
+					AttributeID:  ua.AttributeIDValue,
+					DataEncoding: &ua.QualifiedName{},
+				},
+				MonitoringMode: ua.MonitoringModeReporting,
+				RequestedParameters: &ua.MonitoringParameters{
+					ClientHandle:     uint32(startIdx + pos),
+					DiscardOldest:    true,
+					Filter:           nil,
+					QueueSize:        10,
+					SamplingInterval: 250.0,
+				},
+			}
 			monitoredRequests = append(monitoredRequests, request)
 		}
 
@@ -266,6 +276,9 @@ func (g *OPCUAInput) MonitorBatched(ctx context.Context, nodes []NodeDef) (int, 
 				g.Log.Errorf("Failed to monitor node %s: %v", failedNode, result.StatusCode)
 				// Depending on requirements, you might choose to continue monitoring other nodes
 				// instead of aborting. Here, we abort on the first failure.
+				g.Log.Debugf("MonitoredItem OK ns=%d;id=%s -> revisedSampling=%.0fms revisedQueue=%d itemID=%d",
+					batch[i].NodeID.Namespace(), batch[i].NodeID.String(),
+					result.RevisedSamplingInterval, result.RevisedQueueSize, result.MonitoredItemID)
 				if closeErr := g.Close(ctx); closeErr != nil {
 					g.Log.Errorf("Failed to close OPC UA connection: %v", closeErr)
 				}


### PR DESCRIPTION
### Description:
To fix the issue of bad-status due to server overflow, we don't want to hardcode the `samplingInterval` and `queueSize` here, therefore we need to expose the configuration-fields. So that later on we can try to make it work out from the configuration and try to adjust it for those special cases.

These configuration options are only for advanced users, who have access to the OPC-UA-Server and are able to assume the behaviour here.