### PR TITLE
Fix(s7comm): address naming accordingly

### DIFF
--- a/docs/input/siemens-s7.md
+++ b/docs/input/siemens-s7.md
@@ -58,18 +58,18 @@ Breaking this down:
 | `offset` | Byte position within the area | `20` in `DB1.DW20` (starts at byte 20) |
 | `extra` | Required for some types only | Bit number for `X`, string length for `S` |
 
-Only **DB** (Data Blocks) uses the block number. For all other areas there is only a single memory region in the PLC, so no block number is needed.
+Only **DB** (Data Blocks) uses a block number.
 
 ### Memory Areas
 
-| Area | Name | Description | Has blocks? | Example |
-|------|------|-------------|-------------|---------|
-| `DB` | Data Block | Main data storage — most commonly used | Yes — `DB1`, `DB2`, etc. are different blocks | `DB1.DW20` |
-| `PE` | Process Input | Physical inputs (sensors, switches) | No — only one area | `PE.B0` |
-| `PA` | Process Output | Physical outputs (actuators, relays) | No — only one area | `PA.W0` |
-| `MK` | Merker (Flags) | Internal boolean/word flags | No — only one area | `MK.W0` |
-| `C` | Counter | Hardware counters | No — only one area | `C.W0` |
-| `T` | Timer | Hardware timers | No — only one area | `T.W0` |
+| Area | Name | Description | Example |
+|------|------|-------------|---------|
+| `DB` | Data Block | Main data storage — most commonly used | `DB1.DW20` |
+| `PE` | Process Input | Physical inputs (sensors, switches) | `PE.B0` |
+| `PA` | Process Output | Physical outputs (actuators, relays) | `PA.W0` |
+| `MK` | Merker (Flags) | Internal boolean/word flags | `MK.W0` |
+| `C` | Counter | Hardware counters | `C.W0` |
+| `T` | Timer | Hardware timers | `T.W0` |
 
 ### Data Types
 

--- a/docs/input/siemens-s7.md
+++ b/docs/input/siemens-s7.md
@@ -34,34 +34,42 @@ input:
 
 ## Address Format
 
-Each address tells benthos-umh **where** to read in the PLC memory and **what data type** to expect. Addresses follow this pattern:
+Each address tells benthos-umh **where** to read in the PLC memory and **what data type** to expect.
 
+**For Data Blocks** (block number required):
 ```text
-<area><number>.<type><offset>[.<extra>]
+DB<number>.<type><offset>[.<extra>]
 ```
+Example: `DB1.DW20` — double word at offset 20 in data block 1.
+
+**For all other areas** (no block number):
+```text
+<area>.<type><offset>[.<extra>]
+```
+Example: `PE.W0` — input word at offset 0.
 
 Breaking this down:
 
 | Part | What it means | Example |
 |------|---------------|---------|
 | `area` | Memory area in the PLC | `DB`, `MK`, `PE`, `PA`, `C`, `T` |
-| `number` | Which block within the area | `1` in `DB1` (Data Block 1) |
+| `number` | Which data block (DB only) | `1` in `DB1` (Data Block 1) |
 | `type` | Data type to read | `DW`, `X`, `S`, `R`, etc. |
-| `offset` | Byte position within the block | `20` in `DB1.DW20` (starts at byte 20) |
+| `offset` | Byte position within the area | `20` in `DB1.DW20` (starts at byte 20) |
 | `extra` | Required for some types only | Bit number for `X`, string length for `S` |
 
-> **Note:** The block number is only meaningful for `DB` (Data Blocks), where `DB1` and `DB2` are different blocks. For all other areas (`PE`, `PA`, `MK`, `C`, `T`) there is only a single memory region in the PLC — use `0` as the block number (e.g., `PE0`, `MK0`).
+Only **DB** (Data Blocks) uses the block number. For all other areas there is only a single memory region in the PLC, so no block number is needed.
 
 ### Memory Areas
 
-| Area | Name | Description | Example |
-|------|------|-------------|---------|
-| `DB` | Data Block | Main data storage — most commonly used | `DB1.DW20` |
-| `PE` | Process Input | Physical inputs (sensors, switches) | `PE0.B0` |
-| `PA` | Process Output | Physical outputs (actuators, relays) | `PA0.W0` |
-| `MK` | Merker (Flags) | Internal boolean/word flags | `MK0.W0` |
-| `C` | Counter | Hardware counters | `C0.W0` |
-| `T` | Timer | Hardware timers | `T0.W0` |
+| Area | Name | Description | Has blocks? | Example |
+|------|------|-------------|-------------|---------|
+| `DB` | Data Block | Main data storage — most commonly used | Yes — `DB1`, `DB2`, etc. are different blocks | `DB1.DW20` |
+| `PE` | Process Input | Physical inputs (sensors, switches) | No — only one area | `PE.B0` |
+| `PA` | Process Output | Physical outputs (actuators, relays) | No — only one area | `PA.W0` |
+| `MK` | Merker (Flags) | Internal boolean/word flags | No — only one area | `MK.W0` |
+| `C` | Counter | Hardware counters | No — only one area | `C.W0` |
+| `T` | Timer | Hardware timers | No — only one area | `T.W0` |
 
 ### Data Types
 
