### PR TITLE
fix(sparkplug): track sequence numbers per-NODE instead of per-device (ENG-4031)

### DIFF
--- a/sparkplug_plugin/node_sequence_test.go
+++ b/sparkplug_plugin/node_sequence_test.go
@@ -1,0 +1,159 @@
+//go:build !integration
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unit tests for Sparkplug B NODE-scoped sequence tracking (ENG-4031)
+//
+// Per Sparkplug B spec, sequence numbers are tracked at NODE scope, not device scope.
+// All message types from a node (NBIRTH, NDATA, DBIRTH, DDATA) share one sequence counter.
+//
+// BUG: Current implementation tracks per-deviceKey, causing false sequence gaps when
+// NDATA (deviceKey="group/node") and DDATA (deviceKey="group/node/device") interleave.
+//
+// This test file uses TDD approach:
+// 1. First test demonstrates correct behavior (when using unified nodeKey)
+// 2. Second test reproduces the bug (when using separate device keys)
+// 3. Third test validates the ExtractNodeKey helper function
+
+package sparkplug_plugin_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sparkplugplugin "github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin"
+)
+
+var _ = Describe("Sparkplug B Node-Scoped Sequence Tracking (ENG-4031)", func() {
+	// Per Sparkplug B spec, sequence numbers are tracked at NODE scope, not device scope.
+	// All message types from a node (NBIRTH, NDATA, DBIRTH, DDATA) share one sequence counter.
+
+	Context("when NDATA and DDATA messages interleave from same node", func() {
+		It("should track sequence at NODE level, not device level (customer scenario)", func() {
+			// Given: Customer's exact scenario
+			// NODE publishes: DDATA seq=15 -> NDATA seq=16 -> NDATA seq=17 -> DDATA seq=18
+			// Per spec, this is VALID - sequence is NODE-scoped
+
+			nodeStates := make(map[string]*sparkplugplugin.NodeState)
+
+			// For correct behavior, we need to use NODE key for ALL messages
+			nodeKey := "factory_a/line_1" // This is what we SHOULD use
+
+			// Process DDATA seq=15 (device-level message)
+			action1 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 15)
+			Expect(action1.NeedsRebirth).To(BeFalse(), "First message should not need rebirth")
+
+			// Process NDATA seq=16 (node-level message)
+			action2 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 16)
+			Expect(action2.NeedsRebirth).To(BeFalse(), "Sequential seq=16 should not need rebirth")
+
+			// Process NDATA seq=17 (node-level message)
+			action3 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 17)
+			Expect(action3.NeedsRebirth).To(BeFalse(), "Sequential seq=17 should not need rebirth")
+
+			// Process DDATA seq=18 (device-level message)
+			// THIS IS THE KEY TEST - should NOT trigger gap
+			action4 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 18)
+			Expect(action4.NeedsRebirth).To(BeFalse(),
+				"DDATA seq=18 should be valid - NDATA incremented node counter to 17")
+
+			// Verify final state
+			Expect(nodeStates[nodeKey].LastSeq).To(Equal(uint8(18)))
+		})
+
+		It("should FAIL with current per-device tracking (reproduces the bug)", func() {
+			// This test demonstrates the CURRENT BUGGY behavior
+			// Using separate keys for NDATA vs DDATA causes false sequence gaps
+
+			nodeStates := make(map[string]*sparkplugplugin.NodeState)
+
+			// CURRENT BUGGY BEHAVIOR: Different keys for different message types
+			ndataKey := "factory_a/line_1"            // Node-level messages
+			ddataKey := "factory_a/line_1/plc_device" // Device-level messages
+
+			// Process DDATA seq=15
+			action1 := sparkplugplugin.UpdateNodeState(nodeStates, ddataKey, 15)
+			Expect(action1.IsNewNode).To(BeTrue())
+
+			// Process NDATA seq=16 (different key!)
+			action2 := sparkplugplugin.UpdateNodeState(nodeStates, ndataKey, 16)
+			Expect(action2.IsNewNode).To(BeTrue()) // Creates NEW entry!
+
+			// Process NDATA seq=17
+			action3 := sparkplugplugin.UpdateNodeState(nodeStates, ndataKey, 17)
+			Expect(action3.NeedsRebirth).To(BeFalse())
+
+			// Process DDATA seq=18 - BUG: This triggers false gap!
+			action4 := sparkplugplugin.UpdateNodeState(nodeStates, ddataKey, 18)
+
+			// BUG MANIFESTATION: This returns NeedsRebirth=true because:
+			// - ddataKey state has LastSeq=15
+			// - Expected next: 16
+			// - Got: 18
+			// - Result: FALSE sequence gap detected!
+			Expect(action4.NeedsRebirth).To(BeTrue(),
+				"BUG: Per-device tracking causes false gap detection")
+
+			// Verify we have TWO separate state entries (the bug)
+			Expect(nodeStates).To(HaveLen(2), "BUG: Two separate states instead of one")
+		})
+
+		It("should still detect real sequence gaps across message types", func() {
+			// Real gap: seq=15 -> seq=16 -> seq=19 (missing 17, 18)
+			nodeStates := make(map[string]*sparkplugplugin.NodeState)
+			nodeKey := "test_group/edge_node"
+
+			// Process sequential messages
+			sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 15)
+			sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 16)
+
+			// Process seq=19 - should detect REAL gap (missing 17, 18)
+			action := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 19)
+			Expect(action.NeedsRebirth).To(BeTrue(), "Should detect real gap: expected 17, got 19")
+		})
+	})
+
+	Context("ExtractNodeKey helper function", func() {
+		It("should extract node key from device key", func() {
+			// Device-level key: "group/node/device" -> "group/node"
+			nodeKey := sparkplugplugin.ExtractNodeKey("factory_a/line_1/plc_device")
+			Expect(nodeKey).To(Equal("factory_a/line_1"))
+		})
+
+		It("should return same key for node-level key", func() {
+			// Node-level key: "group/node" -> "group/node"
+			nodeKey := sparkplugplugin.ExtractNodeKey("factory_a/line_1")
+			Expect(nodeKey).To(Equal("factory_a/line_1"))
+		})
+
+		It("should handle nested device IDs", func() {
+			// Nested device: "group/node/device/subdevice" -> "group/node"
+			nodeKey := sparkplugplugin.ExtractNodeKey("factory/line1/plc/module1")
+			Expect(nodeKey).To(Equal("factory/line1"))
+		})
+
+		It("should handle single segment gracefully", func() {
+			// Edge case: only one segment
+			nodeKey := sparkplugplugin.ExtractNodeKey("single")
+			Expect(nodeKey).To(Equal("single"))
+		})
+
+		It("should handle empty string gracefully", func() {
+			// Edge case: empty string
+			nodeKey := sparkplugplugin.ExtractNodeKey("")
+			Expect(nodeKey).To(Equal(""))
+		})
+	})
+})

--- a/sparkplug_plugin/node_sequence_test.go
+++ b/sparkplug_plugin/node_sequence_test.go
@@ -50,23 +50,31 @@ var _ = Describe("Sparkplug B Node-Scoped Sequence Tracking (ENG-4031)", func() 
 			// Process DDATA seq=15 (device-level message)
 			action1 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 15)
 			Expect(action1.NeedsRebirth).To(BeFalse(), "First message should not need rebirth")
+			Expect(action1.IsNewNode).To(BeTrue(), "First message creates new node")
+			Expect(nodeStates[nodeKey].IsOnline).To(BeTrue(), "New node should be online")
 
 			// Process NDATA seq=16 (node-level message)
 			action2 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 16)
 			Expect(action2.NeedsRebirth).To(BeFalse(), "Sequential seq=16 should not need rebirth")
+			Expect(nodeStates[nodeKey].IsOnline).To(BeTrue(), "Valid sequence keeps node online")
 
 			// Process NDATA seq=17 (node-level message)
 			action3 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 17)
 			Expect(action3.NeedsRebirth).To(BeFalse(), "Sequential seq=17 should not need rebirth")
+			Expect(nodeStates[nodeKey].IsOnline).To(BeTrue(), "Valid sequence keeps node online")
 
 			// Process DDATA seq=18 (device-level message)
 			// THIS IS THE KEY TEST - should NOT trigger gap
 			action4 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 18)
 			Expect(action4.NeedsRebirth).To(BeFalse(),
 				"DDATA seq=18 should be valid - NDATA incremented node counter to 17")
+			Expect(nodeStates[nodeKey].IsOnline).To(BeTrue(), "Valid sequence keeps node online")
 
-			// Verify final state
-			Expect(nodeStates[nodeKey].LastSeq).To(Equal(uint8(18)))
+			// Verify final state - all fields
+			state := nodeStates[nodeKey]
+			Expect(state.LastSeq).To(Equal(uint8(18)))
+			Expect(state.IsOnline).To(BeTrue(), "Node should remain online after valid sequence")
+			Expect(state.LastSeen).NotTo(BeZero(), "LastSeen should be set")
 		})
 
 		It("should still detect real sequence gaps across message types", func() {
@@ -75,94 +83,94 @@ var _ = Describe("Sparkplug B Node-Scoped Sequence Tracking (ENG-4031)", func() 
 			nodeKey := "test_group/edge_node"
 
 			// Process sequential messages
-			sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 15)
-			sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 16)
+			action1 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 15)
+			Expect(action1.IsNewNode).To(BeTrue())
+			Expect(nodeStates[nodeKey].IsOnline).To(BeTrue(), "New node should be online")
+
+			action2 := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 16)
+			Expect(action2.NeedsRebirth).To(BeFalse())
+			Expect(nodeStates[nodeKey].IsOnline).To(BeTrue(), "Valid sequence keeps node online")
 
 			// Process seq=19 - should detect REAL gap (missing 17, 18)
 			action := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 19)
 			Expect(action.NeedsRebirth).To(BeTrue(), "Should detect real gap: expected 17, got 19")
