### PR TITLE
Added support for multiple slaves but different registers from the same

### DIFF
--- a/docs/input/modbus.md
+++ b/docs/input/modbus.md
@@ -52,6 +52,33 @@ input:
         type: "UINT16"
 ```
 
+**Per-Slave Address Example**
+
+When different slaves expose different registers, you can assign addresses to specific slaves:
+
+```yaml
+input:
+  modbus:
+    controller: 'tcp://192.168.1.100:502'
+    slaveIDs: [1, 2, 3]
+    addresses:
+      - name: "temperature"
+        register: "holding"
+        address: 100
+        type: "INT16"
+        slaveID: 1          # Only slave 1
+      - name: "pressure"
+        register: "holding"
+        address: 200
+        type: "INT16"
+        slaveID: 2          # Only slave 2
+      - name: "status"
+        register: "coil"
+        address: 10
+        type: "BIT"
+        # No slaveID → read from ALL slaves (1, 2, 3)
+```
+
 **Controller**
 
 Specifies the network address of the Modbus controller:
@@ -328,4 +355,15 @@ input:
 
     ```yaml
     output: "FLOAT64"
+    ```
+
+9. **Slave ID (per-address)**
+
+* **Description**: Optionally restrict this address to a specific slave ID. When set, only the specified slave will read this address. When omitted or set to 0, all configured slaves (from the top-level `slaveIDs`) will read this address.
+* **Default**: 0 (all slaves)
+* **Validation**: If non-zero, the value must appear in the top-level `slaveIDs` list.
+*   **Configuration Example**:
+
+    ```yaml
+    slaveID: 2
     ```

--- a/modbus_plugin/config_helper.go
+++ b/modbus_plugin/config_helper.go
@@ -73,6 +73,21 @@ func tagID(seed maphash.Seed, item ModbusDataItemWithAddress) uint64 {
 	return mh.Sum64()
 }
 
+// tagIDWithSlave generates a hash for deduplication that includes the slave ID.
+// Used for first-pass dedup to catch identical YAML entries.
+func tagIDWithSlave(seed maphash.Seed, item ModbusDataItemWithAddress) uint64 {
+	var mh maphash.Hash
+	mh.SetSeed(seed)
+
+	mh.WriteString(item.Register)
+	mh.WriteByte(0)
+	mh.WriteString(strconv.Itoa(int(item.Address)))
+	mh.WriteByte(0)
+	mh.WriteByte(item.SlaveID)
+
+	return mh.Sum64()
+}
+
 func determineTagLength(input string, length uint16) (uint16, error) {
 	// Handle our special types
 	switch input {

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -173,7 +173,7 @@ var ModbusConfigSpec = service.NewConfigSpec().
 	Field(service.NewDurationField("timeBetweenReads").Description("The time between two reads of a Modbus device. Useful if you want to read the device every x seconds. Not to be confused with TimeBetweenRequests.").Default("1s")).
 	Field(service.NewStringField("controller").Description("The Modbus controller address, e.g., 'tcp://localhost:502'").Default("tcp://localhost:502")).
 	Field(service.NewStringField("transmissionMode").Description("Transmission mode: 'TCP', 'RTUOverTCP', or 'ASCIIOverTCP'").Default("TCP")).
-	Field(service.NewIntListField("slaveIDs").Description("Slave IDs of the Modbus devices to read from").Default([]int{1})).
+	Field(service.NewIntListField("slaveIDs").Description("Slave IDs of the Modbus devices to read from 1-255").Default([]int{1})).
 	Field(service.NewDurationField("timeout").Description("").Default("1s")).
 	Field(service.NewIntField("busyRetries").Description("Maximum number of retries when the device is busy").Default(3)).
 	Field(service.NewDurationField("busyRetriesWait").Description("Time to wait between retries when the device is busy").Default("200ms")).
@@ -233,8 +233,8 @@ func newModbusInput(conf *service.ParsedConfig, mgr *service.Resources) (service
 	slaveIDs = ids
 	// Convert to byte and assign to m.SlaveIDs
 	for _, slaveID := range slaveIDs {
-		if slaveID < 0 || slaveID > 255 {
-			return nil, fmt.Errorf("slaveID out of range (0-255): %d", slaveID)
+		if slaveID < 1 || slaveID > 255 {
+			return nil, fmt.Errorf("slaveID out of range (1-255): %d", slaveID)
 		}
 		m.SlaveIDs = append(m.SlaveIDs, byte(slaveID))
 	}

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -227,20 +227,21 @@ func newModbusInput(conf *service.ParsedConfig, mgr *service.Resources) (service
 
 	// slaveID only exist for backwards compatibility
 	if conf.Contains("slaveIDs") {
-		if ids, err = conf.FieldIntList("slaveIDs"); err == nil {
-			slaveIDs = ids
-		} else {
+		ids, err = conf.FieldIntList("slaveIDs")
+		if err != nil {
 			return nil, err
 		}
+		slaveIDs = ids
 	} else if conf.Contains("slaveID") {
-		if id, err = conf.FieldInt("slaveID"); err == nil {
-			slaveIDs = []int{id}
-		} else {
+		id, err = conf.FieldInt("slaveID")
+		if err != nil {
 			return nil, err
 		}
+		slaveIDs = []int{id}
 	} else {
 		return nil, fmt.Errorf("no valid slaveID or slaveIDs found")
 	}
+
 	// Convert to byte and assign to m.SlaveIDs
 	for _, slaveID := range slaveIDs {
 		if slaveID < 0 || slaveID > 255 {

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -69,6 +69,10 @@ type ModbusDataItemWithAddress struct {
 	// "scale" is provided and to the input "type" class otherwise (i.e. INT* -> INT64, etc).
 	Output string
 
+	// SlaveID optionally restricts this address to a single slave.
+	// 0 means read from all configured slaves.
+	SlaveID byte
+
 	ConverterFunc converterFunc
 }
 
@@ -125,9 +129,10 @@ type ModbusInput struct {
 	// Addresses is a list of Modbus addresses to read
 	Addresses []ModbusDataItemWithAddress
 
-	// Requests is the auto-generated list of requests to be made
-	// They are creates based on the addresses and the optimization strategy
-	RequestSet RequestSet
+	// RequestSets holds the auto-generated requests per slave ID.
+	// Each slave gets its own optimized set of requests based on which
+	// addresses are assigned to it.
+	RequestSets map[byte]RequestSet
 
 	// Internal
 	Handler        modbus.ClientHandler
@@ -190,7 +195,8 @@ var ModbusConfigSpec = service.NewConfigSpec().
 		service.NewIntField("length").Description("Number of registers, only valid for STRING type").Default(0),
 		service.NewIntField("bit").Description("Bit of the register, only valid for BIT type").Default(0),
 		service.NewFloatField("scale").Description("Factor to scale the variable with").Default(0.0),
-		service.NewStringField("output").Description("Type of resulting field: 'INT64', 'UINT64', 'FLOAT64', or 'native'").Default("")).
+		service.NewStringField("output").Description("Type of resulting field: 'INT64', 'UINT64', 'FLOAT64', or 'native'").Default(""),
+		service.NewIntField("slaveID").Description("Optional: only read this address from the specified slave ID. If 0 or omitted, read from all configured slaveIDs.").Default(0)).
 		Description("List of Modbus addresses to read"))
 
 // newModbusInput is the constructor function for ModbusInput. It parses the plugin configuration,
@@ -384,6 +390,30 @@ func newModbusInput(conf *service.ParsedConfig, mgr *service.Resources) (service
 			return nil, err
 		}
 
+		// Parse slaveID
+		var slaveIDInt int
+		if slaveIDInt, err = addrConf.FieldInt("slaveID"); err != nil {
+			return nil, err
+		}
+		if slaveIDInt < 0 || slaveIDInt > 255 {
+			return nil, fmt.Errorf("slaveID out of range (0-255) for field %q: %d", item.Name, slaveIDInt)
+		}
+		item.SlaveID = byte(slaveIDInt)
+
+		// Validate: if slaveID is non-zero, it must exist in the top-level slaveIDs list
+		if item.SlaveID != 0 {
+			found := false
+			for _, sid := range m.SlaveIDs {
+				if sid == item.SlaveID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, fmt.Errorf("address %q has slaveID %d which is not in the top-level slaveIDs list", item.Name, item.SlaveID)
+			}
+		}
+
 		// Check the input and output type for all fields as we later need
 		// it to determine the number of registers to query.
 		switch item.Register {
@@ -442,52 +472,94 @@ func newModbusInput(conf *service.ParsedConfig, mgr *service.Resources) (service
 			}
 		}
 
-		// Check for duplicate fields
-		if _, exists := seenFields[tagID(seed, item)]; exists {
-			m.Log.Warnf("Duplicate field %q %q, ignoring", item.Name, item.Address)
+		// First-pass dedup: catches identical YAML entries (same register+address+slaveID)
+		if _, exists := seenFields[tagIDWithSlave(seed, item)]; exists {
+			m.Log.Warnf("Duplicate field %q register=%s address=%d slaveID=%d, ignoring", item.Name, item.Register, item.Address, item.SlaveID)
 			continue
 		} else {
-			seenFields[tagID(seed, item)] = true
+			seenFields[tagIDWithSlave(seed, item)] = true
 		}
 
 		m.Addresses = append(m.Addresses, item)
 	}
 
-	// Parse the addresses into batches
-	m.RequestSet, err = m.CreateBatchesFromAddresses(m.Addresses)
-	if err != nil {
-		m.Log.Errorf("Failed to create batches: %v", err)
-		return nil, err
+	// Build per-slave address lists
+	perSlaveAddresses := make(map[byte][]ModbusDataItemWithAddress)
+	for _, item := range m.Addresses {
+		if item.SlaveID == 0 {
+			// Global address: add to every slave
+			for _, sid := range m.SlaveIDs {
+				perSlaveAddresses[sid] = append(perSlaveAddresses[sid], item)
+			}
+		} else {
+			// Specific slave
+			perSlaveAddresses[item.SlaveID] = append(perSlaveAddresses[item.SlaveID], item)
+		}
 	}
 
-	// Output debug messages
-	var nHoldingRegs, nInputsRegs, nDiscreteRegs, nCoilRegs uint16
-	var nHoldingFields, nInputsFields, nDiscreteFields, nCoilFields int
+	// Second-pass dedup: within each slave, dedup by register+address
+	// (catches overlap between global slaveID=0 entries and specific slaveID entries)
+	dedupSeed := maphash.MakeSeed()
+	for sid, addrs := range perSlaveAddresses {
+		seen := make(map[uint64]bool)
+		deduped := make([]ModbusDataItemWithAddress, 0, len(addrs))
+		for _, item := range addrs {
+			id := tagID(dedupSeed, item)
+			if seen[id] {
+				m.Log.Warnf("Duplicate register+address for slave %d: field %q register=%s address=%d, keeping first occurrence", sid, item.Name, item.Register, item.Address)
+				continue
+			}
+			seen[id] = true
+			deduped = append(deduped, item)
+		}
+		perSlaveAddresses[sid] = deduped
+	}
 
-	for _, r := range m.RequestSet.holding {
-		nHoldingRegs += r.length
-		nHoldingFields += len(r.fields)
+	// Build per-slave RequestSets
+	m.RequestSets = make(map[byte]RequestSet)
+	for sid, addrs := range perSlaveAddresses {
+		rs, batchErr := m.CreateBatchesFromAddresses(addrs)
+		if batchErr != nil {
+			m.Log.Errorf("Failed to create batches for slave %d: %v", sid, batchErr)
+			return nil, batchErr
+		}
+		m.RequestSets[sid] = rs
 	}
-	for _, r := range m.RequestSet.input {
-		nInputsRegs += r.length
-		nInputsFields += len(r.fields)
+
+	// Output debug messages per slave
+	for _, sid := range m.SlaveIDs {
+		rs, exists := m.RequestSets[sid]
+		if !exists {
+			m.Log.Infof("Slave %d: no addresses configured", sid)
+			continue
+		}
+
+		var nHoldingRegs, nInputsRegs, nDiscreteRegs, nCoilRegs uint16
+		var nHoldingFields, nInputsFields, nDiscreteFields, nCoilFields int
+
+		for _, r := range rs.holding {
+			nHoldingRegs += r.length
+			nHoldingFields += len(r.fields)
+		}
+		for _, r := range rs.input {
+			nInputsRegs += r.length
+			nInputsFields += len(r.fields)
+		}
+		for _, r := range rs.discrete {
+			nDiscreteRegs += r.length
+			nDiscreteFields += len(r.fields)
+		}
+		for _, r := range rs.coil {
+			nCoilRegs += r.length
+			nCoilFields += len(r.fields)
+		}
+		m.Log.Infof("Slave %d: %d holding request(s) (%d regs, %d fields), %d input (%d regs, %d fields), %d discrete (%d regs, %d fields), %d coil (%d regs, %d fields)",
+			sid,
+			len(rs.holding), nHoldingRegs, nHoldingFields,
+			len(rs.input), nInputsRegs, nInputsFields,
+			len(rs.discrete), nDiscreteRegs, nDiscreteFields,
+			len(rs.coil), nCoilRegs, nCoilFields)
 	}
-	for _, r := range m.RequestSet.discrete {
-		nDiscreteRegs += r.length
-		nDiscreteFields += len(r.fields)
-	}
-	for _, r := range m.RequestSet.coil {
-		nCoilRegs += r.length
-		nCoilFields += len(r.fields)
-	}
-	m.Log.Infof("Got %d request(s) touching %d holding registers for %d fields",
-		len(m.RequestSet.holding), nHoldingRegs, nHoldingFields)
-	m.Log.Infof("Got %d request(s) touching %d inputs registers for %d fields",
-		len(m.RequestSet.input), nInputsRegs, nInputsFields)
-	m.Log.Infof("Got %d request(s) touching %d discrete registers for %d fields",
-		len(m.RequestSet.discrete), nDiscreteRegs, nDiscreteFields)
-	m.Log.Infof("Got %d request(s) touching %d coil registers for %d fields",
-		len(m.RequestSet.coil), nCoilRegs, nCoilFields)
 
 	// Now set up the modbus client
 	u, err := url.Parse(m.Controller)
@@ -714,8 +786,13 @@ func (m *ModbusInput) ReadBatch(ctx context.Context) (service.MessageBatch, serv
 
 	// Loop through all slaves
 	for _, slaveID := range m.SlaveIDs {
+		requestSet, exists := m.RequestSets[slaveID]
+		if !exists {
+			m.Log.Debugf("Slave %d has no configured addresses, skipping", slaveID)
+			continue
+		}
 		m.Log.Debugf("Reading slave %d for %s...", slaveID, m.Controller)
-		msgBatch, err := m.readSlaveData(slaveID, m.RequestSet)
+		msgBatch, err := m.readSlaveData(slaveID, requestSet)
 		if err != nil {
 			m.Log.Errorf("slave %d encountered an error: %v", slaveID, err)
 

--- a/modbus_plugin/modbus_test.go
+++ b/modbus_plugin/modbus_test.go
@@ -17,6 +17,7 @@ package modbus_plugin_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -329,9 +330,26 @@ var _ = Describe("Test Against Wago-PLC", func() {
 })
 
 var _ = Describe("Per-Slave Address Routing", func() {
+	// Helper to build per-slave RequestSets with validation and deduplication,
+	// mimicking the constructor logic. Optionally tracks deduplicated addresses.
+	buildPerSlaveRequestSets := func(input *ModbusInput, tracking map[byte][]ModbusDataItemWithAddress) error {
+		// Validation: if slaveID is non-zero, it must exist in top-level slaveIDs
+		for _, item := range input.Addresses {
+			if item.SlaveID != 0 {
+				found := false
+				for _, sid := range input.SlaveIDs {
+					if sid == item.SlaveID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("address %q has slaveID %d which is not in the top-level slaveIDs list", item.Name, item.SlaveID)
+				}
+			}
+		}
 
-	// Helper to build per-slave RequestSets from addresses, mimicking the constructor logic.
-	buildPerSlaveRequestSets := func(input *ModbusInput) error {
+		// Build per-slave address lists
 		perSlaveAddresses := make(map[byte][]ModbusDataItemWithAddress)
 		for _, item := range input.Addresses {
 			if item.SlaveID == 0 {
@@ -343,6 +361,25 @@ var _ = Describe("Per-Slave Address Routing", func() {
 			}
 		}
 
+		// Second-pass dedup: within each slave, dedup by register+address
+		for sid, addrs := range perSlaveAddresses {
+			seen := make(map[string]bool)
+			deduped := make([]ModbusDataItemWithAddress, 0, len(addrs))
+			for _, item := range addrs {
+				key := fmt.Sprintf("%s:%d", item.Register, item.Address)
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				deduped = append(deduped, item)
+			}
+			perSlaveAddresses[sid] = deduped
+			if tracking != nil {
+				tracking[sid] = deduped
+			}
+		}
+
+		// Build RequestSets
 		input.RequestSets = make(map[byte]RequestSet)
 		for sid, addrs := range perSlaveAddresses {
 			rs, err := input.CreateBatchesFromAddresses(addrs)
@@ -365,7 +402,7 @@ var _ = Describe("Per-Slave Address Routing", func() {
 			},
 		}
 
-		err := buildPerSlaveRequestSets(input)
+		err := buildPerSlaveRequestSets(input, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Both slaves should have RequestSets
@@ -386,7 +423,7 @@ var _ = Describe("Per-Slave Address Routing", func() {
 			},
 		}
 
-		err := buildPerSlaveRequestSets(input)
+		err := buildPerSlaveRequestSets(input, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		// All 3 slaves should have RequestSets
@@ -409,7 +446,7 @@ var _ = Describe("Per-Slave Address Routing", func() {
 			},
 		}
 
-		err := buildPerSlaveRequestSets(input)
+		err := buildPerSlaveRequestSets(input, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Both slaves should have their own RequestSet
@@ -431,12 +468,54 @@ var _ = Describe("Per-Slave Address Routing", func() {
 			},
 		}
 
-		err := buildPerSlaveRequestSets(input)
+		err := buildPerSlaveRequestSets(input, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Only slaves 1 and 2 should have RequestSets
 		Expect(input.RequestSets).To(HaveLen(2))
 		_, exists3 := input.RequestSets[3]
 		Expect(exists3).To(BeFalse())
+	})
+
+	It("should error when address slaveID is not in top-level slaveIDs", func() {
+		input := &ModbusInput{
+			SlaveIDs:    []byte{1, 2},
+			BusyRetries: 1,
+			Addresses: []ModbusDataItemWithAddress{
+				{Name: "temp", Register: "holding", Address: 100, Type: "INT16", SlaveID: 3},
+			},
+		}
+
+		err := buildPerSlaveRequestSets(input, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("slaveID 3"))
+		Expect(err.Error()).To(ContainSubstring("not in the top-level slaveIDs"))
+	})
+
+	It("should deduplicate when global address (slaveID=0) overlaps with specific slave address", func() {
+		input := &ModbusInput{
+			SlaveIDs:    []byte{1, 2},
+			BusyRetries: 1,
+			Addresses: []ModbusDataItemWithAddress{
+				{Name: "globalTemp", Register: "holding", Address: 100, Type: "INT16", SlaveID: 0},
+				{Name: "slave1Temp", Register: "holding", Address: 100, Type: "INT16", SlaveID: 1},
+			},
+		}
+
+		// Track deduplicated addresses per slave
+		dedupedAddresses := make(map[byte][]ModbusDataItemWithAddress)
+		err := buildPerSlaveRequestSets(input, dedupedAddresses)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Both slaves should have RequestSets
+		Expect(input.RequestSets).To(HaveLen(2))
+
+		// Slave 1: should have only globalTemp (first wins), not slave1Temp
+		Expect(dedupedAddresses[1]).To(HaveLen(1))
+		Expect(dedupedAddresses[1][0].Name).To(Equal("globalTemp"))
+
+		// Slave 2: should have globalTemp (no overlap)
+		Expect(dedupedAddresses[2]).To(HaveLen(1))
+		Expect(dedupedAddresses[2][0].Name).To(Equal("globalTemp"))
 	})
 })


### PR DESCRIPTION
Added support for multiple slave-id but different registers. Backwards compatible so old configuration will still work. 

Tested against python server on a different device. 


# Modbus TCP → RTU Gateway Test Environment (Linux + pymodbus)

## Purpose
This document describes a **complete Modbus TCP test setup** that emulates a
**Modbus TCP → RTU gateway** with **10 RTU slaves** (Unit IDs 1–10).

It is intended for testing a **PC-based Modbus TCP client** that:
- Connects to a single IP address
- Uses different **Unit IDs** to access RTU slaves
- Handles overlapping and non-overlapping register maps
- Processes changing data and error conditions

The simulator uses **pymodbus 3.x**, running on Linux.

---

## Architecture
```
PC Client (macOS)
|
| Modbus TCP (Port 502)
|
Linux Server (192.168.3.226)
└─ pymodbus simulator.py
   ├─ Unit ID 1
   ├─ Unit ID 2
   ├─ ...
   └─ Unit ID 10
