### PR TITLE
fix(schema): fields shouldnt be required when children have defaults

### DIFF
--- a/cmd/schema-export/exporter.go
+++ b/cmd/schema-export/exporter.go
@@ -165,6 +165,10 @@ func extractFields(configObj map[string]interface{}) map[string]FieldSpec {
 			field.Children = extractFieldsArray(childFields)
 		}
 
+		if field.Required && len(field.Children) > 0 && !hasRequiredChildren(field.Children) {
+			field.Required = false
+		}
+
 		fields[field.Name] = field
 	}
 
@@ -214,6 +218,10 @@ func extractFieldsArray(childFields []interface{}) []FieldSpec {
 		// Recursively handle nested children
 		if childFieldsNested, ok := fieldMap["children"].([]interface{}); ok && len(childFieldsNested) > 0 {
 			field.Children = extractFieldsArray(childFieldsNested)
+		}
+
+		if field.Required && len(field.Children) > 0 && !hasRequiredChildren(field.Children) {
+			field.Required = false
 		}
 
 		fields = append(fields, field)
@@ -284,4 +292,13 @@ func getBool(m map[string]interface{}, key string) bool {
 func hasDefault(m map[string]interface{}) bool {
 	_, ok := m["default"]
 	return ok
+}
+
+func hasRequiredChildren(children []FieldSpec) bool {
+	for _, child := range children {
+		if child.Required {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
# Description

<img width="667" height="432" alt="grafik" src="https://github.com/user-attachments/assets/eac168c0-632d-4d90-8efe-4fa35198076a" />

Currently in ManagementConsole we got the issue that the editor flags multiple fields in several plugins as `required`. These fields are set to required, as we check on them if they're not set to optional and do not have a default field. 

Now we will check for the children if they already have defaults set, if so the parent-field is not anymore required as this then will get set via the defaults.