### PR TITLE
fix: opcua empty detected nodes after reconnect

### DIFF
--- a/opcua_plugin/core_connection.go
+++ b/opcua_plugin/core_connection.go
@@ -209,7 +209,7 @@ func (g *OPCUAConnection) closeConnection(ctx context.Context) {
 		g.cleanup_func(ctx)
 	}
 
-	g.visited = sync.Map{}
+	g.visited.Clear()
 
 	if g.Client != nil {
 		if err := g.Client.Close(ctx); err != nil {

--- a/opcua_plugin/core_connection.go
+++ b/opcua_plugin/core_connection.go
@@ -209,6 +209,8 @@ func (g *OPCUAConnection) closeConnection(ctx context.Context) {
 		g.cleanup_func(ctx)
 	}
 
+	g.visited = sync.Map{}
+
 	if g.Client != nil {
 		if err := g.Client.Close(ctx); err != nil {
 			g.Log.Infof("Error closing OPC UA client: %v", err)

--- a/opcua_plugin/read_discover.go
+++ b/opcua_plugin/read_discover.go
@@ -734,7 +734,7 @@ func (g *OPCUAInput) buildNodeListFromCache() []NodeDef {
 
 func (g *OPCUAInput) canSkipDiscovery() bool {
 	for _, nodeID := range g.NodeIDs {
-		val, found := g.visited.Load(nodeID)
+		val, found := g.visited.Load(nodeID.String())
 		if !found {
 			return false
 		}


### PR DESCRIPTION
# Description:

Fixes ENG-4149

1. the visited map was never cleared, therefore when trying to reconnect it already finds the "old" nodeIDs, therefore nothing gets sent to the resultchannel

2. `canSkipDiscovery` saved the nodeID which was `*ua.NodeID` but in the workers we check on the string representation, therefore we load it now with the string