```
---

## Requirements

- Linux machine (VM or physical)
- Python 3 with venv support
- Network connectivity from PC client
- TCP port 502 open (requires root)

---

## Setup

### Install pymodbus in a virtualenv

```bash
mkdir -p ~/modbus-sim
cd ~/modbus-sim
python3 -m venv venv
source venv/bin/activate
pip install pymodbus
```

### Create the simulator script

Save the following as `~/modbus-sim/simulator.py`:

```python
#!/usr/bin/env python3
"""
Modbus TCP Gateway Simulator - 10 RTU slaves (Unit IDs 1-10)
Uses pymodbus 3.x to emulate a Modbus TCP -> RTU gateway.
"""

import asyncio
import random
import logging

from pymodbus.datastore import (
    ModbusDeviceContext,
    ModbusServerContext,
    ModbusSequentialDataBlock,
)
from pymodbus.server import StartAsyncTcpServer

logging.basicConfig(level=logging.DEBUG)
log = logging.getLogger("modbus-sim")

PORT = 502


def make_block(size, values=None):
    """Create a holding/input register data block.

    pymodbus 3.x ModbusDeviceContext adds +1 to request addresses,
    so we prepend one padding element so that Modbus address 0
    maps to our intended first value.
    """
    data = [0] * (size + 1)  # +1 for the padding element at index 0
    if values:
        for offset, val in values.items():
            data[offset + 1] = val  # shift by 1 for the padding
    return ModbusSequentialDataBlock(0, data)


