### PR TITLE
Bump Go version to 1.25.3 to resolve stdlib security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM management.umh.app/oci/library/golang:1.25.2 as build
+FROM management.umh.app/oci/library/golang:1.25.3 as build
 
 RUN useradd -u 10001 benthos
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/united-manufacturing-hub/benthos-umh
 
-go 1.25.2
+go 1.25.3
 
 // to compile it on go 1.23
 replace github.com/parquet-go/parquet-go => github.com/parquet-go/parquet-go v0.23.0


### PR DESCRIPTION
This PR bumps Go version from 1.25.2 to 1.25.3 to resolve stdlib security vulnerabilities.

## Changes

- **go.mod**: Update go directive from `1.25.2` to `1.25.3`
- **Dockerfile**: Update base image from `golang:1.25.2` to `golang:1.25.3`

## Security Fix

Addresses 10 security vulnerabilities in the Go standard library (4 high, 6 medium severity) by updating to the latest patch release.

## Testing

- ✅ Build verification completed successfully
- ✅ Binary size: 222M (expected for debug build)
- ✅ Version check passed

Resolves: [ENG-3882](https://linear.app/united-manufacturing-hub/issue/ENG-3882)

🤖 Generated with [Claude Code](https://claude.com/claude-code)