### PR TITLE
[ENG-3589] fixes downsampler-issue with type-conversion and s7

### DIFF
--- a/downsampler_plugin/algorithms/processor.go
+++ b/downsampler_plugin/algorithms/processor.go
@@ -15,6 +15,7 @@
 package algorithms
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -263,6 +264,12 @@ func (p *ProcessorWrapper) toFloat64(val interface{}) (float64, error) {
 		return float64(v), nil
 	case uint64:
 		return float64(v), nil
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return 0, fmt.Errorf("json.Number cannot be converted to float64: %w", err)
+		}
+		return f, nil
 	default:
 		return 0, fmt.Errorf("unsupported type: %T", val)
 	}

--- a/downsampler_plugin/downsampler_plugin.go
+++ b/downsampler_plugin/downsampler_plugin.go
@@ -98,12 +98,12 @@ func init() {
 		Summary("Downsamples time-series data using configurable algorithms").
 		Description(`The downsampler reduces data volume by filtering out insignificant changes in time-series data using configurable algorithms.
 
-It processes UMH-core time-series data with data_contract "_historian", 
-passing all other messages through unchanged. Each message that passes the downsampling filter is annotated 
+It processes UMH-core time-series data with data_contract "_historian",
+passing all other messages through unchanged. Each message that passes the downsampling filter is annotated
 with metadata indicating the algorithm used.
 
-In typical UMH deployments, the downsampler is enabled by default with conservative settings to automatically 
-compress time-series data. The tag_processor can be used upstream to selectively bypass downsampling for 
+In typical UMH deployments, the downsampler is enabled by default with conservative settings to automatically
+compress time-series data. The tag_processor can be used upstream to selectively bypass downsampling for
 critical data by setting the ds_ignore metadata field.
 
 Supported format:
@@ -117,17 +117,17 @@ to determine whether each data point represents a significant change worth prese
 
 The downsampler handles different data types as follows:
 
-- **Numeric values** (int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64): 
-  Converted to float64 for algorithm processing and output. This ensures consistent precision and compatibility 
+- **Numeric values** (int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64):
+  Converted to float64 for algorithm processing and output. This ensures consistent precision and compatibility
   with all downsampling algorithms.
 
-- **Boolean values** (true, false): 
+- **Boolean values** (true, false):
   Preserved as-is. Uses change-based logic - only emits when the boolean value changes.
 
-- **String values**: 
+- **String values**:
   Preserved as-is. Uses change-based logic - only emits when the string value changes.
 
-- **Other types**: 
+- **Other types**:
   Rejected with an error to ensure data integrity.
 
 ## Selective Bypass with ds_ignore

--- a/s7comm_plugin/type_conversions.go
+++ b/s7comm_plugin/type_conversions.go
@@ -15,6 +15,7 @@
 package s7comm_plugin
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math"
 
@@ -45,10 +46,15 @@ func determineConversion(dtype string) converterFunc {
 			// Get the length of the encoded string
 			length := int(buf[1])
 			// Clip the string if we do not fill the whole buffer
+			var result []byte
 			if length < len(buf)-2 {
-				return string(buf[2 : 2+length])
+				result = buf[2 : 2+length]
+			} else {
+				result = buf[2:]
 			}
-			return string(buf[2:])
+			// trim the null bytes
+			result = bytes.TrimRight(result, "\x00")
+			return string(result)
 		}
 	case "W":
 		return func(buf []byte) interface{} {


### PR DESCRIPTION
## Description:
This PR should fix 2 issues here:

#### S7-plugin:
Currently when having a 8-byte-string for example "thisIsAt" and trying to read 10 bytes with the configuration `DB1.S30.10` it's appending 2 empty bytes from the plc. Therefore the representation in the value of the payload is looking like this `thisIsAt\u0000\u0000`.
This should be fixed by trimming empty bytes from string reading.

#### Downsampler:
The main issue here [Linear](https://linear.app/united-manufacturing-hub/issue/ENG-3589/downsampler-fails-with-null-padded-strings-from-s7-protocol-converters) was that the `toFloat64` conversion inside the Downsampler didn't have any case for a `json.Number` format and therefore it failed on that one, which caused Errors to be thrown. This should be fixed after adding a case for `json.Number` to convert it into float64.