### PR TITLE
[ENG-3922 ] add make run and and some adjustments to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ GINKGO_SERIAL_FLAGS=$(GINKGO_FLAGS) --procs=1
 
 BENTHOS_BIN := tmp/bin/benthos
 LOG_LEVEL ?= INFO
+CONFIG ?= ./config/opcua-hex-test.yaml
 
 .PHONY: all
 all: clean target
@@ -31,9 +32,57 @@ clean:
 run:
 	@go run cmd/benthos/main.go run --log.level $(LOG_LEVEL) $(CONFIG)
 
-.PHONY: run-debug
-run-debug:
-	@$(MAKE) run LOG_LEVEL=DEBUG
+.PHONY: help
+help:
+	@echo "Quick Start:"
+	@echo "  make run CONFIG=config/stdout.yaml"
+	@echo ""
+	@echo "Common Commands:"
+	@echo "  make all      Clean build from scratch"
+	@echo "  make target   Build binary (faster for repeated builds)"
+	@echo "  make test     Run all unit tests"
+	@echo ""
+	@echo "When to use what:"
+	@echo "  make run      Quick iteration with different configs"
+	@echo "  make target   Build once, then test multiple configs manually"
+	@echo ""
+	@echo "Testing:"
+	@echo "  Most tests run without hardware (unit tests only)"
+	@echo "  To test against real PLCs, set environment variables first"
+	@echo "  See: make env"
+	@echo ""
+
+.PHONY: env
+env:
+	@echo "OPC UA Tests (make test-opc):"
+	@echo "  TEST_S7_ENDPOINT_URI=opc.tcp://<ip>:<port>"
+	@echo "  TEST_WAGO_ENDPOINT_URI=opc.tcp://<ip>:<port>"
+	@echo "  TEST_WAGO_USERNAME=myuser"
+	@echo "  TEST_WAGO_PASSWORD=mypassword"
+	@echo "  TEST_KEPWARE_ENDPOINT=opc.tcp://<ip>:<port>"
+	@echo "  TEST_KEPWARE_USERNAME=myuser"
+	@echo "  TEST_KEPWARE_PASSWORD=mypassword"
+	@echo ""
+	@echo "S7 PLC Tests (make test-s7comm):"
+	@echo "  TEST_S7COMM_UNITTEST=true"
+	@echo "  TEST_S7_TCPDEVICE=<ip:port>"
+	@echo "  TEST_S7_RACK=<rack_number>"
+	@echo "  TEST_S7_SLOT=<slot_number>"
+	@echo ""
+	@echo "Modbus Tests (make test-modbus):"
+	@echo "  TEST_MODBUS_SIMULATOR=true"
+	@echo "  TEST_WAGO_MODBUS_ENDPOINT=<ip:port>  (for WAGO tests)"
+	@echo ""
+	@echo "Sensorconnect Tests (make test-sensorconnect):"
+	@echo "  TEST_DEBUG_IFM_ENDPOINT=<ip_address>"
+	@echo ""
+	@echo "Other plugin tests:"
+	@echo "  TEST_NODERED_JS=true           (make test-noderedjs)"
+	@echo "  TEST_TAG_PROCESSOR=true        (make test-tag-processor)"
+	@echo "  TEST_CLASSIC_TO_CORE=1         (make test-classic-to-core)"
+	@echo "  TEST_TOPIC_BROWSER=1           (make test-topic-browser)"
+	@echo "  TEST_DOWNSAMPLER=1             (make test-downsampler)"
+	@echo ""
 
 .PHONY: target
 target: build-protobuf

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,10 @@ build-protobuf:
 		--go_out=pkg/umh/topic/proto \
 		pkg/umh/topic/proto/topic_browser_data.proto
 
-# TODO: add some information about potential endpoints etc
+# PPROF
+# in config we need to set:
+# http:
+#   debug_endpoints: true
 .PHONY: serve-pprof
 serve-pprof:
 	go tool pprof -http=:8080 "localhost:4195/debug/pprof/profile?seconds=20"

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test-topic-browser:
 		$(GINKGO_CMD) $(GINKGO_FLAGS) ./topic_browser_plugin/...
 
 ## Generate go files from protobuf for topic browser
-.PHONY:
+.PHONY: build-protobuf
 build-protobuf:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	rm pkg/umh/topic/proto/topic_browser_data.pb.go || true
@@ -160,10 +160,6 @@ build-protobuf:
 		--go_out=pkg/umh/topic/proto \
 		pkg/umh/topic/proto/topic_browser_data.proto
 
