### PR TITLE
chore: rmv busybox from dockerfile (not needed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM management.umh.app/oci/library/golang:1.25.5 as build
+FROM management.umh.app/oci/library/golang:1.25.5 AS build
 
 RUN useradd -u 10001 benthos
 
@@ -47,7 +47,7 @@ RUN go build \
     -o benthos \
     cmd/benthos/main.go
 
-FROM management.umh.app/oci/library/busybox as app
+FROM scratch AS app
 
 WORKDIR /
 


### PR DESCRIPTION
## Description:

Due to aikido-issue, which complained about versioning of busybox in the `Dockerfile`, this gets removed as it is not needed at all here. On top of that correct the `as` statements to not get warnings.