### PR TITLE
fix: json-schema type mapping issues

### DIFF
--- a/cmd/schema-export/json_schema.go
+++ b/cmd/schema-export/json_schema.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 )
 
 // validateFormat validates the format flag value
@@ -30,6 +31,8 @@ func validateFormat(format string) error {
 }
 
 // mapBenthosBaseType converts a Benthos type string to JSON Schema type string.
+// Handles primitive types, structural types (object, array), and component
+// reference types (input, output, processor, scanner) which map to "object".
 // Returns the mapped type and whether the type was recognized.
 func mapBenthosBaseType(t string) (string, bool) {
 	switch t {
@@ -46,6 +49,7 @@ func mapBenthosBaseType(t string) (string, bool) {
 	case "input", "output", "processor", "scanner":
 		return "object", true
 	default:
+		fmt.Fprintf(os.Stderr, "warning: unrecognized Benthos type %q, producing unconstrained schema\n", t)
 		return "", false
 	}
 }

--- a/cmd/schema-export/json_schema_test.go
+++ b/cmd/schema-export/json_schema_test.go
@@ -271,6 +271,28 @@ var _ = Describe("JSON Schema Generator", func() {
 		})
 	})
 
+	Context("map kind with unrecognized type", func() {
+		It("should produce unconstrained additionalProperties", func() {
+			field := FieldSpec{Name: "meta", Type: "unknown_thing", Kind: "map"}
+			result := convertFieldToJSONSchema(field)
+			Expect(result["type"]).To(Equal("object"))
+			additionalProps, ok := result["additionalProperties"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(additionalProps).To(BeEmpty())
+		})
+	})
+
+	Context("array kind with unrecognized type", func() {
+		It("should produce unconstrained items", func() {
+			field := FieldSpec{Name: "params", Type: "unknown_thing", Kind: "array"}
+			result := convertFieldToJSONSchema(field)
+			Expect(result["type"]).To(Equal("array"))
+			items, ok := result["items"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(items).To(BeEmpty())
+		})
+	})
+
 	Context("component reference types", func() {
 		DescribeTable("should map to object",
 			func(benthosType string) {


### PR DESCRIPTION
# Description

This PR introduces fixes for the schema-creation, which was incorreclty flagged as faulty in `ManagementConsole`.

- map fields (`kind: "map"`) now correctly produce `"type": "object"` with `"additionalProperties"` instead of `"type": "string"`
- component reference types (`input`, `output`, `processor`, `scanner`) now map to `"object"` instead of `"string"`
- unknown types now produce an empty schema `{}` (any value) instead of `"type": "string"`

Fixes ENG-4418

## Upcoming

- create a new release
- check the schema
- check the ManagementConsole