### PR TITLE
chore: upgrade runner to 4 cores 16gb

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
## Description:
Fixes ENG-4051

Upgrade the runner to 4-cores 16 GB, since it was oom-killed in the linting, which is running with `concurrency: 4`.
If this still happens, we will downgrade the `concurrency` of .golanci.yaml