-# PPROF
-# in config we need to set:
-# http:
-#   debug_endpoints: true
 .PHONY: serve-pprof
 serve-pprof:
 	go tool pprof -http=:8080 "localhost:4195/debug/pprof/profile?seconds=20"

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ GINKGO_FLAGS=-r --output-interceptor-mode=none --github-output -vv -trace -p --r
 GINKGO_SERIAL_FLAGS=$(GINKGO_FLAGS) --procs=1
 
 BENTHOS_BIN := tmp/bin/benthos
+LOG_LEVEL ?= INFO
 
 .PHONY: all
 all: clean target
@@ -25,6 +26,14 @@ all: clean target
 .PHONY: clean
 clean:
 	@rm -rf target tmp/bin tmp/benthos-*.zip
+
+.PHONY: run
+run:
+	@go run cmd/benthos/main.go run --log.level $(LOG_LEVEL) $(CONFIG)
+
+.PHONY: run-debug
+run-debug:
+	@$(MAKE) run LOG_LEVEL=DEBUG
 
 .PHONY: target
 target: build-protobuf

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,6 @@ all: clean build
 
 .PHONY: install
 install: install-tools
-	@ if ! which dot > /dev/null; then \
-		echo "error: dot not installed (install graphviz)" >&2; \
-		exit 1; \
-	fi
 
 .PHONY: clean
 clean:
@@ -162,8 +158,9 @@ proto:
 
 .PHONY: serve-pprof
 serve-pprof:
-	@ if ! which dot > /dev/null; then \
-		echo "error: dot not installed (install graphviz)" >&2; \
-		exit 1; \
-	fi
-	go tool pprof -http=:8080 "localhost:4195/debug/pprof/profile?seconds=20"
+	@export PATH="$(TOOLS_BIN_DIR)/graphviz:$$PATH" && \
+		if ! which dot > /dev/null; then \
+			echo "error: dot not installed (run make install)" >&2; \
+			exit 1; \
+		fi && \
+		go tool pprof -http=:8080 "localhost:4195/debug/pprof/profile?seconds=20"

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -78,6 +78,10 @@ help:
 	@echo "  To test against real PLCs, set environment variables first"
 	@echo "  See: make env"
 	@echo ""
+	@echo "Profiling:"
+	@echo "  make serve-pprof   Start pprof web server on :8080"
+	@echo "                     (requires http.debug_endpoints: true in config)"
+	@echo ""
 
 .PHONY: env
 env:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -19,6 +19,7 @@ LICENSE_EYE_VERSION = v0.7.0
 GOLANGCI_LINT_VERSION = v2.5.0
 NILAWAY_VERSION = latest
 STATICCHECK_VERSION = v0.6.1
+PROTOC_GEN_GO_VERSION = v1.36.10
 
 # ---------------------------------------------------
 # Pinned URLs for go install
@@ -28,6 +29,7 @@ LICENSE_EYE_URL := github.com/apache/skywalking-eyes/cmd/license-eye@$(LICENSE_E
 GOLANGCI_LINT_URL := github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 NILAWAY_URL := go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION)
 STATICCHECK_URL := honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
+PROTOC_GEN_GO_URL := google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)
 
 
 TOOLS_BIN_DIR    := $(SRC_ROOT)/.tools
@@ -40,6 +42,7 @@ LICENSE_EYE := $(TOOLS_BIN_DIR)/license-eye
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 NILAWAY := $(TOOLS_BIN_DIR)/nilaway
 STATICCHECK := $(TOOLS_BIN_DIR)/staticcheck
+PROTOC := docker run --rm -v $(PWD):$(PWD) -w $(PWD) rvolosatovs/protoc:latest
 
 $(TOOLS_BIN_DIR):
 	@mkdir -p $@

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -62,7 +62,7 @@ install-tools: $(LICENSE_EYE) $(GOLANGCI_LINT) $(NILAWAY) $(STATICCHECK)
 .PHONY: help
 help:
 	@echo "Quick Start:"
-	@echo "  make run CONFIG=config/stdout.yaml"
+	@echo "  make run CONFIG=./config/stdout.yaml"
 	@echo ""
 	@echo "Common Commands:"
 	@echo "  make all      Clean build from scratch"
@@ -70,7 +70,7 @@ help:
 	@echo "  make test     Run all unit tests"
 	@echo ""
 	@echo "When to use what:"
-	@echo "  make run      Quick iteration with different configs"
+	@echo "  make run     Quick iteration with different configs, needs CONFIG var."
 	@echo "  make build   Build once, then test multiple configs manually"
 	@echo ""
 	@echo "Testing:"

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -14,11 +14,20 @@
 
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
 