@@ -111,18 +119,18 @@ addresses:
   - "DB1.S28.50"    # String of up to 50 chars starting at offset 28
 
   # Process Inputs (PE) — reading from sensors, switches, etc.
-  - "PE0.X0.0"      # Input bit 0 — e.g., a digital sensor
-  - "PE0.X0.7"      # Input bit 7
-  - "PE0.B2"        # Input byte at offset 2
-  - "PE0.W4"        # Input word at offset 4 — e.g., an analog sensor value
+  - "PE.X0.0"       # Input bit 0 — e.g., a digital sensor
+  - "PE.X0.7"       # Input bit 7
+  - "PE.B2"         # Input byte at offset 2
+  - "PE.W4"         # Input word at offset 4 — e.g., an analog sensor value
 
   # Process Outputs (PA) — reading back output states
-  - "PA0.X0.0"      # Output bit 0 — e.g., a relay state
-  - "PA0.W0"        # Output word at offset 0
+  - "PA.X0.0"       # Output bit 0 — e.g., a relay state
+  - "PA.W0"         # Output word at offset 0
 
   # Merker / Flags (MK)
-  - "MK0.X0.0"      # Merker bit — internal boolean flag
-  - "MK0.W10"       # Merker word at offset 10
+  - "MK.X0.0"       # Merker bit — internal boolean flag
+  - "MK.W10"        # Merker word at offset 10
 ```
 
 ### Mapping from TIA Portal
@@ -137,12 +145,12 @@ When reading addresses from a TIA Portal project, map them like this:
 | `DB1.DBD 100` | `DB1.DW100` | Data double word (unsigned) |
 | `DB1.DBD 100` | `DB1.DI100` | Data double word (signed) — same offset, different type |
 | `DB1.DBD 200` | `DB1.R200` | Data real (float) |
-| `M 0.0` | `MK0.X0.0` | Merker bit |
-| `MW 10` | `MK0.W10` | Merker word |
-| `I 0.0` | `PE0.X0.0` | Input bit |
-| `IW 0` | `PE0.W0` | Input word |
-| `Q 0.0` | `PA0.X0.0` | Output bit |
-| `QW 0` | `PA0.W0` | Output word |
+| `M 0.0` | `MK.X0.0` | Merker bit |
+| `MW 10` | `MK.W10` | Merker word |
+| `I 0.0` | `PE.X0.0` | Input bit |
+| `IW 0` | `PE.W0` | Input word |
+| `Q 0.0` | `PA.X0.0` | Output bit |
+| `QW 0` | `PA.W0` | Output word |
 
 **Output**
 

--- a/s7comm_plugin/s7comm.go
+++ b/s7comm_plugin/s7comm.go
@@ -199,6 +199,8 @@ const (
 )
 
 // deprecatedAddressWarning returns a warning if the address uses the old format.
+// NOTE: when migrating configs the metadata address will change as well, keep that
+// in mind when enforcing deprecation.
 func deprecatedAddressWarning(address string) string {
 	if !regexAddr.MatchString(address) {
 		return ""

--- a/s7comm_plugin/s7comm.go
+++ b/s7comm_plugin/s7comm.go
@@ -431,9 +431,6 @@ func handleFieldAddress(address string) (*gos7.S7DataItem, converterFunc, error)
 		return nil, nil, errors.New("area is missing from address")
 	}
 
-	if _, found := groups["no"]; !found {
-		return nil, nil, errors.New("area index is missing from address")
-	}
 	if _, found := groups["type"]; !found {
 		return nil, nil, errors.New("type is missing from address")
 	}

--- a/s7comm_plugin/s7comm.go
+++ b/s7comm_plugin/s7comm.go
@@ -52,7 +52,7 @@ var (
 		"DI": 0x07, // Double integer (32 bit)
 		"R":  0x08, // IEEE 754 real (32 bit)
 		// see https://support.industry.siemens.com/cs/document/36479/date_and_time-format-for-s7-?dti=0&lc=en-DE
-		"DT": 0x0F, // Date and time (7 byte)
+		"DT": 0x0F, // Date and time (8 byte)
 	}
 )
 
@@ -497,8 +497,8 @@ func handleFieldAddress(address string) (*gos7.S7DataItem, converterFunc, error)
 		buflen = 2
 	case "DW", "DI", "R": // 32-bit types
 		buflen = 4
-	case "DT": // 7-byte
-		buflen = 7
+	case "DT": // 8-byte
+		buflen = 8
 	case "S":
 		amount = extra
 		// Extra bytes as the first byte is the max-length of the string and

--- a/s7comm_plugin/s7comm_test.go
+++ b/s7comm_plugin/s7comm_test.go
@@ -107,8 +107,13 @@ var _ = Describe("S7Comm Plugin Unittests", func() {
 			}),
 		Entry("same Area but different Item.Bit",
 			S7Addresses{
-				addresses:      []string{"PE2.X0.0", "PE2.X0.1"},
+				addresses:      []string{"PE.X0.0", "PE.X0.1"},
 				expectedErrMsg: nil,
+			}),
+		Entry("non-DB area with block number is rejected",
+			S7Addresses{
+				addresses:      []string{"PE2.X0.0"},
+				expectedErrMsg: []string{"does not have sub-blocks", "use PE.X0"},
 			}),
 		Entry("same DBNumber and same Item.Area",
 			S7Addresses{
@@ -119,6 +124,11 @@ var _ = Describe("S7Comm Plugin Unittests", func() {
 			S7Addresses{
 				addresses:      []string{"DB2.X0.0", "DB2.W2", "DB2.X0.0"},
 				expectedErrMsg: []string{"duplicate address", "DB2.X0.0"},
+			}),
+		Entry("DB without block number is rejected",
+			S7Addresses{
+				addresses:      []string{"DB.W0"},
+				expectedErrMsg: []string{"DB requires a block number"},
 			}),
 	)
 

--- a/s7comm_plugin/s7comm_test.go
+++ b/s7comm_plugin/s7comm_test.go
@@ -51,6 +51,9 @@ var _ = Describe("S7Comm Plugin Unittests", func() {
 			tests := []testCase{
 				{"DB2.W0", "0000", uint16(0)},
 				{"DB2.W1", "0001", uint16(1)},
+				// Regression: DT requires an 8-byte buffer.
+				{"DB1.DT0", "2401151030451230",
+					time.Date(2024, 1, 15, 10, 30, 45, 123*1000000, time.UTC).UnixNano()},
 			}
 
 			for _, tc := range tests {

--- a/s7comm_plugin/s7comm_test.go
+++ b/s7comm_plugin/s7comm_test.go
@@ -52,8 +52,10 @@ var _ = Describe("S7Comm Plugin Unittests", func() {
 				{"DB2.W0", "0000", uint16(0)},
 				{"DB2.W1", "0001", uint16(1)},
 				// Regression: DT requires an 8-byte buffer.
-				{"DB1.DT0", "2401151030451230",
-					time.Date(2024, 1, 15, 10, 30, 45, 123*1000000, time.UTC).UnixNano()},
+				{
+					"DB1.DT0", "2401151030451230",
+					time.Date(2024, 1, 15, 10, 30, 45, 123*1000000, time.UTC).UnixNano(),
+				},
 			}
 
 			for _, tc := range tests {

--- a/s7comm_plugin/s7comm_test.go
+++ b/s7comm_plugin/s7comm_test.go
@@ -110,10 +110,10 @@ var _ = Describe("S7Comm Plugin Unittests", func() {
 				addresses:      []string{"PE.X0.0", "PE.X0.1"},
 				expectedErrMsg: nil,
 			}),
-		Entry("non-DB area with block number is rejected",
+		Entry("non-DB area with block number is deprecated but still accepted",
 			S7Addresses{
 				addresses:      []string{"PE2.X0.0"},
-				expectedErrMsg: []string{"does not have sub-blocks", "use PE.X0"},
+				expectedErrMsg: nil,
 			}),
 		Entry("same DBNumber and same Item.Area",
 			S7Addresses{


### PR DESCRIPTION
# Description:

Fixes ENG-4158

This PR adjusts the `s7comm`-addressing accordingly to not anymore be confusing. Also it fixes the correct sizing of the `DateAndTime` format, as it previously crashed due to the wrong buffer size.

| Area | Before | Now | Change |
  |------|--------|-----|--------|
  | Data Block | `DB1.DW20` | `DB1.DW20` | No change — block number required |
  | Process Input | `PE0.X0.0` | `PE.X0.0` | Block number removed |
  | Process Output | `PA0.W0` | `PA.W0` | Block number removed |
  | Merker | `MK0.X0.0` | `MK.X0.0` | Block number removed |
  | Counter | `C0.W0` | `C.W0` | Block number removed |
  | Timer | `T0.W0` | `T.W0` | Block number removed |
