### PR TITLE
docs(s7comm): clearer advices on s7-addressing

### DIFF
--- a/docs/input/siemens-s7.md
+++ b/docs/input/siemens-s7.md
@@ -36,7 +36,7 @@ input:
 
 Each address tells benthos-umh **where** to read in the PLC memory and **what data type** to expect. Addresses follow this pattern:
 
-```
+```text
 <area><number>.<type><offset>[.<extra>]
 ```
 
@@ -83,7 +83,7 @@ Breaking this down:
 Two data types require the extra parameter (the part after the second `.`):
 
 **Bit (`X`) — specify which bit (0–7) within the byte:**
-```
+```text
 DB1.X5.2
        │ └─ bit 2 (third bit, counting from 0)
        └─── byte offset 5
@@ -91,7 +91,7 @@ DB1.X5.2
 Bit numbering: `0` is the least significant bit, `7` is the most significant.
 
 **String (`S`) — specify the maximum string length:**
-```
+```text
 DB1.S30.10
         │  └─ max 10 characters
         └──── byte offset 30

--- a/docs/input/siemens-s7.md
+++ b/docs/input/siemens-s7.md
@@ -30,9 +30,119 @@ input:
 * **slot**: Identifies the specific CPU slot within the rack.
 * **timeout**: Timeout duration in seconds for connection attempts and read requests.
 * **disableCPUInfo**: Set this to true to not fetch CPU information from the PLC. Should be used when you get the error 'Failed to get CPU information'
-* **addresses**: Specifies the list of addresses to read. Addresses are automatically batched to respect protocol limits and PDU size. The format for addresses is `<area>.<type><address>[.extra]`, where:
-  * `area`: Specifies the direct area access, e.g., "DB1" for data block one. Supported areas include inputs (`PE`), outputs (`PA`), Merkers (`MK`), DB (`DB`), counters (`C`), and timers (`T`).
-  * `type`: Indicates the data type, such as bit (`X`), byte (`B`), word (`W`), double word (`DW`), integer (`I`), double integer (`DI`), real (`R`), date-time (`DT`), and string (`S`). Some types require an 'extra' parameter, e.g., the bit number for `X` or the maximum length for `S`.
+* **addresses**: List of PLC memory addresses to read. See [Address Format](#address-format) below.
+
+## Address Format
+
+Each address tells benthos-umh **where** to read in the PLC memory and **what data type** to expect. Addresses follow this pattern:
+
+```
+<area><number>.<type><offset>[.<extra>]
+```
+
+Breaking this down:
+
+| Part | What it means | Example |
+|------|---------------|---------|
+| `area` | Memory area in the PLC | `DB`, `MK`, `PE`, `PA`, `C`, `T` |
+| `number` | Which block within the area | `1` in `DB1` (Data Block 1) |
+| `type` | Data type to read | `DW`, `X`, `S`, `R`, etc. |
+| `offset` | Byte position within the block | `20` in `DB1.DW20` (starts at byte 20) |
+| `extra` | Required for some types only | Bit number for `X`, string length for `S` |
+
+> **Note:** The block number is only meaningful for `DB` (Data Blocks), where `DB1` and `DB2` are different blocks. For all other areas (`PE`, `PA`, `MK`, `C`, `T`) there is only a single memory region in the PLC — use `0` as the block number (e.g., `PE0`, `MK0`).
+
+### Memory Areas
+
+| Area | Name | Description | Example |
+|------|------|-------------|---------|
+| `DB` | Data Block | Main data storage — most commonly used | `DB1.DW20` |
+| `PE` | Process Input | Physical inputs (sensors, switches) | `PE0.B0` |
+| `PA` | Process Output | Physical outputs (actuators, relays) | `PA0.W0` |
+| `MK` | Merker (Flags) | Internal boolean/word flags | `MK0.W0` |
+| `C` | Counter | Hardware counters | `C0.W0` |
+| `T` | Timer | Hardware timers | `T0.W0` |
+
+### Data Types
+
+| Type | Name | Size | Output Type | Extra Required? | Example Address |
+|------|------|------|-------------|-----------------|-----------------|
+| `X` | Bit | 1 bit | `bool` | Yes — bit number (0–7) | `DB1.X5.2` |
+| `B` | Byte | 1 byte | `uint8` | No | `DB1.B10` |
+| `C` | Char | 1 byte | `string` (single character) | No | `DB1.C10` |
+| `W` | Word | 2 bytes | `uint16` | No | `DB1.W20` |
+| `I` | Integer | 2 bytes | `int16` (signed) | No | `DB1.I20` |
+| `DW` | Double Word | 4 bytes | `uint32` | No | `DB1.DW100` |
+| `DI` | Double Integer | 4 bytes | `int32` (signed) | No | `DB1.DI100` |
+| `R` | Real | 4 bytes | `float32` | No | `DB1.R200` |
+| `DT` | Date/Time | 8 bytes | `int64` (Unix nanoseconds) | No | `DB1.DT0` |
+| `S` | String | variable | `string` | Yes — max length (≥ 1) | `DB1.S30.10` |
+
+### The Extra Parameter
+
+Two data types require the extra parameter (the part after the second `.`):
+
+**Bit (`X`) — specify which bit (0–7) within the byte:**
+```
+DB1.X5.2
+       │ └─ bit 2 (third bit, counting from 0)
+       └─── byte offset 5
+```
+Bit numbering: `0` is the least significant bit, `7` is the most significant.
+
+**String (`S`) — specify the maximum string length:**
+```
+DB1.S30.10
+        │  └─ max 10 characters
+        └──── byte offset 30
+```
+The PLC stores strings with a 2-byte header (max length + actual length), so `DB1.S30.10` reads 12 bytes starting at offset 30.
+
+All other types must **not** have an extra parameter.
+
+### Examples
+
+```yaml
+addresses:
+  # Data Block reads
+  - "DB1.X0.0"      # Bit 0 of byte 0 — a boolean flag
+  - "DB1.DW8"       # Unsigned 32-bit double word at offset 8
+  - "DB1.R16"       # 32-bit float at offset 16
+  - "DB1.S28.50"    # String of up to 50 chars starting at offset 28
+
+  # Process Inputs (PE) — reading from sensors, switches, etc.
+  - "PE0.X0.0"      # Input bit 0 — e.g., a digital sensor
+  - "PE0.X0.7"      # Input bit 7
+  - "PE0.B2"        # Input byte at offset 2
+  - "PE0.W4"        # Input word at offset 4 — e.g., an analog sensor value
+
+  # Process Outputs (PA) — reading back output states
+  - "PA0.X0.0"      # Output bit 0 — e.g., a relay state
+  - "PA0.W0"        # Output word at offset 0
+
+  # Merker / Flags (MK)
+  - "MK0.X0.0"      # Merker bit — internal boolean flag
+  - "MK0.W10"       # Merker word at offset 10
+```
+
+### Mapping from TIA Portal
+
+When reading addresses from a TIA Portal project, map them like this:
+
+| TIA Portal | benthos-umh | Notes |
+|------------|-------------|-------|
+| `DB1.DBX 5.2` | `DB1.X5.2` | Data bit — drop "DB" prefix from type |
+| `DB1.DBB 10` | `DB1.B10` | Data byte |
+| `DB1.DBW 20` | `DB1.W20` | Data word |
+| `DB1.DBD 100` | `DB1.DW100` | Data double word (unsigned) |
+| `DB1.DBD 100` | `DB1.DI100` | Data double word (signed) — same offset, different type |
+| `DB1.DBD 200` | `DB1.R200` | Data real (float) |
+| `M 0.0` | `MK0.X0.0` | Merker bit |
+| `MW 10` | `MK0.W10` | Merker word |
+| `I 0.0` | `PE0.X0.0` | Input bit |
+| `IW 0` | `PE0.W0` | Input word |
+| `Q 0.0` | `PA0.X0.0` | Output bit |
+| `QW 0` | `PA0.W0` | Output word |
 
 **Output**
 


### PR DESCRIPTION
# Description:

This PR introduces a clearer overview for s7-addresses. It introduces the opportunity for each non-technical user to simply check the docs for the different addresses and get a better understanding on how addressing works from `TIA Portal` -> `benthos-umh`