### PR TITLE
docs: document the max amount of addresses for each connection

### DIFF
--- a/docs/input/siemens-s7.md
+++ b/docs/input/siemens-s7.md
@@ -31,7 +31,7 @@ input:
 * **batchMaxSize**: Maximum count of addresses bundled in a single batch request. This affects the PDU size.
 * **timeout**: Timeout duration in seconds for connection attempts and read requests.
 * **disableCPUInfo**: Set this to true to not fetch CPU information from the PLC. Should be used when you get the error 'Failed to get CPU information'
-* **addresses**: Specifies the list of addresses to read. The format for addresses is `<area>.<type><address>[.extra]`, where:
+* **addresses**: Specifies the list of addresses to read. **Maximum 20 addresses** per connection to prevent PLC overload. Use multiple S7 inputs for more. The format for addresses is `<area>.<type><address>[.extra]`, where:
   * `area`: Specifies the direct area access, e.g., "DB1" for data block one. Supported areas include inputs (`PE`), outputs (`PA`), Merkers (`MK`), DB (`DB`), counters (`C`), and timers (`T`).
   * `type`: Indicates the data type, such as bit (`X`), byte (`B`), word (`W`), double word (`DW`), integer (`I`), double integer (`DI`), real (`R`), date-time (`DT`), and string (`S`). Some types require an 'extra' parameter, e.g., the bit number for `X` or the maximum length for `S`.
 

--- a/s7comm_plugin/s7comm.go
+++ b/s7comm_plugin/s7comm.go
@@ -118,7 +118,9 @@ var S7CommConfigSpec = service.NewConfigSpec().
 		Advanced().
 		Examples(false, true)).
 	Field(service.NewStringListField("addresses").
-		Description("S7 memory addresses to read. Format: AREA.TYPE<offset>[.extra]. "+
+		Description("S7 memory addresses to read. Maximum 20 addresses per connection "+
+			"to prevent PLC overload; use multiple S7 inputs for more. "+
+			"Format: AREA.TYPE<offset>[.extra]. "+
 			"Areas: DB (data block), MK (marker), PE (input), PA (output). "+
 			"Types: X (bit), B (byte), W (word), DW (dword), I (int), DI (dint), R (real), S (string). "+
 			"For bits (X), add bit number 0-7. For strings (S), add max length.").


### PR DESCRIPTION
## Description:

Fixes ENG-3798

When having configured more then 20 addresses, the plugin will fail the connection/read-attempt, since this is hard-coded in the underlying library.

Logs will look like this:
```
INFO[2025-11-10T16:50:11+01:00] Running main config from specified file       @service=benthos benthos_version=v4.57.1 path=./tmp/s7alex.yaml
INFO[2025-11-10T16:50:11+01:00] Listening for HTTP requests at: http://0.0.0.0:4195  @service=benthos
INFO[2025-11-10T16:50:11+01:00] Launching a Benthos instance, use CTRL+C to close  @service=benthos
INFO[2025-11-10T16:50:11+01:00] Output type stdout is now active              @service=benthos label="" path=root.output
INFO[2025-11-10T16:50:11+01:00] Successfully connected to S7 PLC at 10.13.37.182  @service=benthos label="" path=root.input
WARN[2025-11-10T16:50:11+01:00] Failed to get CPU information: CLI : invalid CPU answer  @service=benthos label="" path=root.input
INFO[2025-11-10T16:50:11+01:00] Input type s7comm is now active               @service=benthos label="" path=root.input
ERRO[2025-11-10T16:50:11+01:00] Failed to read batch 1: CLI : too may items (>20) in multi read/write  @service=benthos label="" path=root.input
INFO[2025-11-10T16:50:11+01:00] Successfully connected to S7 PLC at 10.13.37.182  @service=benthos label="" path=root.input
WARN[2025-11-10T16:50:11+01:00] Failed to get CPU information: CLI : invalid CPU answer  @service=benthos label="" path=root.input
ERRO[2025-11-10T16:50:11+01:00] Failed to read batch 1: CLI : too may items (>20) in multi read/write  @service=benthos label="" path=root.input
INFO[2025-11-10T16:50:11+01:00] Successfully connected to S7 PLC at 10.13.37.182  @service=benthos label="" path=root.input
WARN[2025-11-10T16:50:11+01:00] Failed to get CPU information: CLI : invalid CPU answer  @service=benthos label="" path=root.input
ERRO[2025-11-10T16:50:11+01:00] Failed to read batch 1: CLI : too may items (>20) in multi read/write  @service=benthos label="" path=root.input
INFO[2025-11-10T16:50:11+01:00] Successfully connected to S7 PLC at 10.13.37.182  @service=benthos label="" path=root.input
WARN[2025-11-10T16:50:11+01:00] Failed to get CPU information: CLI : invalid CPU answer  @service=benthos label="" path=root.input
ERRO[2025-11-10T16:50:11+01:00] Failed to read batch 1: CLI : too may items (>20) in multi read/write  @service=benthos label="" path=root.input
```

Therefore no additional loggin needed here.