### PR TITLE
chore: concise test output format

### DIFF
--- a/.github/workflows/classic-to-core-plugin.yml
+++ b/.github/workflows/classic-to-core-plugin.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Test
         env:
           TEST_CLASSIC_TO_CORE: 1

--- a/.github/workflows/ethernetip.yml
+++ b/.github/workflows/ethernetip.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Test
         run: |

--- a/.github/workflows/modbus-plc.yml
+++ b/.github/workflows/modbus-plc.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
 

--- a/.github/workflows/nodered-js.yml
+++ b/.github/workflows/nodered-js.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Test
         run: make test-noderedjs

--- a/.github/workflows/opcua-plc.yml
+++ b/.github/workflows/opcua-plc.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
       - name: Check S7 port availability
@@ -187,7 +187,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
 

--- a/.github/workflows/s7-plc.yml
+++ b/.github/workflows/s7-plc.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
 

--- a/.github/workflows/sensorconnect.yml
+++ b/.github/workflows/sensorconnect.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Test
         env:
           TEST_DEBUG_IFM_ENDPOINT: ${{ secrets.TEST_DEBUG_IFM_ENDPOINT }}

--- a/.github/workflows/sparkplug.yml
+++ b/.github/workflows/sparkplug.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Test
         env:
           TEST_SPARKPLUG_UNIT: true
-        run: make test-sparkplug 
+        run: make test-sparkplug

--- a/.github/workflows/tag-processor.yml
+++ b/.github/workflows/tag-processor.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Test
         env:
           TEST_TAG_PROCESSOR: true

--- a/.github/workflows/topic-browser.yml
+++ b/.github/workflows/topic-browser.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Test
         env:
           TEST_TOPIC_BROWSER: 1

--- a/.github/workflows/uns.yml
+++ b/.github/workflows/uns.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Test
         run: make test-uns

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@
 # limitations under the License.
 include ./Makefile.Common
 
-GINKGO_CMD=ginkgo
-GINKGO_FLAGS=-r --output-interceptor-mode=none --succinct -trace -p --randomize-all --cover --coverprofile=cover.profile
+GINKGO_CMD=go run github.com/onsi/ginkgo/v2/ginkgo
+GINKGO_FLAGS=-r --output-interceptor-mode=none -trace -p --randomize-all --cover --coverprofile=cover.profile
 GINKGO_SERIAL_FLAGS=$(GINKGO_FLAGS) --procs=1
 
 BENTHOS_BIN := tmp/bin/benthos


### PR DESCRIPTION
Issue: ENG-3952

Use a much more concise output for Ginkgo tests. The goal is to have a better experience when tests fail. Only relevant output is printed.

Also: Let go install handle version selection based on the projects `go.mod` file instead of pinning different versions in the workflows. This is the recommended way from ginkgo.

<img width="1764" height="812" alt="image" src="https://github.com/user-attachments/assets/b7d4e2f5-9f75-45ca-aacc-44e928a2be25" />
