### PR TITLE
chore: remove workflow_dispatch from update-umh-core-version workflow

### DIFF
--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -21,22 +21,12 @@ on:
       tag:
         required: true
         type: string
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Version tag (e.g., v0.11.7)'
-        required: true
-        type: string
-      ref:
-        description: 'Git ref to checkout for schema export (default: tag). Use branch name for testing unreleased code.'
-        required: false
-        type: string
 
 jobs:
   update-umh-core:
     runs-on: depot-ubuntu-24.04
     env:
-      VERSION: ${{ inputs.tag || github.event.inputs.tag }}
+      VERSION: ${{ inputs.tag }}
     steps:
       - name: Generate GitHub App Token
         id: generate-token
@@ -91,7 +81,7 @@ jobs:
   update-management-console:
     runs-on: depot-ubuntu-24.04
     env:
-      VERSION: ${{ inputs.tag || github.event.inputs.tag }}
+      VERSION: ${{ inputs.tag }}
     steps:
       - name: Generate GitHub App Token
         id: generate-token
@@ -104,7 +94,7 @@ jobs:
       - name: Checkout benthos-umh repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.ref || env.VERSION }}
+          ref: ${{ env.VERSION }}
 
       - name: Setup Go
         uses: ./.github/actions/setup-go


### PR DESCRIPTION
## Summary
- Removes the temporary `workflow_dispatch` trigger from the update-umh-core-version workflow
- Simplifies `VERSION` environment variable expressions
- Removes `ref` fallback logic in benthos-umh checkout step

## Context
The manual workflow_dispatch with `tag` and `ref` inputs was added temporarily during ENG-3623 (Form-based UI for Industrial Protocol Configuration) development to enable testing unreleased schema exports. Now that the Mahle UI feature has shipped, this cleanup removes the temporary testing mechanism to maintain release automation discipline.

**CodeRabbit Review Reference:** [PR #234 comment](https://github.com/united-manufacturing-hub/benthos-umh/pull/234#discussion_r2592641936)

## Test plan
- [ ] Verify workflow_dispatch option no longer appears in GitHub Actions UI for this workflow
- [ ] Confirm the workflow can still be called via `workflow_call` from the release workflow

Closes ENG-4000

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)