### PR TITLE
fix: opc-tests run now on go.mod/go.sum changes

### DIFF
--- a/.github/actions/path-filter/action.yml
+++ b/.github/actions/path-filter/action.yml
@@ -37,5 +37,4 @@ runs:
             - '${{ inputs.plugin_path }}'
             - '!**/*.md'
           gomod:
-            - 'go.mod'
-            - 'go.sum'
+            - 'go.{mod,sum}'


### PR DESCRIPTION
# Description:

Fixes ENG-4168

The workflow didn't run on changes for `go.mod` `go.sum` as the filter was checking for both patterns in 1 file, which is not possible. This should be resolved via this pattern here