### PR TITLE
[ENG-4413] Deprecated flag missing in schema export

### DIFF
--- a/cmd/schema-export/exporter.go
+++ b/cmd/schema-export/exporter.go
@@ -132,6 +132,7 @@ func extractFields(configObj map[string]interface{}) map[string]FieldSpec {
 			Description: getString(fieldMap, "description"),
 			Required:    !getBool(fieldMap, "is_optional") && !hasDefault(fieldMap),
 			Advanced:    getBool(fieldMap, "is_advanced"),
+			Deprecated:  getBool(fieldMap, "is_deprecated"),
 		}
 
 		// Skip fields with empty names to avoid map key collision
@@ -187,6 +188,7 @@ func extractFieldsArray(childFields []interface{}) []FieldSpec {
 			Description: getString(fieldMap, "description"),
 			Required:    !getBool(fieldMap, "is_optional") && !hasDefault(fieldMap),
 			Advanced:    getBool(fieldMap, "is_advanced"),
+			Deprecated:  getBool(fieldMap, "is_deprecated"),
 		}
 
 		// Handle default value

--- a/cmd/schema-export/exporter_test.go
+++ b/cmd/schema-export/exporter_test.go
@@ -208,6 +208,37 @@ var _ = Describe("extractFields", func() {
 			Expect(fields["field_without_default"].Required).To(BeTrue())
 		})
 
+		It("should set Advanced and Deprecated flags correctly", func() {
+			configObj := map[string]any{
+				"children": []any{
+					map[string]any{
+						"name":        "basic_field",
+						"type":        "string",
+						"kind":        "scalar",
+						"description": "Basic field",
+						"is_optional": false,
+						"is_advanced": false,
+					},
+					map[string]any{
+						"name":          "advanced_field",
+						"type":          "string",
+						"kind":          "scalar",
+						"description":   "Advanced field",
+						"is_optional":   false,
+						"is_advanced":   true,
+						"is_deprecated": true,
+					},
+				},
+			}
+
+			fields := extractFields(configObj)
+
+			Expect(fields["basic_field"].Advanced).To(BeFalse())
+			Expect(fields["basic_field"].Deprecated).To(BeFalse())
+			Expect(fields["advanced_field"].Advanced).To(BeTrue())
+			Expect(fields["advanced_field"].Deprecated).To(BeTrue())
+		})
+
 		It("should set Advanced flag correctly", func() {
 			configObj := map[string]interface{}{
 				"children": []interface{}{

--- a/cmd/schema-export/exporter_test.go
+++ b/cmd/schema-export/exporter_test.go
@@ -238,34 +238,6 @@ var _ = Describe("extractFields", func() {
 			Expect(fields["advanced_field"].Advanced).To(BeTrue())
 			Expect(fields["advanced_field"].Deprecated).To(BeTrue())
 		})
-
-		It("should set Advanced flag correctly", func() {
-			configObj := map[string]interface{}{
-				"children": []interface{}{
-					map[string]interface{}{
-						"name":        "basic_field",
-						"type":        "string",
-						"kind":        "scalar",
-						"description": "Basic field",
-						"is_optional": false,
-						"is_advanced": false,
-					},
-					map[string]interface{}{
-						"name":        "advanced_field",
-						"type":        "string",
-						"kind":        "scalar",
-						"description": "Advanced field",
-						"is_optional": false,
-						"is_advanced": true,
-					},
-				},
-			}
-
-			fields := extractFields(configObj)
-
-			Expect(fields["basic_field"].Advanced).To(BeFalse())
-			Expect(fields["advanced_field"].Advanced).To(BeTrue())
-		})
 	})
 
 	Context("when given fields with examples and options", func() {

--- a/cmd/schema-export/json_schema.go
+++ b/cmd/schema-export/json_schema.go
@@ -93,6 +93,11 @@ func convertFieldToJSONSchema(field FieldSpec) map[string]interface{} {
 		schema["x-advanced"] = true
 	}
 
+	// Add deprecated flag
+	if field.Deprecated {
+		schema["deprecated"] = true
+	}
+
 	// Handle object arrays with children (e.g., modbus addresses: type="object", kind="array")
 	// Properties go INSIDE items, not at top level
 	if field.Kind == "array" && field.Type == "object" && len(field.Children) > 0 {

--- a/cmd/schema-export/json_schema.go
+++ b/cmd/schema-export/json_schema.go
@@ -95,7 +95,7 @@ func convertFieldToJSONSchema(field FieldSpec) map[string]interface{} {
 
 	// Add deprecated flag
 	if field.Deprecated {
-		schema["deprecated"] = true
+		schema["x-deprecated"] = true
 	}
 
 	// Handle object arrays with children (e.g., modbus addresses: type="object", kind="array")

--- a/cmd/schema-export/types.go
+++ b/cmd/schema-export/types.go
@@ -55,5 +55,6 @@ type FieldSpec struct {
 	Examples    []interface{} `json:"examples,omitempty"`
 	Options     []string      `json:"options,omitempty"`
 	Advanced    bool          `json:"advanced,omitempty"`
+	Deprecated  bool          `json:"deprecated,omitempty"`
 	Children    []FieldSpec   `json:"children,omitempty"` // For nested objects/arrays
 }


### PR DESCRIPTION
### Problem
The schema-export tool does not extract the is_deprecated flag from Benthos field metadata when generating ui.json schema files. This means fields marked with .Deprecated() in Go plugin definitions (e.g., batchMaxSize in s7comm_plugin/s7comm.go:109) are missing the "deprecated": true property in the generated ui.json.



