### PR TITLE
fix: add dns validation for hostnames in certs

### DIFF
--- a/opcua_plugin/core_generate_cert.go
+++ b/opcua_plugin/core_generate_cert.go
@@ -239,7 +239,8 @@ func ParseHosts(hosts string) ([]net.IP, []string, []*url.URL, error) {
 		}
 
 		// Check if it's a URI with a scheme (urn:, http://, https://)
-		if uri, parseErr := url.Parse(h); parseErr == nil && uri.Scheme != "" && (uri.Scheme == "urn" || uri.Scheme == "http" || uri.Scheme == "https") {
+		uri, parseErr := url.Parse(h)
+		if parseErr == nil && (uri.Scheme == "urn" || uri.Scheme == "http" || uri.Scheme == "https") {
 			uris = append(uris, uri)
 			continue
 		}

--- a/opcua_plugin/core_generate_cert.go
+++ b/opcua_plugin/core_generate_cert.go
@@ -147,7 +147,7 @@ func GenerateCertWithMode(
 
 	template.IPAddresses, template.DNSNames, template.URIs, err = ParseHosts(host)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, "", fmt.Errorf("failed to parse certificate hosts: %w", err)
 	}
 
 	// Set Key Usage bits according to OPC UA Part 6 specification.

--- a/opcua_plugin/core_generate_cert_test.go
+++ b/opcua_plugin/core_generate_cert_test.go
@@ -335,6 +335,8 @@ var _ = Describe("GenerateCertWithMode Certificate Generation", func() {
 			Entry("invalid DNS hostname", "invalid_hostname.com", []string{}, []string{}, []string{}, true),
 			Entry("IPv4 address", "192.168.1.100", []string{"192.168.1.100"}, []string{}, []string{}, false),
 			Entry("mixed IP, URN, and DNS are separated correctly", "192.168.1.1, urn:test:app, server.local", []string{"192.168.1.1"}, []string{"server.local"}, []string{"urn:test:app"}, false),
+			Entry("empty strings are skipped", " , , ", []string{}, []string{}, []string{}, false),
+			Entry("whitespace is trimmed", " 192.168.1.1 , example.com ", []string{"192.168.1.1"}, []string{"example.com"}, []string{}, false),
 		)
 	})
 })

--- a/opcua_plugin/core_generate_cert_test.go
+++ b/opcua_plugin/core_generate_cert_test.go
@@ -330,7 +330,7 @@ var _ = Describe("GenerateCertWithMode Certificate Generation", func() {
 				}
 			},
 			Entry("valid DNS hostname", "example.com", []string{}, []string{"example.com"}, []string{}, false),
-			Entry("DNS hostname with upercase", "Example.COM", []string{}, []string{"example.com"}, []string{}, false),
+			Entry("DNS hostname with uppercase", "Example.COM", []string{}, []string{"example.com"}, []string{}, false),
 			Entry("hardcoded benthos-urn", "urn:benthos-umh:client-predefined-abc123", []string{}, []string{}, []string{"urn:benthos-umh:client-predefined-abc123"}, false),
 			Entry("invalid DNS hostname", "invalid_hostname.com", []string{}, []string{}, []string{}, true),
 			Entry("IPv4 address", "192.168.1.100", []string{"192.168.1.100"}, []string{}, []string{}, false),


### PR DESCRIPTION
## Description:

Fixes [ENG-3793](https://linear.app/united-manufacturing-hub/issue/ENG-3793/fix-urn-placement-in-opc-ua-certificate-san-ignition-rejects-certs)

This PR introduces:

- dns validation for x509 certificates within `opcua_plugin`
-> currently the hostname is hardcoded, but if there might be any potential changes in the future, it makes sense to validate the DNS, which then might land up in the certificate to ensure there are no issues for the OPC-server.