### PR TITLE
chore: repace S7 eos runner with depot

### DIFF
--- a/.github/workflows/s7-plc.yml
+++ b/.github/workflows/s7-plc.yml
@@ -29,8 +29,7 @@ concurrency:
 
 jobs:
   go-test-s7-plc:
-    runs-on:
-      group: eos
+    runs-on: depot-ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
Overlooked one of the `eos` runners when migrating over to depot runners.
This commit now replaces the last runner with `depot`.