### PR TITLE
fix: update managementConsole workflow because of failure

### DIFF
--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -118,7 +118,7 @@ jobs:
           mkdir -p "ManagementConsole/frontend/src/lib/schemas/benthos/v${VERSION_CLEAN}/"
           cp "benthos-schemas-v${VERSION_CLEAN}.json" \
              "ManagementConsole/frontend/src/lib/schemas/benthos/v${VERSION_CLEAN}/ui.json"
-          cp "benthos-schemas-v${VERSION_CLEAN}-json-schema.json" \
+          cp "schema.json" \
              "ManagementConsole/frontend/src/lib/schemas/benthos/v${VERSION_CLEAN}/monaco.json"
 
       - name: Create Pull Request

--- a/.gitignore
+++ b/.gitignore
@@ -217,7 +217,7 @@ umh-core-data*.pprof
 *.pb
 *.txt
 
-# Local data directories  
+# Local data directories
 umh-core-data/
 
 # Diffs
@@ -225,6 +225,7 @@ umh-core-data/
 
 # Generated schema files (output of schema-export tool)
 benthos-schemas*.json
+schema.json
 
 # Schema export binary
 cmd/schema-export/schema-export


### PR DESCRIPTION
https://github.com/united-manufacturing-hub/benthos-umh/actions/runs/21411909634/job/61651673692

this PR-run failed due to a mismatch of the schema-naming, this should fix it