+			Expect(nodeStates[nodeKey].IsOnline).To(BeFalse(), "Sequence gap should mark node offline")
+			Expect(nodeStates[nodeKey].LastSeq).To(Equal(uint8(19)), "LastSeq should still update even with gap")
+		})
+
+		// Regression test: demonstrates the bug fixed by ENG-4031
+		It("should NOT produce false gaps when node key is used consistently (regression ENG-4031)", func() {
+			// This test demonstrates the FIX behavior
+			// BEFORE FIX: Device-scoped keys caused false sequence gaps
+			// AFTER FIX: Node-scoped keys prevent false gaps
+
+			// Scenario from customer: interleaved DDATA and NDATA messages
+			// DDATA seq=15 → NDATA seq=16 → NDATA seq=17 → DDATA seq=18
+			//
+			// BUG (device-scoped): DDATA used "group/node/device", NDATA used "group/node"
+			//   - After DDATA seq=15: deviceStates["group/node/device"].LastSeq = 15
+			//   - After NDATA seq=16: deviceStates["group/node"].LastSeq = 16 (different key!)
+			//   - After DDATA seq=18: compared to 15, not 17 → FALSE GAP
+			//
+			// FIX (node-scoped): All messages use "group/node" key
+			//   - All messages share one counter: 15 → 16 → 17 → 18 = valid
+
+			nodeStates := make(map[string]*sparkplugplugin.NodeState)
+
+			// Using TopicInfo to derive keys ensures consistency
+			ddataTopicInfo := &sparkplugplugin.TopicInfo{
+				Group:    "factory",
+				EdgeNode: "plc_line1",
+				Device:   "motor_01", // Device-level message
+			}
+			ndataTopicInfo := &sparkplugplugin.TopicInfo{
+				Group:    "factory",
+				EdgeNode: "plc_line1",
+				// No device - node-level message
+			}
+
+			// THE KEY INSIGHT: Both use NodeKey(), not DeviceKey()
+			// This ensures all messages from same node share sequence state
+			nodeKey := ddataTopicInfo.NodeKey() // "factory/plc_line1"
+			Expect(nodeKey).To(Equal(ndataTopicInfo.NodeKey()), "Both should derive same node key")
+
+			// Simulate customer scenario with node-scoped keys (FIXED behavior)
+			sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 15) // DDATA
+			sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 16) // NDATA
+			sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 17) // NDATA
+
+			// Final DDATA - with node-scoped keys, this is valid (17 → 18)
+			action := sparkplugplugin.UpdateNodeState(nodeStates, nodeKey, 18)
+			Expect(action.NeedsRebirth).To(BeFalse(),
+				"REGRESSION CHECK: node-scoped keys prevent false gap (was bug with device-scoped)")
+			Expect(nodeStates[nodeKey].IsOnline).To(BeTrue(),
+				"Node should remain online when using correct node-scoped keys")
 		})
 	})
 
-	Context("TopicInfo.NodeKey() method", func() {
-		It("should return node key from TopicInfo with device", func() {
-			// Device-level: group + node + device -> "group/node"
-			ti := &sparkplugplugin.TopicInfo{
-				Group:    "factory_a",
-				EdgeNode: "line_1",
-				Device:   "plc_device",
-			}
-			Expect(ti.NodeKey()).To(Equal("factory_a/line_1"))
-		})
+	// Table-driven tests for TopicInfo key methods
+	// Replaces 10 granular tests with one comprehensive table
+	DescribeTable("TopicInfo.NodeKey() and DeviceKey() extraction",
+		func(ti *sparkplugplugin.TopicInfo, expectedNodeKey, expectedDeviceKey string) {
+			Expect(ti.NodeKey()).To(Equal(expectedNodeKey))
+			Expect(ti.DeviceKey()).To(Equal(expectedDeviceKey))
+		},
+		Entry("with device", &sparkplugplugin.TopicInfo{
+			Group: "factory_a", EdgeNode: "line_1", Device: "plc_1",
+		}, "factory_a/line_1", "factory_a/line_1/plc_1"),
 
-		It("should return node key from TopicInfo without device", func() {
-			// Node-level: group + node -> "group/node"
-			ti := &sparkplugplugin.TopicInfo{
-				Group:    "factory_a",
-				EdgeNode: "line_1",
-			}
-			Expect(ti.NodeKey()).To(Equal("factory_a/line_1"))
-		})
+		Entry("without device", &sparkplugplugin.TopicInfo{
+			Group: "factory_a", EdgeNode: "line_1",
+		}, "factory_a/line_1", "factory_a/line_1"),
 
-		It("should return empty string for nil TopicInfo", func() {
-			var ti *sparkplugplugin.TopicInfo
-			Expect(ti.NodeKey()).To(Equal(""))
-		})
+		Entry("nil TopicInfo", nil, "", ""),
 
-		It("should return empty string for empty Group", func() {
-			ti := &sparkplugplugin.TopicInfo{
-				EdgeNode: "line_1",
-			}
-			Expect(ti.NodeKey()).To(Equal(""))
-		})
+		Entry("empty Group", &sparkplugplugin.TopicInfo{
+			EdgeNode: "line_1", Device: "plc_1",
+		}, "", ""),
 
-		It("should return empty string for empty EdgeNode", func() {
-			ti := &sparkplugplugin.TopicInfo{
-				Group: "factory_a",
-			}
-			Expect(ti.NodeKey()).To(Equal(""))
-		})
-	})
-
-	Context("TopicInfo.DeviceKey() method", func() {
-		It("should return device key with device", func() {
-			// Device-level: group + node + device -> "group/node/device"
-			ti := &sparkplugplugin.TopicInfo{
-				Group:    "factory_a",
-				EdgeNode: "line_1",
-				Device:   "plc_1",
-			}
-			Expect(ti.DeviceKey()).To(Equal("factory_a/line_1/plc_1"))
-		})
-
-		It("should return node key without device", func() {
-			// Node-level: group + node -> "group/node"
-			ti := &sparkplugplugin.TopicInfo{
-				Group:    "factory_a",
-				EdgeNode: "line_1",
-			}
-			Expect(ti.DeviceKey()).To(Equal("factory_a/line_1"))
-		})
-
-		It("should return empty string for nil TopicInfo", func() {
-			var ti *sparkplugplugin.TopicInfo
-			Expect(ti.DeviceKey()).To(Equal(""))
-		})
-
-		It("should return empty string for empty Group", func() {
-			ti := &sparkplugplugin.TopicInfo{
-				EdgeNode: "line_1",
-				Device:   "plc_1",
-			}
-			Expect(ti.DeviceKey()).To(Equal(""))
-		})
-
-		It("should return empty string for empty EdgeNode", func() {
-			ti := &sparkplugplugin.TopicInfo{
-				Group:  "factory_a",
-				Device: "plc_1",
-			}
-			Expect(ti.DeviceKey()).To(Equal(""))
-		})
-	})
+		Entry("empty EdgeNode", &sparkplugplugin.TopicInfo{
+			Group: "factory_a", Device: "plc_1",
+		}, "", ""),
+	)
 })

--- a/sparkplug_plugin/node_sequence_test.go
+++ b/sparkplug_plugin/node_sequence_test.go
@@ -164,4 +164,46 @@ var _ = Describe("Sparkplug B Node-Scoped Sequence Tracking (ENG-4031)", func() 
 			Expect(ti.NodeKey()).To(Equal(""))
 		})
 	})
+
+	Context("TopicInfo.DeviceKey() method", func() {
+		It("should return device key with device", func() {
+			// Device-level: group + node + device -> "group/node/device"
+			ti := &sparkplugplugin.TopicInfo{
+				Group:    "factory_a",
+				EdgeNode: "line_1",
+				Device:   "plc_1",
+			}
+			Expect(ti.DeviceKey()).To(Equal("factory_a/line_1/plc_1"))
+		})
+
+		It("should return node key without device", func() {
+			// Node-level: group + node -> "group/node"
+			ti := &sparkplugplugin.TopicInfo{
+				Group:    "factory_a",
+				EdgeNode: "line_1",
+			}
+			Expect(ti.DeviceKey()).To(Equal("factory_a/line_1"))
+		})
+
+		It("should return empty string for nil TopicInfo", func() {
+			var ti *sparkplugplugin.TopicInfo
+			Expect(ti.DeviceKey()).To(Equal(""))
+		})
+
+		It("should return empty string for empty Group", func() {
+			ti := &sparkplugplugin.TopicInfo{
+				EdgeNode: "line_1",
+				Device:   "plc_1",
+			}
+			Expect(ti.DeviceKey()).To(Equal(""))
+		})
+
+		It("should return empty string for empty EdgeNode", func() {
+			ti := &sparkplugplugin.TopicInfo{
+				Group:  "factory_a",
+				Device: "plc_1",
+			}
+			Expect(ti.DeviceKey()).To(Equal(""))
+		})
+	})
 })

--- a/sparkplug_plugin/sequence_gap_validation_test.go
+++ b/sparkplug_plugin/sequence_gap_validation_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Sequence Gap Validator - Message Drop Investigation (ENG-3720)
 			// 1. processDataMessage is not exposed by test wrapper
 			// 2. The code path shows createSplitMessages is ALWAYS called after processDataMessage
 			// 3. There is NO conditional logic that prevents batch creation on validation failure
