### PR TITLE
[ENG-3884] add workflow for benthos-bump & set-flag in main.yaml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,7 +311,7 @@ jobs:
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
 
       - name: Trigger version bump workflow
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           event-type: release-completed
           client-payload: '{"tag": "${{ github.ref_name }}"}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -309,3 +309,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
+
+      - name: Trigger version bump workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: release-completed
+          client-payload: '{"tag": "${{ github.ref_name }}"}'

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -1,0 +1,62 @@
+# Copyright 2023 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Update benthos-umh in umh-core
+
+on:
+  repository_dispatch:
+    types: [release-completed]
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.client_payload.tag }}
+    steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PR_APP_ID }}
+          private-key: ${{ secrets.PR_APP_PK }}
+          repositories: united-manufacturing-hub
+
+      - name: Checkout united-manufacturing-hub Repository
+        uses: actions/checkout@v4
+        with:
+          repository: united-manufacturing-hub/united-manufacturing-hub
+          ref: staging
+          token: ${{ steps.generate-token.outputs.token }}
+          path: united-manufacturing-hub
+
+      - name: Update BENTHOS_UMH_VERSION in Makefile
+        working-directory: united-manufacturing-hub/umh-core
+        run: |
+          VERSION_WITHOUT_PREFIX="${VERSION#v}"
+          sed -i "s/^BENTHOS_UMH_VERSION = .*/BENTHOS_UMH_VERSION = ${VERSION_WITHOUT_PREFIX}/" Makefile
+          grep -q "^BENTHOS_UMH_VERSION = ${VERSION_WITHOUT_PREFIX}$" Makefile || exit 1
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: united-manufacturing-hub
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: "chore: bump benthos-umh to ${{ env.VERSION }}"
+          branch: chore/benthos-umh-${{ env.VERSION }}
+          delete-branch: true
+          title: "chore: bump benthos-umh to ${{ env.VERSION }}"
+          labels: |
+            automation
+            dependencies

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -56,12 +56,12 @@ jobs:
           RELEASE_NOTES=$(gh release view "${VERSION}" --json body --jq '.body')
           {
             echo 'body<<EOF'
-            echo "$RELEASE_NOTES
+            echo "$RELEASE_NOTES"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7
         with:
           path: united-manufacturing-hub
           token: ${{ steps.generate-token.outputs.token }}
@@ -71,7 +71,7 @@ jobs:
           title: "chore: bump benthos-umh to ${{ env.VERSION }}"
           body: ${{ steps.release-notes.outputs.body }}
           labels: |
-            automation
+            auto-generated
             dependencies
           team-reviewers: |
             developers

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -48,6 +48,18 @@ jobs:
           sed -i "s/^BENTHOS_UMH_VERSION = .*/BENTHOS_UMH_VERSION = ${VERSION_WITHOUT_PREFIX}/" Makefile
           grep -q "^BENTHOS_UMH_VERSION = ${VERSION_WITHOUT_PREFIX}$" Makefile || exit 1
 
+      - name: Get Release Notes
+        id: release-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE_NOTES=$(gh release view "${VERSION}" --json body --jq '.body')
+          {
+            echo 'body<<EOF'
+            echo "$RELEASE_NOTES
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -57,6 +69,7 @@ jobs:
           branch: chore/benthos-umh-${{ env.VERSION }}
           delete-branch: true
           title: "chore: bump benthos-umh to ${{ env.VERSION }}"
+          body: ${{ steps.release-notes.outputs.body }}
           labels: |
             automation
             dependencies

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -60,3 +60,6 @@ jobs:
           labels: |
             automation
             dependencies
+          team-reviewers: |
+            developers
+          draft: false


### PR DESCRIPTION
## Description:

This PR introduces a new workflow which should:
- generate the app token
- checks out `united-manufacturing-hub` repository
- replaces the `BENTHOS_UMH_VERSION` in Makefile+
- checks on the replacmenet -> if not then exit 1
- creates a PR in united-manufacturing-hub

---

### Open questions:
- is the previously App for ManagementConsole cross-repo available, because it needs write-access here
    -> contents: write and pull-requests: write
- at a certain point, we could somehow check the release-notes from `benthos-umh` and include them here, but first we need to make sure that this behaves like intended