+
+LICENSE_EYE_VERSION = v0.7.0
+GOLANGCI_LINT_VERSION = v2.5.0
+NILAWAY_VERSION = latest
+STATICCHECK_VERSION = v0.6.1
+
 # ---------------------------------------------------
 # Pinned URLs for go install
 # ---------------------------------------------------
 #  we might add some additional tools later e.g. golangci-lint/gofmt
-LICENSE_EYE_URL := github.com/apache/skywalking-eyes/cmd/license-eye@v0.7.0
+LICENSE_EYE_URL := github.com/apache/skywalking-eyes/cmd/license-eye@$(LICENSE_EYE_VERSION)
+GOLANGCI_LINT_URL := github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+NILAWAY_URL := go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION)
+STATICCHECK_URL := honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
 
 
 TOOLS_BIN_DIR    := $(SRC_ROOT)/.tools
@@ -28,6 +37,9 @@ TOOLS_BIN_DIR    := $(SRC_ROOT)/.tools
 # Tools references
 # ---------------------------------------------------
 LICENSE_EYE := $(TOOLS_BIN_DIR)/license-eye
+GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
+NILAWAY := $(TOOLS_BIN_DIR)/nilaway
+STATICCHECK := $(TOOLS_BIN_DIR)/staticcheck
 
 $(TOOLS_BIN_DIR):
 	@mkdir -p $@
@@ -35,5 +47,66 @@ $(TOOLS_BIN_DIR):
 $(LICENSE_EYE): $(TOOLS_BIN_DIR)
 	@GOBIN=$(TOOLS_BIN_DIR) go install $(LICENSE_EYE_URL)
 
+$(GOLANGCI_LINT): $(TOOLS_BIN_DIR)
+	@GOBIN=$(TOOLS_BIN_DIR) go install $(GOLANGCI_LINT_URL)
+
+$(NILAWAY): $(TOOLS_BIN_DIR)
+	@GOBIN=$(TOOLS_BIN_DIR) go install $(NILAWAY_URL)
+
+$(STATICCHECK): $(TOOLS_BIN_DIR)
+	@GOBIN=$(TOOLS_BIN_DIR) go install $(STATICCHECK_URL)
+
 .PHONY: install-tools
-install-tools: $(LICENSE_EYE)
+install-tools: $(LICENSE_EYE) $(GOLANGCI_LINT) $(NILAWAY) $(STATICCHECK)
+
+.PHONY: help
+help:
+	@echo "Quick Start:"
+	@echo "  make run CONFIG=config/stdout.yaml"
+	@echo ""
+	@echo "Common Commands:"
+	@echo "  make all      Clean build from scratch"
+	@echo "  make build   Build binary (faster for repeated builds)"
+	@echo "  make test     Run all unit tests"
+	@echo ""
+	@echo "When to use what:"
+	@echo "  make run      Quick iteration with different configs"
+	@echo "  make build   Build once, then test multiple configs manually"
+	@echo ""
+	@echo "Testing:"
+	@echo "  Most tests run without hardware (unit tests only)"
+	@echo "  To test against real PLCs, set environment variables first"
+	@echo "  See: make env"
+	@echo ""
+
+.PHONY: env
+env:
+	@echo "OPC UA Tests (make test-opc):"
+	@echo "  TEST_S7_ENDPOINT_URI=opc.tcp://<ip>:<port>"
+	@echo "  TEST_WAGO_ENDPOINT_URI=opc.tcp://<ip>:<port>"
+	@echo "  TEST_WAGO_USERNAME=myuser"
+	@echo "  TEST_WAGO_PASSWORD=mypassword"
+	@echo "  TEST_KEPWARE_ENDPOINT=opc.tcp://<ip>:<port>"
+	@echo "  TEST_KEPWARE_USERNAME=myuser"
+	@echo "  TEST_KEPWARE_PASSWORD=mypassword"
+	@echo ""
+	@echo "S7 PLC Tests (make test-s7comm):"
+	@echo "  TEST_S7COMM_UNITTEST=true"
+	@echo "  TEST_S7_TCPDEVICE=<ip:port>"
+	@echo "  TEST_S7_RACK=<rack_number>"
+	@echo "  TEST_S7_SLOT=<slot_number>"
+	@echo ""
+	@echo "Modbus Tests (make test-modbus):"
+	@echo "  TEST_MODBUS_SIMULATOR=true"
+	@echo "  TEST_WAGO_MODBUS_ENDPOINT=<ip:port>  (for WAGO tests)"
+	@echo ""
+	@echo "Sensorconnect Tests (make test-sensorconnect):"
+	@echo "  TEST_DEBUG_IFM_ENDPOINT=<ip_address>"
+	@echo ""
+	@echo "Other plugin tests:"
+	@echo "  TEST_NODERED_JS=true           (make test-noderedjs)"
+	@echo "  TEST_TAG_PROCESSOR=true        (make test-tag-processor)"
+	@echo "  TEST_CLASSIC_TO_CORE=1         (make test-classic-to-core)"
+	@echo "  TEST_TOPIC_BROWSER=1           (make test-topic-browser)"
+	@echo "  TEST_DOWNSAMPLER=1             (make test-downsampler)"
+	@echo ""

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -20,6 +20,7 @@ GOLANGCI_LINT_VERSION = v2.5.0
 NILAWAY_VERSION = latest
 STATICCHECK_VERSION = v0.6.1
 PROTOC_GEN_GO_VERSION = v1.36.10