-			batch := wrapper.CreateSplitMessages(payload, "NDATA", "test/edge1/device1", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
+			batch := wrapper.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
 
 			// Then: Message should be processed (NOT DROPPED)
 			Expect(batch).NotTo(BeNil(), "Batch should be created despite sequence gap")
@@ -154,7 +154,7 @@ var _ = Describe("Sequence Gap Validator - Message Drop Investigation (ENG-3720)
 			}
 
 			// When: Processing the message
-			batch := wrapper.CreateSplitMessages(payload, "NDATA", "test/edge1/device1", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
+			batch := wrapper.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
 
 			// Then: Message is processed normally
 			Expect(batch).To(HaveLen(1), "Out-of-order message should still be processed")
@@ -190,7 +190,7 @@ var _ = Describe("Sequence Gap Validator - Message Drop Investigation (ENG-3720)
 			}
 
 			// When: Processing sequence=0 (after presumed sequence=255)
-			batch := wrapper.CreateSplitMessages(payload, "NDATA", "test/edge1/device1", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
+			batch := wrapper.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
 
 			// Then: Message is processed
 			Expect(batch).To(HaveLen(1), "Wrapped sequence should be processed")

--- a/sparkplug_plugin/sequence_implicit_test.go
+++ b/sparkplug_plugin/sequence_implicit_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 			}
 
 			// When: Processing NBIRTH
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", payload, topicInfo)
+			input.ProcessBirthMessage("NBIRTH", payload, topicInfo)
 
 			// Then: Node state should be created with seq=0
 			state := input.GetNodeState(topicInfo.DeviceKey())
@@ -157,7 +157,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 			}
 
 			// When: Processing DBIRTH
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "DBIRTH", payload, topicInfo)
+			input.ProcessBirthMessage("DBIRTH", payload, topicInfo)
 
 			// Then: Device state should be created with seq=0
 			state := input.GetNodeState(topicInfo.DeviceKey())
@@ -184,7 +184,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("temperature"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeDouble), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 23.5}},
 				},
 			}
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
+			input.ProcessBirthMessage("NBIRTH", birthPayload, topicInfo)
 
 			// When: NDATA with explicit seq=1 (expected next sequence)
 			seq1 := uint64(1)
@@ -195,7 +195,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("temperature"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeDouble), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 24.1}},
 				},
 			}
-			input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", dataPayload, topicInfo)
+			input.ProcessDataMessage("NDATA", dataPayload, topicInfo)
 
 			// Then: Sequence validation should pass (0 → 1 is valid)
 			state := input.GetNodeState(topicInfo.DeviceKey())
@@ -219,7 +219,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("temperature"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeDouble), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 23.5}},
 				},
 			}
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
+			input.ProcessBirthMessage("NBIRTH", birthPayload, topicInfo)
 
 			// When: NDATA with seq=2 (skips expected seq=1)
 			seq2 := uint64(2)
@@ -230,7 +230,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("temperature"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeDouble), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 24.1}},
 				},
 			}
-			input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", dataPayload, topicInfo)
+			input.ProcessDataMessage("NDATA", dataPayload, topicInfo)
 
 			// Then: Sequence validation should fail (0 → 2 is invalid, expected 1)
 			state := input.GetNodeState(topicInfo.DeviceKey())
@@ -258,7 +258,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("sensor1"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt64), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "DBIRTH", birth1, topicInfo)
+			input.ProcessBirthMessage("DBIRTH", birth1, topicInfo)
 
 			state := input.GetNodeState(topicInfo.DeviceKey())
 			Expect(state.LastSeq).To(Equal(uint8(0)), "first DBIRTH should set seq to 0")
@@ -272,7 +272,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("sensor1"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt64), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 101}},
 				},
 			}
-			input.ProcessDataMessage(topicInfo.DeviceKey(), "DDATA", data1, topicInfo)
+			input.ProcessDataMessage("DDATA", data1, topicInfo)
 
 			state = input.GetNodeState(topicInfo.DeviceKey())
 			Expect(state.LastSeq).To(Equal(uint8(1)), "DDATA should advance to seq=1")
@@ -287,7 +287,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("sensor1"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt64), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 102}},
 				},
 			}
-			input.ProcessDataMessage(topicInfo.DeviceKey(), "DDATA", data2, topicInfo)
+			input.ProcessDataMessage("DDATA", data2, topicInfo)
 
 			state = input.GetNodeState(topicInfo.DeviceKey())
 			Expect(state.LastSeq).To(Equal(uint8(2)), "DDATA should advance to seq=2")
@@ -300,7 +300,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("sensor1"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt64), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "DBIRTH", birth2, topicInfo)
+			input.ProcessBirthMessage("DBIRTH", birth2, topicInfo)
 
 			state = input.GetNodeState(topicInfo.DeviceKey())
 			Expect(state.LastSeq).To(Equal(uint8(0)), "rebirth should reset seq to 0")
@@ -315,7 +315,7 @@ var _ = Describe("Integration Tests - seq=0 implicit behavior in real messages",
 					{Name: stringPtr("sensor1"), Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt64), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 103}},
 				},
 			}
-			input.ProcessDataMessage(topicInfo.DeviceKey(), "DDATA", data3, topicInfo)
+			input.ProcessDataMessage("DDATA", data3, topicInfo)
 
 			state = input.GetNodeState(topicInfo.DeviceKey())
 			Expect(state.LastSeq).To(Equal(uint8(1)), "sequence should advance from 0 to 1 after rebirth")

--- a/sparkplug_plugin/sparkplug_b_core.go
+++ b/sparkplug_plugin/sparkplug_b_core.go
@@ -155,6 +155,28 @@ func SpbDeviceKey(gid string, nid string, did string) string {
 	return gid + "/" + nid + "/" + did
 }
 
+// ExtractNodeKey returns the node-level key (group/edgeNode) from a deviceKey.
+// Per Sparkplug B specification, sequence numbers are tracked at NODE scope,
+// not device scope. All message types from a node (NBIRTH, NDATA, DBIRTH, DDATA)
+// share one sequence counter that increments across all message types.
+//
+// Examples:
+//   - "factory/line1/device" -> "factory/line1" (device-level -> node-level)
+//   - "factory/line1" -> "factory/line1" (already node-level)
+//   - "single" -> "single" (malformed, return as-is)
+//
+// ENG-4031: This function enables correct per-node sequence tracking.
+func ExtractNodeKey(deviceKey string) string {
+	if deviceKey == "" {
+		return ""
+	}
+	parts := strings.Split(deviceKey, "/")
+	if len(parts) >= 2 {
+		return parts[0] + "/" + parts[1] // group/edgeNode
+	}
+	return deviceKey // Fallback for malformed keys
+}
+
 // TopicParser provides functions for parsing and constructing Sparkplug B topics.
 type TopicParser struct{}
 

--- a/sparkplug_plugin/sparkplug_b_core.go
+++ b/sparkplug_plugin/sparkplug_b_core.go
@@ -50,6 +50,19 @@ func (ti *TopicInfo) NodeKey() string {
 	return ti.Group + "/" + ti.EdgeNode
 }
 
