### PR TITLE
[ENG-4033] fix(ci): preserve release body when uploading artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,7 @@ jobs:
           artifacts: './artifacts/artifact-*-${{ github.run_id }}-${{ github.run_attempt }}/*'
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
+          omitBodyDuringUpdate: true
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
 
   update-umh-core:


### PR DESCRIPTION
## Summary

Fixes the issue where release changelogs were disappearing after the binary upload workflow ran.

## Problem

The `ncipollo/release-action` was configured with `allowUpdates: true` but without `omitBodyDuringUpdate: true`. When the action ran to upload binaries, it was clearing the release body.

**Evidence:** v0.11.14 release was created with a full changelog, but the body was cleared when binaries were uploaded.

## Solution

Added `omitBodyDuringUpdate: true` to preserve the existing release body when the action updates the release with binary artifacts.

## Test plan

- [x] Verified `omitBodyDuringUpdate` is a valid option for ncipollo/release-action
- [ ] Next release should preserve its changelog after binary upload

Fixes: ENG-4033

🤖 Generated with [Claude Code](https://claude.com/claude-code)