+GRAPHVIZ_VERSION = latest
 
 # ---------------------------------------------------
 # Pinned URLs for go install
@@ -43,6 +44,7 @@ GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 NILAWAY := $(TOOLS_BIN_DIR)/nilaway
 STATICCHECK := $(TOOLS_BIN_DIR)/staticcheck
 PROTOC := docker run --rm -v $(PWD):$(PWD) -w $(PWD) rvolosatovs/protoc:latest
+DOT := $(TOOLS_BIN_DIR)/graphviz/dot
 
 $(TOOLS_BIN_DIR):
 	@mkdir -p $@
@@ -59,8 +61,14 @@ $(NILAWAY): $(TOOLS_BIN_DIR)
 $(STATICCHECK): $(TOOLS_BIN_DIR)
 	@GOBIN=$(TOOLS_BIN_DIR) go install $(STATICCHECK_URL)
 
+$(DOT): $(TOOLS_BIN_DIR)
+	@mkdir -p $(dir $(DOT))
+	@printf '#!/bin/sh\n' > $(DOT)
+	@printf 'exec docker run --rm -i minidocks/graphviz:$(GRAPHVIZ_VERSION) dot "$$@"\n' >> $(DOT)
+	@chmod +x $(DOT)
+
 .PHONY: install-tools
-install-tools: $(LICENSE_EYE) $(GOLANGCI_LINT) $(NILAWAY) $(STATICCHECK)
+install-tools: $(LICENSE_EYE) $(GOLANGCI_LINT) $(NILAWAY) $(STATICCHECK) $(DOT)
 
 .PHONY: help
 help:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -17,10 +17,11 @@ SRC_ROOT := $(shell git rev-parse --show-toplevel)
 
 LICENSE_EYE_VERSION = v0.7.0
 GOLANGCI_LINT_VERSION = v2.5.0
-NILAWAY_VERSION = latest
+NILAWAY_VERSION = v0.0.0-20251119034912-44f92224c998
 STATICCHECK_VERSION = v0.6.1
 PROTOC_GEN_GO_VERSION = v1.36.10
-GRAPHVIZ_VERSION = latest
+PROTOC_VERSION = cbbe65675855d0db6d94a43f565952c69ef7fc58081569837d44af3f044aa73d
+GRAPHVIZ_VERSION = 939f896cd783daeed8ab08c446f3e2b79213f5e5d87d73bada58667f3bcd8906
 
 # ---------------------------------------------------
 # Pinned URLs for go install
@@ -43,7 +44,7 @@ LICENSE_EYE := $(TOOLS_BIN_DIR)/license-eye
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 NILAWAY := $(TOOLS_BIN_DIR)/nilaway
 STATICCHECK := $(TOOLS_BIN_DIR)/staticcheck
-PROTOC := docker run --rm -v $(PWD):$(PWD) -w $(PWD) rvolosatovs/protoc:latest
+PROTOC := docker run --rm -v $(PWD):$(PWD) -w $(PWD) rvolosatovs/protoc@sha256:$(PROTOC_VERSION)
 DOT := $(TOOLS_BIN_DIR)/graphviz/dot
 
 $(TOOLS_BIN_DIR):
@@ -64,7 +65,7 @@ $(STATICCHECK): $(TOOLS_BIN_DIR)
 $(DOT): $(TOOLS_BIN_DIR)
 	@mkdir -p $(dir $(DOT))
 	@printf '#!/bin/sh\n' > $(DOT)
-	@printf 'exec docker run --rm -i minidocks/graphviz:$(GRAPHVIZ_VERSION) dot "$$@"\n' >> $(DOT)
+	@printf 'exec docker run --rm -i minidocks/graphviz@sha256:$(GRAPHVIZ_VERSION) dot "$$@"\n' >> $(DOT)
 	@chmod +x $(DOT)
 
 .PHONY: install-tools


### PR DESCRIPTION
### Description:

To make it more intentional and easier to use this PR introduces the `make run` and `make run-debug` commands. You can set your envvar `CONFIG=./path/to/your/config` relatively from within the benthos-umh repository and use this to have benthos running with this config. 