def build_slaves():
    """Build slave contexts matching the simulator spec."""
    slaves = {}

    # Slave 1 - Main device (HR offsets 0-2)
    slaves[1] = ModbusDeviceContext(
        hr=make_block(100, {0: 215, 1: 1013, 2: 1}),
        ir=make_block(100),
        di=make_block(100),
        co=make_block(100),
    )

    # Slave 2 - Small device (HR offset 0)
    slaves[2] = ModbusDeviceContext(
        hr=make_block(100, {0: 0}),
        ir=make_block(100),
        di=make_block(100),
        co=make_block(100),
    )

    # Slave 3 - Offset register map (HR offsets 10-11)
    slaves[3] = ModbusDeviceContext(
        hr=make_block(100, {10: 55, 11: 1200}),
        ir=make_block(100),
        di=make_block(100),
        co=make_block(100),
    )

    # Slave 4 - Input Registers (IR offsets 0-1)
    slaves[4] = ModbusDeviceContext(
        hr=make_block(100),
        ir=make_block(100, {0: 2300, 1: 512}),
        di=make_block(100),
        co=make_block(100),
    )

    # Slave 5 - Slow-changing device (HR offsets 0-1)
    slaves[5] = ModbusDeviceContext(
        hr=make_block(100, {0: 75, 1: 0}),
        ir=make_block(100),
        di=make_block(100),
        co=make_block(100),
    )

    # Slave 6 - Single-value device (HR offset 0)
    slaves[6] = ModbusDeviceContext(
        hr=make_block(100, {0: 2}),
        ir=make_block(100),
        di=make_block(100),
        co=make_block(100),
    )

    # Slave 7 - High-address registers (HR offsets 99-100)
    slaves[7] = ModbusDeviceContext(
        hr=make_block(200, {99: 5000, 100: 250}),
        ir=make_block(100),
        di=make_block(100),
        co=make_block(100),
    )

    # Slave 8 - Normal device (HR offsets 0-1)
    slaves[8] = ModbusDeviceContext(
        hr=make_block(100, {0: 1450, 1: 60}),
        ir=make_block(100),
        di=make_block(100),
        co=make_block(100),
    )

    # Slave 9 - Empty / broken device
    # Minimal block: only the padding element, so any address access fails
    slaves[9] = ModbusDeviceContext(
        hr=ModbusSequentialDataBlock(0, [0]),
        ir=ModbusSequentialDataBlock(0, [0]),
        di=ModbusSequentialDataBlock(0, [0]),
        co=ModbusSequentialDataBlock(0, [0]),
    )

    # Slave 10 - Critical device (HR offsets 0-3)
    slaves[10] = ModbusDeviceContext(
        hr=make_block(100, {0: 300, 1: 950, 2: 1, 3: 0}),
        ir=make_block(100),
        di=make_block(100),
        co=make_block(100),
    )

    return slaves


