### PR TITLE
chore(renovate): update go import paths automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "commitMessagePrefix": "[renovate]chore(deps):",
   "enabledManagers": ["dockerfile", "gomod"],
-  "postUpdateOptions": ["gomodTidy"],
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "minimumReleaseAge": "7 days",
   "timezone": "Europe/Berlin",
   "schedule": ["* * * * 0"],


### PR DESCRIPTION
# Description

Currently we need to manually update go import paths whenever the `go.mod` file gets updated versions.
This should automate it and then we would be able to see any issues from breaking changes as well, since `go build` should then fail.