### PR TITLE
chore(schema): update the schema disc test in ManagementConsole

### DIFF
--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -126,8 +126,27 @@ jobs:
           VERSION_CLEAN="${VERSION#v}"
           TEST_FILE="ManagementConsole/frontend/src/lib/schemas/loaders/versioned-ui-loader.test.ts"
 
+<<<<<<< Updated upstream
           if ! grep -q "toContain('v${VERSION_CLEAN}')" "$TEST_FILE"; then
               sed -i "/expect(versions\.length)\.toBeGreaterThanOrEqual/i\\      expect(versions).toContain('v${VERSION_CLEAN}');" "$TEST_FILE"
+=======
+          if [ ! -f "$TEST_FILE" ]; then
+              echo "Missing test file: $TEST_FILE" >&2
+              exit 1
+          fi
+
+          if ! grep -q "expect(versions\.length)\.toBeGreaterThanOrEqual" "$TEST_FILE"; then
+              echo "Anchor line not found in $TEST_FILE" >&2
+              exit 1
+          fi
+
+          if ! grep -q "toContain('v${VERSION_CLEAN}')" "$TEST_FILE"; then
+              sed -i "/expect(versions\.length)\.toBeGreaterThanOrEqual/i\\      expect(versions).toContain('v${VERSION_CLEAN}');" "$TEST_FILE"
+              grep -q "toContain('v${VERSION_CLEAN}')" "$TEST_FILE" || {
+                  echo "Failed to insert version assertion into $TEST_FILE" >&2
+                  exit 1
+              }
+>>>>>>> Stashed changes
           fi
 
       - name: Create Pull Request

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -126,10 +126,6 @@ jobs:
           VERSION_CLEAN="${VERSION#v}"
           TEST_FILE="ManagementConsole/frontend/src/lib/schemas/loaders/versioned-ui-loader.test.ts"
 
-<<<<<<< Updated upstream
-          if ! grep -q "toContain('v${VERSION_CLEAN}')" "$TEST_FILE"; then
-              sed -i "/expect(versions\.length)\.toBeGreaterThanOrEqual/i\\      expect(versions).toContain('v${VERSION_CLEAN}');" "$TEST_FILE"
-=======
           if [ ! -f "$TEST_FILE" ]; then
               echo "Missing test file: $TEST_FILE" >&2
               exit 1
@@ -146,7 +142,6 @@ jobs:
                   echo "Failed to insert version assertion into $TEST_FILE" >&2
                   exit 1
               }
->>>>>>> Stashed changes
           fi
 
       - name: Create Pull Request

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -121,6 +121,15 @@ jobs:
           cp "schema.json" \
              "ManagementConsole/frontend/src/lib/schemas/benthos/v${VERSION_CLEAN}/monaco.json"
 
+      - name: Update schema discovery test
+        run: |
+          VERSION_CLEAN="${VERSION#v}"
+          TEST_FILE="ManagementConsole/frontend/src/lib/schemas/loaders/versioned-ui-loader.test.ts"
+
+          if ! grep -q "toContain('v${VERSION_CLEAN}')" "$TEST_FILE"; then
+              sed -i "/expect(versions\.length)\.toBeGreaterThanOrEqual/i\\      expect(versions).toContain('v${VERSION_CLEAN}');" "$TEST_FILE"
+          fi
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7
         with:


### PR DESCRIPTION
# Description

Updates the schema release workflow to add new versions to ManagementConsole's schema discovery test automatically, preventing CI failures on future schema update PRs.

Fixes ENG-4440