async def dynamic_updater(context):
    """Continuously update registers to simulate live devices."""
    log.info("Dynamic updater started")
    while True:
        await asyncio.sleep(1)

        # Slave 1: temperature drift (offset 0, range 210-229)
        context[1].setValues(3, 0, [random.randint(210, 229)])

        # Slave 2: counter increments (offset 0)
        context[2].setValues(3, 0, [random.randint(0, 999)])

        # Slave 3: totalizer growth (offset 11)
        context[3].setValues(3, 11, [random.randint(1200, 1249)])

        # Slave 5: level fluctuation (offset 0)
        context[5].setValues(3, 0, [random.randint(70, 79)])

        # Slave 10: error injection (offset 3)
        context[10].setValues(3, 3, [random.randint(0, 4)])


async def main():
    slaves = build_slaves()
    context = ModbusServerContext(slaves=slaves, single=False)

    asyncio.create_task(dynamic_updater(context))

    log.info(f"Starting Modbus TCP server on port {PORT} with Unit IDs 1-10")
    await StartAsyncTcpServer(
        context=context,
        address=("0.0.0.0", PORT),
    )


if __name__ == "__main__":
    asyncio.run(main())
```

---

## Starting the Simulator

Port 502 requires root:

```bash
sudo ~/modbus-sim/venv/bin/python3 ~/modbus-sim/simulator.py
```

Dynamic register updates are built-in (the `dynamic_updater` coroutine runs
automatically). No separate update script is needed.

---

## Modbus Addressing Notes

* Holding Register **40001 = offset 0**
* Input Register **30001 = offset 0**
* Each Unit ID has an **independent register space**
* Same register numbers may exist on multiple slaves with different values

---

## Slave Register Definitions

### Slave 1 – Main device

| Register | Offset | Description     | Initial |
| -------- | ------ | --------------- | ------- |
| HR 40001 | 0      | Temperature ×10 | 215     |
| HR 40002 | 1      | Pressure ×10    | 1013    |
| HR 40003 | 2      | Status word     | 1       |

---

### Slave 2 – Small device

| Register | Offset | Description | Initial |
| -------- | ------ | ----------- | ------- |
| HR 40001 | 0      | Counter     | 0       |

---

### Slave 3 – Offset register map

| Register | Offset | Description | Initial |
| -------- | ------ | ----------- | ------- |
| HR 40011 | 10     | Flow rate   | 55      |
| HR 40012 | 11     | Totalizer   | 1200    |

---

### Slave 4 – Read-only sensors (Input Registers)

| Register | Offset | Description  | Initial |
| -------- | ------ | ------------ | ------- |
| IR 30001 | 0      | Voltage ×10  | 2300    |
| IR 30002 | 1      | Current ×100 | 512     |

---

### Slave 5 – Slow-changing device

| Register | Offset | Description | Initial |
| -------- | ------ | ----------- | ------- |
| HR 40001 | 0      | Level %     | 75      |
| HR 40002 | 1      | Alarm flags | 0       |

---

### Slave 6 – Single-value device

| Register | Offset | Description | Initial |
| -------- | ------ | ----------- | ------- |
| HR 40001 | 0      | Mode        | 2       |

---

### Slave 7 – High-address registers

| Register | Offset | Description  | Initial |
| -------- | ------ | ------------ | ------- |
| HR 40100 | 99     | Energy (kWh) | 5000    |
| HR 40101 | 100    | Power (kW)   | 250     |

---

### Slave 8 – Normal device

| Register | Offset | Description | Initial |
| -------- | ------ | ----------- | ------- |
| HR 40001 | 0      | Speed (RPM) | 1450    |
| HR 40002 | 1      | Torque %    | 60      |

---

### Slave 9 – Empty / broken device

* No registers defined
* Any read or write returns **Illegal Data Address**

---

### Slave 10 – Critical device

| Register | Offset | Description     | Initial |
| -------- | ------ | --------------- | ------- |
| HR 40001 | 0      | Temperature ×10 | 300     |
| HR 40002 | 1      | Pressure ×10    | 950     |
| HR 40003 | 2      | State           | 1       |
| HR 40004 | 3      | Error code      | 0       |

---

## Dynamic Data Updates

The `dynamic_updater` coroutine modifies these registers every second:

| Slave | Offset | Range       | Behaviour         |
| ----- | ------ | ----------- | ----------------- |
| 1     | 0      | 210 – 229   | Temperature drift |
| 2     | 0      | 0 – 999     | Counter increment |
| 3     | 11     | 1200 – 1249 | Totalizer growth  |
| 5     | 0      | 70 – 79     | Level fluctuation |
| 10    | 3      | 0 – 4       | Error injection   |

---

## Test Scenarios Enabled

* Multiple RTU slaves behind one IP
* Overlapping register addresses
* Different register maps per slave
* Read-only vs writable registers
* Illegal register access
* Dynamic process data
* Random error code injection

This setup closely emulates a **real Modbus TCP → RTU gateway**.

---

## Troubleshooting

### Proxmox firewall blocks port 502

If the Linux server runs inside a Proxmox VM, port 502 must be allowed at the
**node level** firewall, not just the VM level. Proxmox has three firewall
layers (Datacenter, Node, VM) and the node-level rules can block traffic even
when the VM firewall is disabled.

Add a rule: **Direction: IN, Action: ACCEPT, Protocol: TCP, Dest. port: 502**
at the Node (or Datacenter) level.

Symptom: `nc -vz <ip> 502` returns "No route to host" (ICMP reject) rather
than "Connection refused" or a timeout.

### macOS Local Network permissions for unsigned binaries

macOS (Ventura+) blocks **non-Apple-signed binaries** from accessing the local
network. This affects Homebrew-installed tools and custom binaries like
`benthos`.

The permission prompt is tied to the **terminal application** making the
connection (e.g. Ghostty, iTerm, Terminal.app), not the binary itself. Grant
Local Network access to your terminal under **System Settings → Privacy &
Security → Local Network**.

If you never see a prompt, try running from a different terminal application
(e.g. Ghostty) that already has Local Network access.
