### PR TITLE
[ENG-4539] Moved Modbus fields into advanced settings

### DIFF
--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -85,7 +85,7 @@ type ModbusInput struct {
 
 	// Standard
 	Controller       string        // e.g., "tcp://localhost:502"
-	TransmissionMode string        // Can be "TCP" (default), "RTUOverTCP", "ASCIIOverTCP"\
+	TransmissionMode string        // Can be "TCP" (default), "RTUoverTCP", "ASCIIoverTCP"\
 	SlaveIDs         []byte        // This allows to fetch the same Addresses from different SlaveIDs
 	Timeout          time.Duration // Timeout for the connection
 	BusyRetries      int           // Maximum number of retries when the device is busy
@@ -171,8 +171,8 @@ var ModbusConfigSpec = service.NewConfigSpec().
 	Summary("Creates an input that reads data from Modbus devices. Created & maintained by the United Manufacturing Hub. About us: www.umh.app").
 	Description("This input plugin enables Benthos to read data directly from Modbus devices using the Modbus protocol.").
 	Field(service.NewDurationField("timeBetweenReads").Description("The time between two reads of a Modbus device. Useful if you want to read the device every x seconds. Not to be confused with TimeBetweenRequests.").Default("1s").Advanced()).
-	Field(service.NewStringField("controller").Description("The Modbus controller address, e.g., 'tcp://localhost:502'").Default("tcp://localhost:502")).
-	Field(service.NewStringField("transmissionMode").Description("Transmission mode: 'TCP', 'RTUOverTCP', or 'ASCIIOverTCP'").Default("TCP").Advanced()).
+	Field(service.NewStringField("controller").Description("The Modbus controller address, e.g., 'tcp://localhost:502'").Default("tcp://localhost:502").Advanced()).
+	Field(service.NewStringField("transmissionMode").Description("Transmission mode: 'TCP', 'RTUoverTCP', or 'ASCIIoverTCP'").Default("TCP").Advanced()).
 	Field(service.NewIntListField("slaveIDs").Description("Slave IDs of the Modbus devices to read from 1-255").Default([]int{1})).
 	Field(service.NewDurationField("timeout").Description("").Default("1s").Advanced()).
 	Field(service.NewIntField("busyRetries").Description("Maximum number of retries when the device is busy").Default(3).Advanced()).


### PR DESCRIPTION
To improve the structure and clarity, a few fields of the protocol should be listed under Advanced.