+// DeviceKey returns the full device key (group/edgeNode or group/edgeNode/device).
+// For node-level messages (NBIRTH, NDEATH, NDATA), Device is empty and this returns group/edgeNode.
+// For device-level messages (DBIRTH, DDEATH, DDATA), this returns group/edgeNode/device.
+func (ti *TopicInfo) DeviceKey() string {
+	if ti == nil || ti.Group == "" || ti.EdgeNode == "" {
+		return ""
+	}
+	if ti.Device == "" {
+		return ti.Group + "/" + ti.EdgeNode
+	}
+	return ti.Group + "/" + ti.EdgeNode + "/" + ti.Device
+}
+
 // NodeState tracks the state of a Sparkplug node/device for sequence management.
 type NodeState struct {
 	LastSeen time.Time

--- a/sparkplug_plugin/sparkplug_b_death_validation_test.go
+++ b/sparkplug_plugin/sparkplug_b_death_validation_test.go
@@ -25,6 +25,9 @@ import (
 )
 
 var _ = Describe("NDEATH bdSeq Validation", func() {
+	// NOTE: These tests use SetNodeBdSeq() for state setup because ProcessBirthMessage()
+	// has different bdSeq handling. This is a known limitation - full BIRTH → DEATH
+	// integration testing should be done separately. See PR #257 analysis for details.
 	Context("when processing NDEATH with bdSeq", func() {
 		It("should accept NDEATH with matching bdSeq", func() {
 			wrapper := sparkplugplugin.NewSparkplugInputForTesting()

--- a/sparkplug_plugin/sparkplug_b_death_validation_test.go
+++ b/sparkplug_plugin/sparkplug_b_death_validation_test.go
@@ -49,7 +49,7 @@ var _ = Describe("NDEATH bdSeq Validation", func() {
 			}
 
 			// Process NDEATH
-			wrapper.ProcessDeathMessage(topicInfo.DeviceKey(), "NDEATH", payload, topicInfo)
+			wrapper.ProcessDeathMessage("NDEATH", payload, topicInfo)
 
 			// Verify state is updated (node marked offline)
 			state := wrapper.GetNodeState(topicInfo.DeviceKey())
@@ -80,7 +80,7 @@ var _ = Describe("NDEATH bdSeq Validation", func() {
 			}
 
 			// Process NDEATH
-			wrapper.ProcessDeathMessage(topicInfo.DeviceKey(), "NDEATH", payload, topicInfo)
+			wrapper.ProcessDeathMessage("NDEATH", payload, topicInfo)
 
 			// Verify state is NOT updated (stale NDEATH ignored)
 			state := wrapper.GetNodeState(topicInfo.DeviceKey())
@@ -104,7 +104,7 @@ var _ = Describe("NDEATH bdSeq Validation", func() {
 			}
 
 			// Process NDEATH
-			wrapper.ProcessDeathMessage(topicInfo.DeviceKey(), "NDEATH", payload, topicInfo)
+			wrapper.ProcessDeathMessage("NDEATH", payload, topicInfo)
 
 			// Verify state is updated (backwards compatibility)
 			state := wrapper.GetNodeState(topicInfo.DeviceKey())
@@ -129,7 +129,7 @@ var _ = Describe("NDEATH bdSeq Validation", func() {
 			}
 
 			// Process DDEATH
-			wrapper.ProcessDeathMessage(topicInfo.DeviceKey(), "DDEATH", payload, topicInfo)
+			wrapper.ProcessDeathMessage("DDEATH", payload, topicInfo)
 
 			// Verify state is updated
 			state := wrapper.GetNodeState(topicInfo.DeviceKey())

--- a/sparkplug_plugin/sparkplug_b_death_validation_test.go
+++ b/sparkplug_plugin/sparkplug_b_death_validation_test.go
@@ -17,12 +17,30 @@
 package sparkplug_plugin_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	sparkplugplugin "github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin"
 	"github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin/sparkplugb"
 )
+
+// makeTopicInfoDeath constructs a TopicInfo from a deviceKey string (group/node/device format)
+func makeTopicInfoDeath(deviceKey string) *sparkplugplugin.TopicInfo {
+	parts := strings.Split(deviceKey, "/")
+	if len(parts) < 2 {
+		return &sparkplugplugin.TopicInfo{}
+	}
+	ti := &sparkplugplugin.TopicInfo{
+		Group:    parts[0],
+		EdgeNode: parts[1],
+	}
+	if len(parts) > 2 {
+		ti.Device = parts[2]
+	}
+	return ti
+}
 
 var _ = Describe("NDEATH bdSeq Validation", func() {
 	Context("when processing NDEATH with bdSeq", func() {
@@ -46,7 +64,7 @@ var _ = Describe("NDEATH bdSeq Validation", func() {
 			}
 
 			// Process NDEATH
-			wrapper.ProcessDeathMessage(deviceKey, "NDEATH", payload)
+			wrapper.ProcessDeathMessage(deviceKey, "NDEATH", payload, makeTopicInfoDeath(deviceKey))
 
 			// Verify state is updated (node marked offline)
 			state := wrapper.GetNodeState(deviceKey)
@@ -74,7 +92,7 @@ var _ = Describe("NDEATH bdSeq Validation", func() {
 			}
 
 			// Process NDEATH
-			wrapper.ProcessDeathMessage(deviceKey, "NDEATH", payload)
+			wrapper.ProcessDeathMessage(deviceKey, "NDEATH", payload, makeTopicInfoDeath(deviceKey))
 
 			// Verify state is NOT updated (stale NDEATH ignored)
 			state := wrapper.GetNodeState(deviceKey)
@@ -95,7 +113,7 @@ var _ = Describe("NDEATH bdSeq Validation", func() {
 			}
 
 			// Process NDEATH
-			wrapper.ProcessDeathMessage(deviceKey, "NDEATH", payload)
+			wrapper.ProcessDeathMessage(deviceKey, "NDEATH", payload, makeTopicInfoDeath(deviceKey))
 
 			// Verify state is updated (backwards compatibility)
 			state := wrapper.GetNodeState(deviceKey)
@@ -116,7 +134,7 @@ var _ = Describe("NDEATH bdSeq Validation", func() {
 			}
 
 			// Process DDEATH
-			wrapper.ProcessDeathMessage(deviceKey, "DDEATH", payload)
+			wrapper.ProcessDeathMessage(deviceKey, "DDEATH", payload, makeTopicInfoDeath(deviceKey))
 
 			// Verify state is updated
 			state := wrapper.GetNodeState(deviceKey)

--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -555,19 +555,19 @@ func (s *sparkplugInput) processSparkplugMessage(mqttMsg mqttMessage) (service.M
 	s.logger.Debugf("🔄 processSparkplugMessage: starting to process topic %s", mqttMsg.topic)
 
 	// Parse topic to extract Sparkplug components
-	msgType, deviceKey, topicInfo := s.parseSparkplugTopicDetailed(mqttMsg.topic)
+	msgType, topicInfo := s.parseSparkplugTopicDetailed(mqttMsg.topic)
 	if msgType == "" {
 		s.logger.Debugf("Ignoring non-Sparkplug topic: %s", mqttMsg.topic)
 		return nil, nil
 	}
 
-	s.logger.Debugf("📊 processSparkplugMessage: parsed topic - msgType=%s, deviceKey=%s", msgType, deviceKey)
+	s.logger.Debugf("📊 processSparkplugMessage: parsed topic - msgType=%s, deviceKey=%s", msgType, topicInfo.DeviceKey())
 
 	// **FIX: Filter STATE messages from protobuf parsing**
 	// STATE messages contain plain text "ONLINE"/"OFFLINE", not protobuf payloads
 	if msgType == "STATE" {
 		s.logger.Debugf("🏛️ processSparkplugMessage: processing STATE message (payload: %s)", string(mqttMsg.payload))
-		return s.processStateMessage(deviceKey, msgType, topicInfo, mqttMsg.topic, string(mqttMsg.payload))
+		return s.processStateMessage(msgType, topicInfo, mqttMsg.topic, string(mqttMsg.payload))
 	}
 
 	// DEBUG: Log before protobuf unmarshal as recommended in the plan
@@ -596,28 +596,28 @@ func (s *sparkplugInput) processSparkplugMessage(mqttMsg mqttMessage) (service.M
 
 	if isBirthMessage {
 		s.logger.Debugf("🎂 processSparkplugMessage: processing BIRTH message")
-		s.processBirthMessage(deviceKey, msgType, &payload, topicInfo)
+		s.processBirthMessage(msgType, &payload, topicInfo)
 		s.birthsProcessed.Incr(1)
 
 		// Always process birth messages (they contain valuable current state)
 		// Always split metrics for UMH-Core format (one metric per message)
-		batch = s.createSplitMessages(&payload, msgType, deviceKey, topicInfo, mqttMsg.topic)
+		batch = s.createSplitMessages(&payload, msgType, topicInfo, mqttMsg.topic)
 	} else if isDataMessage {
 		s.logger.Debugf("📈 processSparkplugMessage: processing DATA message")
-		s.processDataMessage(deviceKey, msgType, &payload, topicInfo)
+		s.processDataMessage(msgType, &payload, topicInfo)
 
 		// Always split metrics for UMH-Core format (one metric per message)
-		batch = s.createSplitMessages(&payload, msgType, deviceKey, topicInfo, mqttMsg.topic)
+		batch = s.createSplitMessages(&payload, msgType, topicInfo, mqttMsg.topic)
 	} else if isDeathMessage {
 		s.logger.Debugf("💀 processSparkplugMessage: processing DEATH message")
-		s.processDeathMessage(deviceKey, msgType, &payload, topicInfo)
+		s.processDeathMessage(msgType, &payload, topicInfo)
 		s.deathsProcessed.Incr(1)
 
 		// Create status event message for death
-		batch = s.createDeathEventMessage(msgType, deviceKey, topicInfo, mqttMsg.topic)
+		batch = s.createDeathEventMessage(msgType, topicInfo, mqttMsg.topic)
 	} else if isCommandMessage {
 		s.logger.Debugf("⚡ processSparkplugMessage: processing COMMAND message")
-		batch = s.processCommandMessage(deviceKey, msgType, &payload, topicInfo, mqttMsg.topic)
+		batch = s.processCommandMessage(msgType, &payload, topicInfo, mqttMsg.topic)
 	}
 
 	// DEBUG: Log when pushing to Benthos pipeline as recommended in the plan
@@ -637,7 +637,7 @@ func (s *sparkplugInput) processSparkplugMessage(mqttMsg mqttMessage) (service.M
 //
 // Key behavior: Caches alias → metric name mappings from BIRTH certificates
 // for use in subsequent DATA message resolution.
-func (s *sparkplugInput) processBirthMessage(deviceKey string, msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
+func (s *sparkplugInput) processBirthMessage(msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 
@@ -670,10 +670,10 @@ func (s *sparkplugInput) processBirthMessage(deviceKey string, msgType string, p
 	}
 
 	// Cache aliases from birth message
-	// NOTE: Alias caching still uses deviceKey - aliases ARE per-device from DBIRTH
-	s.cacheAliases(deviceKey, payload.Metrics)
+	// NOTE: Alias caching uses deviceKey - aliases ARE per-device from DBIRTH
+	s.cacheAliases(topicInfo.DeviceKey(), payload.Metrics)
 
-	s.logger.Debugf("Processed %s for device %s (node: %s)", msgType, deviceKey, nodeKey)
+	s.logger.Debugf("Processed %s for device %s (node: %s)", msgType, topicInfo.DeviceKey(), nodeKey)
 }
 
 // processDataMessage handles DATA messages (NDATA/DDATA) with sequence validation.
@@ -699,7 +699,7 @@ func (s *sparkplugInput) processBirthMessage(deviceKey string, msgType string, p
 // - All state access protected by stateMu lock
 // - No I/O operations performed while holding lock
 // - Deterministic behavior ensured by UpdateNodeState pure function
-func (s *sparkplugInput) processDataMessage(deviceKey string, msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
+func (s *sparkplugInput) processDataMessage(msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
 	s.stateMu.Lock()
 
 	currentSeq := GetSequenceNumber(payload)
@@ -718,14 +718,14 @@ func (s *sparkplugInput) processDataMessage(deviceKey string, msgType string, pa
 	action := UpdateNodeState(s.nodeStates, nodeKey, currentSeq)
 
 	// Resolve aliases while holding lock (safe operation)
-	// NOTE: Alias resolution still uses deviceKey - aliases ARE per-device from DBIRTH
-	s.resolveAliases(deviceKey, payload.Metrics)
+	// NOTE: Alias resolution uses deviceKey - aliases ARE per-device from DBIRTH
+	s.resolveAliases(topicInfo.DeviceKey(), payload.Metrics)
 
 	s.stateMu.Unlock()
 
 	// Logging after lock release to minimize lock hold time
 	if action.IsNewNode {
-		s.logger.Infof("Discovered new node from %s message: %s (node: %s)", msgType, deviceKey, nodeKey)
+		s.logger.Infof("Discovered new node from %s message: %s (node: %s)", msgType, topicInfo.DeviceKey(), nodeKey)
 	}
 
 	if action.NeedsRebirth {
@@ -740,7 +740,7 @@ func (s *sparkplugInput) processDataMessage(deviceKey string, msgType string, pa
 	}
 }
 
-func (s *sparkplugInput) processDeathMessage(deviceKey string, msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
+func (s *sparkplugInput) processDeathMessage(msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 
@@ -754,7 +754,7 @@ func (s *sparkplugInput) processDeathMessage(deviceKey string, msgType string, p
 			IsOnline: false,
 			LastSeen: time.Now(),
 		}
-		s.logger.Debugf("Processed %s for unknown device %s (node: %s, created state)", msgType, deviceKey, nodeKey)
+		s.logger.Debugf("Processed %s for unknown device %s (node: %s, created state)", msgType, topicInfo.DeviceKey(), nodeKey)
 		return
 	}
 
@@ -791,11 +791,11 @@ func (s *sparkplugInput) processDeathMessage(deviceKey string, msgType string, p
 	state.IsOnline = false
 	state.LastSeen = time.Now()
 
-	s.logger.Debugf("Processed %s for device %s (node: %s)", msgType, deviceKey, nodeKey)
+	s.logger.Debugf("Processed %s for device %s (node: %s)", msgType, topicInfo.DeviceKey(), nodeKey)
 }
 
-func (s *sparkplugInput) processCommandMessage(deviceKey string, msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo, originalTopic string) service.MessageBatch {
-	s.logger.Debugf("⚡ processCommandMessage: processing %s for device %s with %d metrics", msgType, deviceKey, len(payload.Metrics))
+func (s *sparkplugInput) processCommandMessage(msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo, originalTopic string) service.MessageBatch {
+	s.logger.Debugf("⚡ processCommandMessage: processing %s for device %s with %d metrics", msgType, topicInfo.DeviceKey(), len(payload.Metrics))
 
 	// ENG-4031: Use node-level key for state tracking consistency
 	nodeKey := topicInfo.NodeKey()
@@ -816,7 +816,7 @@ func (s *sparkplugInput) processCommandMessage(deviceKey string, msgType string,
 	for _, metric := range payload.Metrics {
 		if metric.Name != nil && *metric.Name == "Node Control/Rebirth" {
 			if metric.GetBooleanValue() {
-				s.logger.Infof("🔄 Rebirth request received for device %s (node: %s)", deviceKey, nodeKey)
+				s.logger.Infof("🔄 Rebirth request received for device %s (node: %s)", topicInfo.DeviceKey(), nodeKey)
 				// Handle rebirth logic here if needed for edge nodes
 				// For primary hosts, this is typically just logged
 			}
@@ -824,17 +824,18 @@ func (s *sparkplugInput) processCommandMessage(deviceKey string, msgType string,
 	}
 
 	// Resolve aliases in command message (same as data messages)
-	// NOTE: Alias resolution still uses deviceKey - aliases ARE per-device
-	s.resolveAliases(deviceKey, payload.Metrics)
+	// NOTE: Alias resolution uses deviceKey - aliases ARE per-device
+	s.resolveAliases(topicInfo.DeviceKey(), payload.Metrics)
 
 	// Create batch from command metrics - always split for UMH-Core format
-	batch := s.createSplitMessages(payload, msgType, deviceKey, topicInfo, originalTopic)
+	batch := s.createSplitMessages(payload, msgType, topicInfo, originalTopic)
 
 	s.logger.Debugf("✅ processCommandMessage: created batch with %d messages for %s", len(batch), msgType)
 	return batch
 }
 
-func (s *sparkplugInput) processStateMessage(deviceKey string, msgType string, topicInfo *TopicInfo, originalTopic string, statePayload string) (service.MessageBatch, error) {
+func (s *sparkplugInput) processStateMessage(msgType string, topicInfo *TopicInfo, originalTopic string, statePayload string) (service.MessageBatch, error) {
+	deviceKey := topicInfo.DeviceKey()
 	s.logger.Debugf("🏛️ processStateMessage: processing STATE message for device %s, state: %s", deviceKey, statePayload)
 
 	s.stateMu.Lock()
@@ -977,13 +978,13 @@ func (s *sparkplugInput) resolveAliases(deviceKey string, metrics []*sparkplugb.
 	}
 }
 
-func (s *sparkplugInput) parseSparkplugTopicDetailed(topic string) (string, string, *TopicInfo) {
+func (s *sparkplugInput) parseSparkplugTopicDetailed(topic string) (string, *TopicInfo) {
 	// Use core component instead of processor
 	return s.topicParser.ParseSparkplugTopicDetailed(topic)
 }
 
 // Message creation methods
-func (s *sparkplugInput) createSplitMessages(payload *sparkplugb.Payload, msgType string, deviceKey string, topicInfo *TopicInfo, originalTopic string) service.MessageBatch {
+func (s *sparkplugInput) createSplitMessages(payload *sparkplugb.Payload, msgType string, topicInfo *TopicInfo, originalTopic string) service.MessageBatch {
 	var batch service.MessageBatch
 
 	for i, metric := range payload.Metrics {
@@ -991,7 +992,7 @@ func (s *sparkplugInput) createSplitMessages(payload *sparkplugb.Payload, msgTyp
 			continue
 		}
 
-		msg := s.createMessageFromMetric(metric, payload, msgType, deviceKey, topicInfo, originalTopic, i, len(payload.Metrics))
+		msg := s.createMessageFromMetric(metric, payload, msgType, topicInfo, originalTopic, i, len(payload.Metrics))
 		if msg != nil {
 			batch = append(batch, msg)
 		}
@@ -1000,7 +1001,7 @@ func (s *sparkplugInput) createSplitMessages(payload *sparkplugb.Payload, msgTyp
 	return batch
 }
 
-func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metric, payload *sparkplugb.Payload, msgType string, deviceKey string, topicInfo *TopicInfo, originalTopic string, metricIndex int, totalMetrics int) *service.Message {
+func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metric, payload *sparkplugb.Payload, msgType string, topicInfo *TopicInfo, originalTopic string, metricIndex int, totalMetrics int) *service.Message {
 	// Extract metric value as JSON (always preserve Sparkplug B format)
 	value := s.extractMetricValue(metric)
 	if value == nil {
@@ -1016,7 +1017,7 @@ func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metr
 		msg.MetaSet("spb_device_id", topicInfo.Device)
 	}
 	msg.MetaSet("spb_message_type", msgType)
-	msg.MetaSet("spb_device_key", deviceKey)
+	msg.MetaSet("spb_device_key", topicInfo.DeviceKey())
 	msg.MetaSet("spb_topic", originalTopic)
 
 	// Add pre-sanitized versions for easier processing
@@ -1025,7 +1026,7 @@ func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metr
 	if topicInfo.Device != "" {
 		msg.MetaSet("spb_device_id_sanitized", s.sanitizeForTopic(topicInfo.Device))
 	}
-	msg.MetaSet("spb_device_key_sanitized", s.sanitizeForTopic(deviceKey))
+	msg.MetaSet("spb_device_key_sanitized", s.sanitizeForTopic(topicInfo.DeviceKey()))
 
 	// Set Sparkplug B metric name
 	metricName := "unknown_metric"
@@ -1067,8 +1068,9 @@ func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metr
 	}
 
 	// Add birth-death sequence if available from node state
+	// ENG-4031: Use nodeKey for state lookup - nodeStates is keyed by node, not device
 	s.stateMu.RLock()
-	if state, exists := s.nodeStates[deviceKey]; exists {
+	if state, exists := s.nodeStates[topicInfo.NodeKey()]; exists {
 		msg.MetaSet("spb_bdseq", fmt.Sprintf("%d", state.BdSeq))
 	}
 	s.stateMu.RUnlock()
@@ -1079,10 +1081,10 @@ func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metr
 	return msg
 }
 
-func (s *sparkplugInput) createDeathEventMessage(msgType string, deviceKey string, topicInfo *TopicInfo, originalTopic string) service.MessageBatch {
+func (s *sparkplugInput) createDeathEventMessage(msgType string, topicInfo *TopicInfo, originalTopic string) service.MessageBatch {
 	event := map[string]interface{}{
 		"event":        "DeviceOffline",
-		"device_key":   deviceKey,
+		"device_key":   topicInfo.DeviceKey(),
 		"group_id":     topicInfo.Group,
 		"edge_node_id": topicInfo.EdgeNode,
 		"timestamp_ms": time.Now().UnixMilli(),
@@ -1102,7 +1104,7 @@ func (s *sparkplugInput) createDeathEventMessage(msgType string, deviceKey strin
 
 	// Set Sparkplug B standard metadata for death events
 	msg.MetaSet("spb_message_type", msgType)
-	msg.MetaSet("spb_device_key", deviceKey)
+	msg.MetaSet("spb_device_key", topicInfo.DeviceKey())
 	msg.MetaSet("spb_topic", originalTopic)
 	msg.MetaSet("spb_group_id", topicInfo.Group)
 	msg.MetaSet("spb_edge_node_id", topicInfo.EdgeNode)
@@ -1116,7 +1118,7 @@ func (s *sparkplugInput) createDeathEventMessage(msgType string, deviceKey strin
 	if topicInfo.Device != "" {
 		msg.MetaSet("spb_device_id_sanitized", s.sanitizeForTopic(topicInfo.Device))
 	}
-	msg.MetaSet("spb_device_key_sanitized", s.sanitizeForTopic(deviceKey))
+	msg.MetaSet("spb_device_key_sanitized", s.sanitizeForTopic(topicInfo.DeviceKey()))
 	msg.MetaSet("event_type", "device_offline")
 
 	return service.MessageBatch{msg}

--- a/sparkplug_plugin/sparkplug_b_input_sequence_test.go
+++ b/sparkplug_plugin/sparkplug_b_input_sequence_test.go
@@ -81,7 +81,7 @@ var _ = Describe("NDATA Message Splitting - Sequence Number Handling", func() {
 			}
 
 			// When: Processing through createSplitMessages
-			batch := input.CreateSplitMessages(payload, "NDATA", "test/edge1/702", topicInfo, "spBv1.0/test/NDATA/edge1/702")
+			batch := input.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/702")
 
 			// Then: Should create 5 messages
 			Expect(batch).To(HaveLen(5), "Should create one message per metric")
@@ -127,7 +127,7 @@ var _ = Describe("NDATA Message Splitting - Sequence Number Handling", func() {
 			}
 
 			// When: Creating split messages
-			batch := input.CreateSplitMessages(payload, "NDATA", "test/edge1/device1", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
+			batch := input.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
 
 			// Then: Extract sequence numbers (CURRENT BEHAVIOR - all duplicates)
 			sequences := []string{}
@@ -186,7 +186,7 @@ var _ = Describe("NDATA Message Splitting - Sequence Number Handling", func() {
 			}
 
 			// When: Creating split messages
-			batch := input.CreateSplitMessages(payload, "NDATA", "org_A/site_B/702", topicInfo, "spBv1.0/org_A/NDATA/site_B/702")
+			batch := input.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/org_A/NDATA/site_B/702")
 
 			// Then: Verify Dual-Sequence metadata on all messages
 			Expect(batch).To(HaveLen(5), "Should create 5 split messages")
@@ -247,7 +247,7 @@ var _ = Describe("NDATA Message Splitting - Sequence Number Handling", func() {
 			}
 
 			// When: Creating split messages
-			batch := input.CreateSplitMessages(payload, "NDATA", "test/edge1/device1", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
+			batch := input.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
 
 			// Then: Should create 1 message with correct metadata
 			Expect(batch).To(HaveLen(1))
@@ -328,9 +328,9 @@ var _ = Describe("NDATA Message Splitting - Sequence Number Handling", func() {
 			}
 
 			// When: Processing all three messages
-			batch1 := input.CreateSplitMessages(payload1, "NDATA", "org_A/site_B/702", topicInfo, "spBv1.0/org_A/NDATA/site_B/702")
-			batch2 := input.CreateSplitMessages(payload2, "NDATA", "org_A/site_B/702", topicInfo, "spBv1.0/org_A/NDATA/site_B/702")
-			batch3 := input.CreateSplitMessages(payload3, "NDATA", "org_A/site_B/702", topicInfo, "spBv1.0/org_A/NDATA/site_B/702")
+			batch1 := input.CreateSplitMessages(payload1, "NDATA", topicInfo, "spBv1.0/org_A/NDATA/site_B/702")
+			batch2 := input.CreateSplitMessages(payload2, "NDATA", topicInfo, "spBv1.0/org_A/NDATA/site_B/702")
+			batch3 := input.CreateSplitMessages(payload3, "NDATA", topicInfo, "spBv1.0/org_A/NDATA/site_B/702")
 
 			// Then: Each NDATA should produce 5 split messages
 			Expect(batch1).To(HaveLen(5), "First NDATA (seq=253) should create 5 messages")
@@ -499,9 +499,9 @@ var _ = Describe("NDATA Message Splitting - Sequence Number Handling", func() {
 			}
 
 			// When: Processing all messages through SparkplugB input
-			batch1 := input.CreateSplitMessages(payload1, "NDATA", "org_A/site_B/702", device702, "spBv1.0/org_A/NDATA/site_B/702")
-			batch2 := input.CreateSplitMessages(payload2, "NDATA", "org_A/site_B/702", device702, "spBv1.0/org_A/NDATA/site_B/702")
-			batch3 := input.CreateSplitMessages(payload3, "NDATA", "org_A/site_B/702", device702, "spBv1.0/org_A/NDATA/site_B/702")
+			batch1 := input.CreateSplitMessages(payload1, "NDATA", device702, "spBv1.0/org_A/NDATA/site_B/702")
+			batch2 := input.CreateSplitMessages(payload2, "NDATA", device702, "spBv1.0/org_A/NDATA/site_B/702")
+			batch3 := input.CreateSplitMessages(payload3, "NDATA", device702, "spBv1.0/org_A/NDATA/site_B/702")
 
 			// Collect all output messages
 			allMessages := append(batch1, batch2...)

--- a/sparkplug_plugin/sparkplug_b_input_test_helper.go
+++ b/sparkplug_plugin/sparkplug_b_input_test_helper.go
@@ -97,18 +97,21 @@ func (w *SparkplugInputTestWrapper) GetStateMu() *sync.RWMutex {
 }
 
 // CreateSplitMessages is an exported wrapper for testing the private createSplitMessages method
-func (w *SparkplugInputTestWrapper) CreateSplitMessages(payload *sparkplugb.Payload, msgType string, deviceKey string, topicInfo *TopicInfo, originalTopic string) service.MessageBatch {
-	return w.input.createSplitMessages(payload, msgType, deviceKey, topicInfo, originalTopic)
+// ENG-4031: Removed redundant deviceKey parameter - now derived from topicInfo.DeviceKey()
+func (w *SparkplugInputTestWrapper) CreateSplitMessages(payload *sparkplugb.Payload, msgType string, topicInfo *TopicInfo, originalTopic string) service.MessageBatch {
+	return w.input.createSplitMessages(payload, msgType, topicInfo, originalTopic)
 }
 
 // ProcessBirthMessage is an exported wrapper for testing the private processBirthMessage method
-func (w *SparkplugInputTestWrapper) ProcessBirthMessage(deviceKey string, msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
-	w.input.processBirthMessage(deviceKey, msgType, payload, topicInfo)
+// ENG-4031: Removed redundant deviceKey parameter - now derived from topicInfo.DeviceKey()
+func (w *SparkplugInputTestWrapper) ProcessBirthMessage(msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
+	w.input.processBirthMessage(msgType, payload, topicInfo)
 }
 
 // ProcessDataMessage is an exported wrapper for testing the private processDataMessage method
-func (w *SparkplugInputTestWrapper) ProcessDataMessage(deviceKey string, msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
-	w.input.processDataMessage(deviceKey, msgType, payload, topicInfo)
+// ENG-4031: Removed redundant deviceKey parameter - now derived from topicInfo.DeviceKey()
+func (w *SparkplugInputTestWrapper) ProcessDataMessage(msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
+	w.input.processDataMessage(msgType, payload, topicInfo)
 }
 
 // NodeStateInfo represents the public view of a node state for testing
@@ -136,8 +139,9 @@ func (w *SparkplugInputTestWrapper) GetNodeState(deviceKey string) *NodeStateInf
 }
 
 // ProcessDeathMessage is an exported wrapper for testing the private processDeathMessage method
-func (w *SparkplugInputTestWrapper) ProcessDeathMessage(deviceKey string, msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
-	w.input.processDeathMessage(deviceKey, msgType, payload, topicInfo)
+// ENG-4031: Removed redundant deviceKey parameter - now derived from topicInfo.DeviceKey()
+func (w *SparkplugInputTestWrapper) ProcessDeathMessage(msgType string, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
+	w.input.processDeathMessage(msgType, payload, topicInfo)
 }
 
 // SetNodeBdSeq allows tests to set the bdSeq for a device (simulating NBIRTH)

--- a/sparkplug_plugin/sparkplug_b_input_test_helper.go
+++ b/sparkplug_plugin/sparkplug_b_input_test_helper.go
@@ -104,11 +104,13 @@ type NodeStateInfo struct {
 }
 
 // GetNodeState is an exported wrapper for accessing node state in tests
+// ENG-4031: Uses ExtractNodeKey because state is now stored at node level
 func (w *SparkplugInputTestWrapper) GetNodeState(deviceKey string) *NodeStateInfo {
 	w.input.stateMu.RLock()
 	defer w.input.stateMu.RUnlock()
 
-	state, exists := w.input.nodeStates[deviceKey]
+	nodeKey := ExtractNodeKey(deviceKey)
+	state, exists := w.input.nodeStates[nodeKey]
 	if !exists {
 		return nil
 	}
@@ -125,14 +127,16 @@ func (w *SparkplugInputTestWrapper) ProcessDeathMessage(deviceKey string, msgTyp
 }
 
 // SetNodeBdSeq allows tests to set the bdSeq for a device (simulating NBIRTH)
+// ENG-4031: Uses ExtractNodeKey because state is now stored at node level
 func (w *SparkplugInputTestWrapper) SetNodeBdSeq(deviceKey string, bdSeq uint64) {
 	w.input.stateMu.Lock()
 	defer w.input.stateMu.Unlock()
 
-	if state, exists := w.input.nodeStates[deviceKey]; exists {
+	nodeKey := ExtractNodeKey(deviceKey)
+	if state, exists := w.input.nodeStates[nodeKey]; exists {
 		state.BdSeq = bdSeq
 	} else {
-		w.input.nodeStates[deviceKey] = &nodeState{
+		w.input.nodeStates[nodeKey] = &nodeState{
 			BdSeq:    bdSeq,
 			IsOnline: true,
 			LastSeen: time.Now(),
@@ -141,11 +145,13 @@ func (w *SparkplugInputTestWrapper) SetNodeBdSeq(deviceKey string, bdSeq uint64)
 }
 
 // GetNodeBdSeq returns the bdSeq for a device
+// ENG-4031: Uses ExtractNodeKey because state is now stored at node level
 func (w *SparkplugInputTestWrapper) GetNodeBdSeq(deviceKey string) (uint64, bool) {
 	w.input.stateMu.RLock()
 	defer w.input.stateMu.RUnlock()
 
-	state, exists := w.input.nodeStates[deviceKey]
+	nodeKey := ExtractNodeKey(deviceKey)
+	state, exists := w.input.nodeStates[nodeKey]
 	if !exists {
 		return 0, false
 	}

--- a/sparkplug_plugin/sparkplug_b_lock_management_test.go
+++ b/sparkplug_plugin/sparkplug_b_lock_management_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Lock Management in processDataMessage", func() {
 			initialPayload := createSparkplugPayload(0, []*sparkplugb.Payload_Metric{
 				{Name: stringPtr("temp"), Value: &sparkplugb.Payload_Metric_IntValue{IntValue: 42}},
 			})
-			wrapper.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", initialPayload, topicInfo)
+			wrapper.ProcessDataMessage("NDATA", initialPayload, topicInfo)
 
 			// Verify initial state established
 			state := wrapper.GetNodeState(topicInfo.DeviceKey())
@@ -117,7 +117,7 @@ var _ = Describe("Lock Management in processDataMessage", func() {
 			})
 
 			// Process message that triggers rebirth (line 630)
-			wrapper.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", gapPayload, topicInfo)
+			wrapper.ProcessDataMessage("NDATA", gapPayload, topicInfo)
 
 			// Wait for lock detection to complete
 			<-done
@@ -147,7 +147,7 @@ var _ = Describe("Lock Management in processDataMessage", func() {
 			initialPayload := createSparkplugPayload(0, []*sparkplugb.Payload_Metric{
 				{Name: stringPtr("temp"), Value: &sparkplugb.Payload_Metric_IntValue{IntValue: 42}},
 			})
-			wrapper.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", initialPayload, topicInfo)
+			wrapper.ProcessDataMessage("NDATA", initialPayload, topicInfo)
 
 			// Trigger sequence gap - this will call sendRebirthRequest at line 630
 			gapPayload := createSparkplugPayload(10, []*sparkplugb.Payload_Metric{
@@ -169,7 +169,7 @@ var _ = Describe("Lock Management in processDataMessage", func() {
 			// 5. Lock released via defer at line 638
 
 			// Process the gap message
-			wrapper.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", gapPayload, topicInfo)
+			wrapper.ProcessDataMessage("NDATA", gapPayload, topicInfo)
 
 			// Verify state was updated (proves processDataMessage completed)
 			state := wrapper.GetNodeState(topicInfo.DeviceKey())

--- a/sparkplug_plugin/sparkplug_b_robustness_test.go
+++ b/sparkplug_plugin/sparkplug_b_robustness_test.go
@@ -37,7 +37,6 @@ package sparkplug_plugin_test
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -48,22 +47,6 @@ import (
 	"github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin/sparkplugb"
 )
 
-// makeTopicInfo constructs a TopicInfo from a deviceKey string (group/node/device format)
-func makeTopicInfo(deviceKey string) *sparkplugplugin.TopicInfo {
-	parts := strings.Split(deviceKey, "/")
-	if len(parts) < 2 {
-		return &sparkplugplugin.TopicInfo{}
-	}
-	ti := &sparkplugplugin.TopicInfo{
-		Group:    parts[0],
-		EdgeNode: parts[1],
-	}
-	if len(parts) > 2 {
-		ti.Device = parts[2]
-	}
-	return ti
-}
-
 var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 	Context("Burst arrival after idle period (PCAP pattern)", func() {
 		// Test validates behavior under production timing pattern from customer PCAP:
@@ -73,7 +56,11 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 		It("should handle burst without drops after idle messages", func() {
 			// Given: Mock input with standard configuration
 			input := createMockSparkplugInput()
-			deviceKey := "test/edge1/device_burst"
+			topicInfo := &sparkplugplugin.TopicInfo{
+				Group:    "test",
+				EdgeNode: "edge1",
+				Device:   "device_burst",
+			}
 
 			// Create baseline NBIRTH to establish node state
 			birthSeq := uint64(0)
@@ -85,7 +72,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					{Name: stringPtr("bdSeq"), Datatype: uint32Ptr(8), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(deviceKey, "NBIRTH", birthPayload, makeTopicInfo(deviceKey))
+			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
 
 			// Phase 1: Idle period - Send 5 messages slowly (simulate 1 msg/10sec pattern)
 			// This establishes normal sequence progression: 0 → 1 → 2 → 3 → 4
@@ -99,7 +86,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 						{Name: stringPtr(fmt.Sprintf("idle_metric_%d", i)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: float64(i)}},
 					},
 				}
-				input.ProcessDataMessage(deviceKey, "NDATA", payload, makeTopicInfo(deviceKey))
+				input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
 				time.Sleep(10 * time.Millisecond) // Small delay to simulate timing
 			}
 
@@ -117,7 +104,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 						{Name: stringPtr(fmt.Sprintf("burst_metric_%d", i)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: float64(i)}},
 					},
 				}
-				input.ProcessDataMessage(deviceKey, "NDATA", payload, makeTopicInfo(deviceKey))
+				input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
 			}
 			burstDuration := time.Since(burstStart)
 
@@ -125,7 +112,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 			GinkgoWriter.Printf("Burst processing completed in %v (100 messages)\n", burstDuration)
 
 			// Validate node state reflects last sequence
-			nodeState := input.GetNodeState(deviceKey)
+			nodeState := input.GetNodeState(topicInfo.DeviceKey())
 			Expect(nodeState).NotTo(BeNil(), "Node state should exist after burst")
 			Expect(nodeState.LastSeq).To(Equal(uint8(104)), "Last sequence should be 104 after burst")
 			// Note: IsOnline may be false because ProcessDataMessage doesn't trigger full state machine
@@ -150,7 +137,11 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 			// Phase 1: Initialize all devices with NBIRTH (sequential)
 			// This establishes nodeStates entries and baseline sequences
 			for deviceID := 0; deviceID < deviceCount; deviceID++ {
-				deviceKey := fmt.Sprintf("test/edge1/device%d", deviceID)
+				topicInfo := &sparkplugplugin.TopicInfo{
+					Group:    "test",
+					EdgeNode: "edge1",
+					Device:   fmt.Sprintf("device%d", deviceID),
+				}
 				birthSeq := uint64(0)
 				birthTs := uint64(1730986400000)
 				birthPayload := &sparkplugb.Payload{
@@ -161,7 +152,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 						{Name: stringPtr(fmt.Sprintf("sensor_%d", deviceID)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 23.5}},
 					},
 				}
-				input.ProcessBirthMessage(deviceKey, "NBIRTH", birthPayload, makeTopicInfo(deviceKey))
+				input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
 			}
 
 			// Phase 2: Concurrent NDATA from all devices
@@ -175,7 +166,11 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					defer wg.Done()
 					defer GinkgoRecover() // Catch panics in goroutines
 
-					deviceKey := fmt.Sprintf("test/edge1/device%d", id)
+					topicInfo := &sparkplugplugin.TopicInfo{
+						Group:    "test",
+						EdgeNode: "edge1",
+						Device:   fmt.Sprintf("device%d", id),
+					}
 
 					// Each device sends 5 NDATA messages with sequential sequence numbers
 					for msgNum := 1; msgNum <= 5; msgNum++ {
@@ -192,7 +187,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 								},
 							},
 						}
-						input.ProcessDataMessage(deviceKey, "NDATA", payload, makeTopicInfo(deviceKey))
+						input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
 					}
 				}(deviceID)
 			}
@@ -204,8 +199,12 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 
 			// Then: Validate all devices processed successfully
 			for deviceID := 0; deviceID < deviceCount; deviceID++ {
-				deviceKey := fmt.Sprintf("test/edge1/device%d", deviceID)
-				nodeState := input.GetNodeState(deviceKey)
+				topicInfo := &sparkplugplugin.TopicInfo{
+					Group:    "test",
+					EdgeNode: "edge1",
+					Device:   fmt.Sprintf("device%d", deviceID),
+				}
+				nodeState := input.GetNodeState(topicInfo.DeviceKey())
 
 				Expect(nodeState).NotTo(BeNil(), "Device %d should have node state", deviceID)
 				Expect(nodeState.LastSeq).To(Equal(uint8(5)), "Device %d should have last sequence = 5", deviceID)
@@ -226,7 +225,11 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 		It("should gracefully drop messages when buffer exceeds 1000", func() {
 			// Given: Mock input
 			input := createMockSparkplugInput()
-			deviceKey := "test/edge1/device_overflow"
+			topicInfo := &sparkplugplugin.TopicInfo{
+				Group:    "test",
+				EdgeNode: "edge1",
+				Device:   "device_overflow",
+			}
 
 			// Initialize device with NBIRTH
 			birthSeq := uint64(0)
@@ -238,7 +241,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					{Name: stringPtr("bdSeq"), Datatype: uint32Ptr(8), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(deviceKey, "NBIRTH", birthPayload, makeTopicInfo(deviceKey))
+			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
 
 			// When: Send 1100 messages (100 more than buffer capacity of 1000)
 			// Note: This test validates the DESIGN INTENT even if buffer size is not yet enforced
@@ -254,11 +257,11 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 						{Name: stringPtr(fmt.Sprintf("overflow_metric_%d", i)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: float64(i)}},
 					},
 				}
-				input.ProcessDataMessage(deviceKey, "NDATA", payload, makeTopicInfo(deviceKey))
+				input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
 			}
 
 			// Then: Validate system remained stable
-			nodeState := input.GetNodeState(deviceKey)
+			nodeState := input.GetNodeState(topicInfo.DeviceKey())
 			Expect(nodeState).NotTo(BeNil(), "Node state should exist after overflow")
 			// Note: IsOnline status not checked - requires full MQTT infrastructure
 
@@ -279,7 +282,11 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 		It("should handle concurrent DBIRTH and DDATA from same device", func() {
 			// Given: Mock input
 			input := createMockSparkplugInput()
-			deviceKey := "test/edge1/device_alias"
+			topicInfo := &sparkplugplugin.TopicInfo{
+				Group:    "test",
+				EdgeNode: "edge1",
+				Device:   "device_alias",
+			}
 
 			// Initialize node with NBIRTH (must happen first to establish node state)
 			nbirthSeq := uint64(0)
@@ -291,7 +298,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					{Name: stringPtr("bdSeq"), Datatype: uint32Ptr(8), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(deviceKey, "NBIRTH", nbirthPayload, makeTopicInfo(deviceKey))
+			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", nbirthPayload, topicInfo)
 
 			// Prepare DBIRTH payload with alias definitions
 			dbirthSeq := uint64(1)
@@ -326,7 +333,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 			go func() {
 				defer wg.Done()
 				defer GinkgoRecover()
-				input.ProcessBirthMessage(deviceKey, "DBIRTH", dbirthPayload, makeTopicInfo(deviceKey))
+				input.ProcessBirthMessage(topicInfo.DeviceKey(), "DBIRTH", dbirthPayload, topicInfo)
 			}()
 
 			go func() {
@@ -334,13 +341,13 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 				defer GinkgoRecover()
 				// Small delay to make race more likely (DDATA might arrive before DBIRTH processed)
 				time.Sleep(1 * time.Millisecond)
-				input.ProcessDataMessage(deviceKey, "DDATA", ddataPayload, makeTopicInfo(deviceKey))
+				input.ProcessDataMessage(topicInfo.DeviceKey(), "DDATA", ddataPayload, topicInfo)
 			}()
 
 			wg.Wait()
 
 			// Then: Validate system handled race condition properly
-			nodeState := input.GetNodeState(deviceKey)
+			nodeState := input.GetNodeState(topicInfo.DeviceKey())
 			Expect(nodeState).NotTo(BeNil(), "Node state should exist after concurrent processing")
 			Expect(nodeState.LastSeq).To(Equal(uint8(2)), "Last sequence should be 2 (DDATA processed)")
 			// Note: IsOnline status not checked - requires full MQTT infrastructure
@@ -360,7 +367,11 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 		It("should cleanly shutdown while messages are processing", func() {
 			// Given: Mock input with active message processing
 			input := createMockSparkplugInput()
-			deviceKey := "test/edge1/device_shutdown"
+			topicInfo := &sparkplugplugin.TopicInfo{
+				Group:    "test",
+				EdgeNode: "edge1",
+				Device:   "device_shutdown",
+			}
 
 			// Initialize device with NBIRTH
 			birthSeq := uint64(0)
@@ -372,7 +383,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					{Name: stringPtr("bdSeq"), Datatype: uint32Ptr(8), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(deviceKey, "NBIRTH", birthPayload, makeTopicInfo(deviceKey))
+			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
 
 			// Start background goroutine that continuously sends messages
 			var wg sync.WaitGroup
@@ -399,7 +410,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 								{Name: stringPtr(fmt.Sprintf("shutdown_metric_%d", messagesSent)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: float64(messagesSent)}},
 							},
 						}
-						input.ProcessDataMessage(deviceKey, "NDATA", payload, makeTopicInfo(deviceKey))
+						input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
 						time.Sleep(1 * time.Millisecond) // Small delay to simulate real timing
 					}
 				}
@@ -413,7 +424,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 			wg.Wait()
 
 			// Then: Validate clean shutdown
-			nodeState := input.GetNodeState(deviceKey)
+			nodeState := input.GetNodeState(topicInfo.DeviceKey())
 			Expect(nodeState).NotTo(BeNil(), "Node state should exist after shutdown")
 			// Note: IsOnline status not checked - requires full MQTT infrastructure
 

--- a/sparkplug_plugin/sparkplug_b_robustness_test.go
+++ b/sparkplug_plugin/sparkplug_b_robustness_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					{Name: stringPtr("bdSeq"), Datatype: uint32Ptr(8), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
+			input.ProcessBirthMessage("NBIRTH", birthPayload, topicInfo)
 
 			// Phase 1: Idle period - Send 5 messages slowly (simulate 1 msg/10sec pattern)
 			// This establishes normal sequence progression: 0 → 1 → 2 → 3 → 4
@@ -86,7 +86,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 						{Name: stringPtr(fmt.Sprintf("idle_metric_%d", i)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: float64(i)}},
 					},
 				}
-				input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
+				input.ProcessDataMessage("NDATA", payload, topicInfo)
 				time.Sleep(10 * time.Millisecond) // Small delay to simulate timing
 			}
 
@@ -104,7 +104,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 						{Name: stringPtr(fmt.Sprintf("burst_metric_%d", i)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: float64(i)}},
 					},
 				}
-				input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
+				input.ProcessDataMessage("NDATA", payload, topicInfo)
 			}
 			burstDuration := time.Since(burstStart)
 
@@ -152,7 +152,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 						{Name: stringPtr(fmt.Sprintf("sensor_%d", deviceID)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 23.5}},
 					},
 				}
-				input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
+				input.ProcessBirthMessage("NBIRTH", birthPayload, topicInfo)
 			}
 
 			// Phase 2: Concurrent NDATA from all devices
@@ -187,7 +187,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 								},
 							},
 						}
-						input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
+						input.ProcessDataMessage("NDATA", payload, topicInfo)
 					}
 				}(deviceID)
 			}
@@ -241,7 +241,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					{Name: stringPtr("bdSeq"), Datatype: uint32Ptr(8), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
+			input.ProcessBirthMessage("NBIRTH", birthPayload, topicInfo)
 
 			// When: Send 1100 messages (100 more than buffer capacity of 1000)
 			// Note: This test validates the DESIGN INTENT even if buffer size is not yet enforced
@@ -257,7 +257,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 						{Name: stringPtr(fmt.Sprintf("overflow_metric_%d", i)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: float64(i)}},
 					},
 				}
-				input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
+				input.ProcessDataMessage("NDATA", payload, topicInfo)
 			}
 
 			// Then: Validate system remained stable
@@ -298,7 +298,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					{Name: stringPtr("bdSeq"), Datatype: uint32Ptr(8), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", nbirthPayload, topicInfo)
+			input.ProcessBirthMessage("NBIRTH", nbirthPayload, topicInfo)
 
 			// Prepare DBIRTH payload with alias definitions
 			dbirthSeq := uint64(1)
@@ -333,7 +333,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 			go func() {
 				defer wg.Done()
 				defer GinkgoRecover()
-				input.ProcessBirthMessage(topicInfo.DeviceKey(), "DBIRTH", dbirthPayload, topicInfo)
+				input.ProcessBirthMessage("DBIRTH", dbirthPayload, topicInfo)
 			}()
 
 			go func() {
@@ -341,7 +341,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 				defer GinkgoRecover()
 				// Small delay to make race more likely (DDATA might arrive before DBIRTH processed)
 				time.Sleep(1 * time.Millisecond)
-				input.ProcessDataMessage(topicInfo.DeviceKey(), "DDATA", ddataPayload, topicInfo)
+				input.ProcessDataMessage("DDATA", ddataPayload, topicInfo)
 			}()
 
 			wg.Wait()
@@ -383,7 +383,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 					{Name: stringPtr("bdSeq"), Datatype: uint32Ptr(8), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 100}},
 				},
 			}
-			input.ProcessBirthMessage(topicInfo.DeviceKey(), "NBIRTH", birthPayload, topicInfo)
+			input.ProcessBirthMessage("NBIRTH", birthPayload, topicInfo)
 
 			// Start background goroutine that continuously sends messages
 			var wg sync.WaitGroup
@@ -410,7 +410,7 @@ var _ = Describe("Robustness Tests - Message Timing and Concurrency", func() {
 								{Name: stringPtr(fmt.Sprintf("shutdown_metric_%d", messagesSent)), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: float64(messagesSent)}},
 							},
 						}
-						input.ProcessDataMessage(topicInfo.DeviceKey(), "NDATA", payload, topicInfo)
+						input.ProcessDataMessage("NDATA", payload, topicInfo)
 						time.Sleep(1 * time.Millisecond) // Small delay to simulate real timing
 					}
 				}


### PR DESCRIPTION
## Summary

- Fix Sparkplug B sequence tracking to be per-NODE instead of per-device
- Per spec, sequence numbers are NODE-scoped (shared across NBIRTH, NDATA, DBIRTH, DDATA)
- Bug caused false "Sequence gap detected" errors when NDATA/DDATA interleaved

## Problem

When a Sparkplug node publishes interleaved messages:
```
DDATA seq=15 → NDATA seq=16 → NDATA seq=17 → DDATA seq=18
```

The old code tracked sequence per-deviceKey:
- NDATA used key `"group/node"` 
- DDATA used key `"group/node/device"`

This created separate map entries, so DDATA seq=18 was compared to DDATA seq=15, triggering a false gap.

## Solution

Added `ExtractNodeKey()` helper that extracts `"group/node"` from any device key, ensuring all messages from the same node share one sequence counter.

## Changes

| File | Change |
|------|--------|
| `sparkplug_b_core.go` | Add `ExtractNodeKey()` helper |
| `sparkplug_b_input.go` | Fix 4 process methods to use nodeKey |
| `sparkplug_b_input_test_helper.go` | Fix test helpers for new key structure |
| `node_sequence_test.go` | New TDD tests for node-scoped tracking |

## Test plan

- [x] All 241 Sparkplug tests pass
- [x] New node-scoped sequence tracking tests pass
- [x] Real sequence gap detection still works

Closes ENG-4031

🤖 Generated with [Claude Code](https://claude.com/claude-code)