### PR TITLE
fix(opcua): handle bad-status values and ExtensionObjects gracefully without dropping the batch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ msg.meta.umh_topic = `umh.v1.${msg.meta.location_path}.${msg.meta.data_contract}
 
 ## Topic Naming Convention
 
-UMH topics follow strict validation rules defined in `pkg/umh/topic/`:
+UMH topics follow strict validation rules defined in `pkg/umhtopic/`:
 
 ### Pattern Structure
 
@@ -489,50 +489,25 @@ Field(service.NewIntField("queueSize").
 ### Core Commands
 ```bash
 make all          # Clean and build
-make build        # Build benthos binary (outputs to tmp/bin/benthos)
+make target       # Build benthos binary
 make clean        # Remove build artifacts
 make test         # Run all tests with Ginkgo
-make run CONFIG=./config/opcua-hex-test.yaml LOG_LEVEL=DEBUG  # Run locally with a config
 ```
 
 ### Plugin-Specific Tests
 ```bash
-make test-unit-opc           # OPC UA unit tests (sets TEST_OPCUA_UNIT=true)
-make test-integration-opc    # OPC UA integration tests (needs hardware env vars, see `make env`)
+make test-opcua              # OPC UA plugin tests
 make test-modbus             # Modbus plugin tests
-make test-s7comm             # S7 protocol tests
+make test-s7                 # S7 protocol tests
 make test-sparkplug          # Sparkplug B tests
 make test-eip                # Ethernet/IP tests
-make test-sensorconnect      # Sensorconnect tests (runs serially)
-make test-stream-processor   # Stream processor tests (with -race)
-make test-tag-processor      # Tag processor tests (sets TEST_TAG_PROCESSOR=true)
-make test-noderedjs          # Node-RED JS tests (sets TEST_NODERED_JS=true)
-make test-topic-browser      # Topic browser tests (sets TEST_TOPIC_BROWSER=1)
+make test-sensorconnect      # Sensorconnect tests
+make test-stream-processor   # Stream processor tests
+make test-tag-processor      # Tag processor tests
+make test-topic-browser      # Topic browser tests
 make test-downsampler        # Downsampler tests
-make test-classic-to-core    # Migration plugin tests (sets TEST_CLASSIC_TO_CORE=1)
-make test-pkg-umh-topic      # UMH topic library tests
-make test-uns                # UNS tests (excludes Redpanda-dependent tests)
-make test-uns-redpanda       # Full UNS tests (requires Docker for testcontainers)
-```
-
-### Lint & Format
-```bash
-make lint              # Run golangci-lint
-make lint-fix          # Auto-fix lint issues
-make fmt               # Format with gofumpt + gci (import ordering)
-```
-
-### Code Generation
-```bash
-make proto                              # Regenerate protobuf Go files
-make generate-schema VERSION=0.11.7     # Generate plugin schemas for ManagementConsole
-```
-
-### Fuzz & Benchmarks
-```bash
-make fuzz-stream-processor   # Run fuzz tests (press Ctrl+C to stop)
-make bench-stream-processor  # Benchmark stream processor
-make bench-pkg-umh-topic     # Benchmark topic parsing
+make test-classic-to-core    # Migration plugin tests
+make test-uns                # UNS output tests
 ```
 
 ### Utility Commands
@@ -540,33 +515,8 @@ make bench-pkg-umh-topic     # Benchmark topic parsing
 make license-check    # Verify Apache 2.0 headers
 make license-fix      # Add missing license headers
 make setup-test-deps  # Install test dependencies
-make install          # Install all dev tools (lint, fmt, license, protoc, etc.)
 make serve-pprof      # Run profiling server
-make env              # Show all test environment variables
 ```
-
-### Running a Single Test
-```bash
-# Run a single test by name pattern
-go run github.com/onsi/ginkgo/v2/ginkgo --focus "test name pattern" ./plugin_dir/...
-
-# Or use FIt/FDescribe in code to focus tests (don't commit these)
-FIt("should handle valid input", func() { ... })
-```
-
-### Test Environment Variables
-
-Many tests are gated by environment variables and silently skip without them. The `make test-*` targets set these automatically, but they matter when running tests directly with `go test` or Ginkgo.
-
-| Variable | Used by | Set by make target |
-|---|---|---|
-| `TEST_TAG_PROCESSOR=true` | tag_processor_plugin tests | `test-tag-processor` |
-| `TEST_OPCUA_UNIT=true` | opcua_plugin unit tests | `test-unit-opc` |
-| `TEST_NODERED_JS=true` | nodered_js_plugin tests | `test-noderedjs` |
-| `TEST_CLASSIC_TO_CORE=1` | classic_to_core_plugin tests | `test-classic-to-core` |
-| `TEST_TOPIC_BROWSER=1` | topic_browser_plugin tests | `test-topic-browser` |
-
-Run `make env` for the full list including hardware integration test variables.
 
 ## Testing Approach
 
@@ -577,7 +527,9 @@ Run `make env` for the full list including hardware integration test variables.
   - Test real protocol connections
   - Validate end-to-end data flow
 - **YAML Validation**: Schema-based config testing
-- **Benchmarks**: Performance testing for critical paths (see Fuzz & Benchmarks section above)
+- **Benchmarks**: Performance testing for critical paths
+  - `make bench-stream-processor`
+  - `make bench-pkg-umh-topic`
 
 ### Test Patterns
 ```go
@@ -616,7 +568,7 @@ benthos-umh/
 ├── config/               # Configuration examples
 ├── docs/                 # Documentation (GitBook format)
 ├── pkg/                  # Shared packages
-│   └── umh/topic/        # UMH topic parsing
+│   └── umhtopic/         # UMH topic parsing
 ├── *_plugin/             # Protocol/processor plugins
 ├── Makefile              # Build automation
 └── Makefile.Common       # Shared Make configuration
@@ -625,21 +577,11 @@ benthos-umh/
 ## Important Notes
 
 - Default branch is `master` (not `main` or `staging`)
-- Go version: 1.25.5
-- GODEBUG: `x509negativeserial=1` (for Kepware OPC UA certificate compatibility)
-- Import ordering (enforced by `make fmt`): standard → third-party → `github.com/united-manufacturing-hub/benthos-umh`
 - Apache 2.0 license headers required on all source files
 - Ginkgo runs tests in parallel with randomization
 - Plugins are loaded dynamically at runtime
 - Configuration uses standard Benthos YAML format
 - Each plugin maintains its own documentation
-
-### External Plugins
-
-The bundle (`cmd/benthos/bundle/package.go`) also imports 3 external community plugins:
-- `github.com/RuneRoven/benthosADS` - Beckhoff ADS protocol
-- `github.com/RuneRoven/benthosAlarm` - Alarm plugin
-- `github.com/RuneRoven/benthosSMTP` - SMTP output
 
 ## UX Standards
 

--- a/docs/input/opc-ua-input.md
+++ b/docs/input/opc-ua-input.md
@@ -39,11 +39,12 @@ The plugin has been rigorously tested with an array of datatypes, both as single
 * `Variant`
 * `XmlElement`
 
-There are specific datatypes which are currently not supported by the plugin and attempting to use them will result in errors. These include:
+There are specific datatypes which are currently not supported by the plugin:
 
 * Two-dimensional arrays
-* UA Extension Objects
 * Variant arrays (Arrays with multiple different datatypes)
+
+**UA Extension Objects** (custom vendor structs/UDTs) are automatically detected and skipped with a warning log. Since the browse phase discovers individual struct member nodes separately, the data within Extension Objects is still accessible by subscribing to those member nodes directly. If the Extension Object type is registered and decodable by the OPC UA library, it will be serialized as JSON.
 
 **Authentication and Security**
 

--- a/docs/input/opc-ua-input.md
+++ b/docs/input/opc-ua-input.md
@@ -1,6 +1,6 @@
 # OPC UA (Input)
 
-The plugin is designed to browse and subscribe to all child nodes within a folder for each configured NodeID, provided that the NodeID represents a folder. It features a recursion depth of up to 10 levels, enabling thorough exploration of nested folder structures. The browsing specifically targets nodes organized under the OPC UA 'Organizes' relationship type, intentionally excluding nodes under 'HasProperty' and 'HasComponent' relationships. Additionally, the plugin does not browse Objects represented by red, blue, or green cube icons in UAExpert.
+The plugin is designed to browse and subscribe to all child nodes within a folder for each configured NodeID, provided that the NodeID represents a folder. It features a recursion depth of up to 10 levels, enabling thorough exploration of nested folder structures. The plugin recursively discovers nodes through HierarchicalReferences, which includes Organizes, HasComponent, HasProperty, and other hierarchical reference types. The plugin does not browse Objects represented by red, blue, or green cube icons in UAExpert.
 
 Subscriptions are selectively managed, with tags having a DataType of null being excluded from subscription. Also, by default, the plugin does not subscribe to the properties of a tag, such as minimum and maximum values.
 
@@ -44,7 +44,7 @@ There are specific datatypes which are currently not supported by the plugin:
 * Two-dimensional arrays
 * Variant arrays (Arrays with multiple different datatypes)
 
-**UA Extension Objects** (custom vendor structs/UDTs) are automatically detected and skipped with a warning log. Since the browse phase discovers individual struct member nodes separately, the data within Extension Objects is still accessible by subscribing to those member nodes directly. If the Extension Object type is registered and decodable by the OPC UA library, it will be serialized as JSON.
+**UA Extension Objects** (custom vendor structs/UDTs) are automatically detected and skipped with a warning log. Many Extension Object values are opaque and not automatically browseable. Member nodes are only discovered if the server models them via HierarchicalReferences (Organizes, HasComponent, HasProperty, or other hierarchical reference types). If member nodes are not exposed by the server, you can access them by specifying their NodeID directly in the configuration. If the Extension Object type is registered and decodable by the OPC UA library, it will be serialized as JSON.
 
 **Authentication and Security**
 
@@ -255,27 +255,6 @@ If you are unsure if the OPC UA server is actually sending new data, you can ena
 input:
   opcua:
     useHeartbeat: true
-```
-
-**Browse Hierarchical References (Option until version 0.5.2)**
-
-**NOTE**: This property is removed in version 0.6.0 and made as a standard way to browse OPCUA nodes. From version 0.6.0 onwards, opcua\_plugin will browse all nodes with Hierarchical References.
-
-The plugin offers an option to browse OPCUA nodes by following Hierarchical References. By default, this feature is disabled (`false`), which means the plugin will only browse a limited subset of reference types, including:
-
-* `HasComponent`
-* `Organizes`
-* `FolderType`
-* `HasNotifier`
-
-When set to `true`, the plugin will explore a broader range of node references. For a deeper understanding of the different reference types, refer to the [Standard References Type documentation](https://qiyuqi.gitbooks.io/opc-ua/content/Part3/Chapter7.html).
-
-**Recommendation**: Enable this option (`browseHierarchicalReferences: true`) for more comprehensive node discovery.
-
-```yaml
-input:
-  opcua:
-    browseHierarchicalReferences: true
 ```
 
 **Auto Reconnect**

--- a/opcua_plugin/core_browse_global_pool.go
+++ b/opcua_plugin/core_browse_global_pool.go
@@ -744,20 +744,13 @@ func (gwp *GlobalWorkerPool) workerLoop(workerID uuid.UUID, controlChan chan str
 			// Filter by NodeClass - only send Variables to ResultChan
 			switch nodeDef.NodeClass {
 			case ua.NodeClassVariable:
-				// Skip container/structural Variable nodes that have children.
-				// These are parent nodes (e.g., Siemens custom struct/array types like
-				// Meldungen, Betriebsmeldungen, Störmeldungen, Warnmeldungen) whose values are not meaningful on their own.
-				// Their actual data is accessed through their child nodes (e.g., [0], [1]).
-				// Only leaf Variable nodes (no children) carry real data values.
-				if len(children) > 0 {
-					if gwp.logger != nil {
-						gwp.logger.Debugf("Skipping container Variable node (has %d children) - not subscribing: nodeID=%s path=%s browseName=%s",
-							len(children), nodeDef.NodeID.String(), nodeDef.Path, nodeDef.BrowseName)
-					}
-					break
-				}
-
-				// Leaf Variables: send to ResultChan (subscription list)
+				// Always send Variables to the subscription list. We intentionally do
+				// not skip Variables that have children: HierarchicalReferences include
+				// HasProperty/HasComponent, so a normal data-bearing Variable can have
+				// metadata children (e.g. EngineeringUnits, EURange) and still carry a
+				// real value. Bad or undecodable values (e.g. unregistered ExtensionObject
+				// UDTs) are filtered downstream in getBytesFromValue via statusIsBad and
+				// the ExtensionObject nil-Value check.
 				if gwp.logger != nil {
 					gwp.logger.Debugf("Adding Variable to subscription list: nodeID=%s path=%s browseName=%s",
 						nodeDef.NodeID.String(), nodeDef.Path, nodeDef.BrowseName)

--- a/opcua_plugin/core_browse_global_pool.go
+++ b/opcua_plugin/core_browse_global_pool.go
@@ -744,7 +744,20 @@ func (gwp *GlobalWorkerPool) workerLoop(workerID uuid.UUID, controlChan chan str
 			// Filter by NodeClass - only send Variables to ResultChan
 			switch nodeDef.NodeClass {
 			case ua.NodeClassVariable:
-				// Variables: send to ResultChan (subscription list)
+				// Skip container/structural Variable nodes that have children.
+				// These are parent nodes (e.g., Siemens custom struct/array types like
+				// Meldungen, Betriebsmeldungen, Störmeldungen, Warnmeldungen) whose values are not meaningful on their own.
+				// Their actual data is accessed through their child nodes (e.g., [0], [1]).
+				// Only leaf Variable nodes (no children) carry real data values.
+				if len(children) > 0 {
+					if gwp.logger != nil {
+						gwp.logger.Debugf("Skipping container Variable node (has %d children) - not subscribing: nodeID=%s path=%s browseName=%s",
+							len(children), nodeDef.NodeID.String(), nodeDef.Path, nodeDef.BrowseName)
+					}
+					break
+				}
+
+				// Leaf Variables: send to ResultChan (subscription list)
 				if gwp.logger != nil {
 					gwp.logger.Debugf("Adding Variable to subscription list: nodeID=%s path=%s browseName=%s",
 						nodeDef.NodeID.String(), nodeDef.Path, nodeDef.BrowseName)

--- a/opcua_plugin/core_read.go
+++ b/opcua_plugin/core_read.go
@@ -149,9 +149,15 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 // Read performs a synchronous read operation on the OPC UA server using the provided ReadRequest.
 //
 // This function sends a ReadRequest to the OPC UA server and handles the response. It manages
-// specific error conditions by closing the current session and signaling that the client is
-// no longer connected, prompting reconnection attempts if necessary. Successful reads return
-// the ReadResponse, while errors are appropriately logged and propagated.
+// specific session/transport error conditions by closing the current session and signaling that
+// the client is no longer connected, prompting reconnection attempts if necessary.
+//
+// NOTE: Read only returns a non-nil error for session/transport failures. Per-result problems
+// (e.g. StatusBadDataTypeIDUnknown on a single node, UNCERTAIN values, undecodable
+// ExtensionObjects) are NOT surfaced as errors here — they are carried on each
+// resp.Results[i].Status. Callers must iterate resp.Results and inspect DataValue.Status per
+// entry (see statusIsBad and getBytesFromValue for the canonical BAD-severity filter used in
+// this plugin). Failing to do so will silently propagate bad values downstream.
 func (g *OPCUAConnection) Read(ctx context.Context, req *ua.ReadRequest) (*ua.ReadResponse, error) {
 	resp, err := g.Client.Read(ctx, req)
 	if err != nil {

--- a/opcua_plugin/core_read.go
+++ b/opcua_plugin/core_read.go
@@ -24,6 +24,14 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
+// statusIsBad reports whether a StatusCode has BAD severity per OPC UA Part 8.
+// The top 2 bits of the 32-bit code encode severity: 00=Good, 01=Uncertain, 10/11=Bad.
+// GOOD variants (e.g. GoodClamped, GoodLocalOverride) and UNCERTAIN codes carry usable
+// data and must not be dropped by callers checking value validity.
+func statusIsBad(code ua.StatusCode) bool {
+	return uint32(code)>>30 >= 2
+}
+
 // getBytesFromValue returns the bytes and the tag type for a given OPC UA DataValue and NodeDef.
 func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef NodeDef) ([]byte, string) {
 	variant := dataValue.Value
@@ -32,8 +40,8 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 		return nil, ""
 	}
 
-	if !errors.Is(dataValue.Status, ua.StatusOK) {
-		g.Log.Warnf("Skipping node %s: status %v", nodeDef.NodeID.String(), dataValue.Status)
+	if statusIsBad(dataValue.Status) {
+		g.Log.Warnf("Skipping node %s: bad status %v", nodeDef.NodeID.String(), dataValue.Status)
 		return nil, ""
 	}
 

--- a/opcua_plugin/core_read.go
+++ b/opcua_plugin/core_read.go
@@ -93,10 +93,16 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 		b = append(b, []byte(strconv.FormatUint(v, 10))...)
 		tagType = "number"
 	case *ua.ExtensionObject:
-		if v.Value == nil {
-			// Unregistered type — skip (binary data already discarded by gopcua)
+		if v == nil || v.Value == nil {
+			// Unregistered type — skip (binary data already discarded by gopcua).
+			// Note: a typed-nil *ua.ExtensionObject still matches this case, so guard v itself.
+			// TypeID / TypeID.NodeID can also be nil for unknown extension types.
+			typeIDStr := "<unknown>"
+			if v != nil && v.TypeID != nil && v.TypeID.NodeID != nil {
+				typeIDStr = v.TypeID.NodeID.String()
+			}
 			g.Log.Warnf("Skipping node %s: ExtensionObject type %s not decodable (custom UDT not registered)",
-				nodeDef.NodeID.String(), v.TypeID.NodeID.String())
+				nodeDef.NodeID.String(), typeIDStr)
 			return nil, ""
 		}
 		// Type was registered and decoded — serialize the actual value

--- a/opcua_plugin/core_read.go
+++ b/opcua_plugin/core_read.go
@@ -18,33 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 
 	"github.com/gopcua/opcua/ua"
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
-
-// Context key for capability probe flag
-type contextKey string
-
-const capabilityProbeKey contextKey = "capability_probe"
-
-// WithCapabilityProbe returns a context marked for capability probe operations.
-// Capability probe reads are expected to fail on servers that don't support optional features.
-func WithCapabilityProbe(ctx context.Context) context.Context {
-	return context.WithValue(ctx, capabilityProbeKey, true)
-}
-
-// isCapabilityProbe checks if context is marked for capability probe operations.
-func isCapabilityProbe(ctx context.Context) bool {
-	if val := ctx.Value(capabilityProbeKey); val != nil {
-		if b, ok := val.(bool); ok {
-			return b
-		}
-	}
-	return false
-}
 
 // getBytesFromValue returns the bytes and the tag type for a given OPC UA DataValue and NodeDef.
 func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef NodeDef) ([]byte, string) {
@@ -55,7 +33,8 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 	}
 
 	if !errors.Is(dataValue.Status, ua.StatusOK) {
-		g.Log.Warnf("Received bad status %v for node %s", dataValue.Status, nodeDef.NodeID.String())
+		g.Log.Warnf("Skipping node %s: status %v", nodeDef.NodeID.String(), dataValue.Status)
+		return nil, ""
 	}
 
 	b := make([]byte, 0)
@@ -105,6 +84,41 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 	case uint64:
 		b = append(b, []byte(strconv.FormatUint(v, 10))...)
 		tagType = "number"
+	case *ua.ExtensionObject:
+		if v.Value == nil {
+			// Unregistered type — skip (binary data already discarded by gopcua)
+			g.Log.Warnf("Skipping node %s: ExtensionObject type %s not decodable (custom UDT not registered)",
+				nodeDef.NodeID.String(), v.TypeID.NodeID.String())
+			return nil, ""
+		}
+		// Type was registered and decoded — serialize the actual value
+		jsonBytes, err := json.Marshal(v.Value)
+		if err != nil {
+			g.Log.Errorf("Error marshaling ExtensionObject value for node %s: %v", nodeDef.NodeID.String(), err)
+			return nil, ""
+		}
+		b = append(b, jsonBytes...)
+		tagType = "string"
+	case []*ua.ExtensionObject:
+		// Filter: collect only decoded Extension Objects
+		var decoded []interface{}
+		for _, eo := range v {
+			if eo != nil && eo.Value != nil {
+				decoded = append(decoded, eo.Value)
+			}
+		}
+		if len(decoded) == 0 {
+			g.Log.Warnf("Skipping node %s: array of %d ExtensionObjects, none decodable (custom UDTs not registered)",
+				nodeDef.NodeID.String(), len(v))
+			return nil, ""
+		}
+		jsonBytes, err := json.Marshal(decoded)
+		if err != nil {
+			g.Log.Errorf("Error marshaling ExtensionObject array for node %s: %v", nodeDef.NodeID.String(), err)
+			return nil, ""
+		}
+		b = append(b, jsonBytes...)
+		tagType = "string"
 	default:
 		// Convert unknown types to JSON
 		jsonBytes, err := json.Marshal(v)
@@ -158,16 +172,6 @@ func (g *OPCUAConnection) Read(ctx context.Context, req *ua.ReadRequest) (*ua.Re
 
 		// return error and stop executing this function.
 		return nil, err
-	}
-
-	if !errors.Is(resp.Results[0].Status, ua.StatusOK) {
-		// Capability probes are expected to fail on servers without optional features
-		if isCapabilityProbe(ctx) {
-			g.Log.Debugf("Capability probe returned status: %v (expected for servers without this feature)", resp.Results[0].Status)
-		} else {
-			g.Log.Errorf("Status not OK: %v", resp.Results[0].Status)
-		}
-		return nil, fmt.Errorf("status not OK: %w", resp.Results[0].Status)
 	}
 
 	return resp, nil

--- a/opcua_plugin/core_read_test.go
+++ b/opcua_plugin/core_read_test.go
@@ -57,7 +57,7 @@ var _ = Describe("getBytesFromValue", func() {
 		Expect(tagType).To(BeEmpty())
 	})
 
-	It("should return nil for any non-OK status", func() {
+	It("should return nil for BAD status (StatusBadNodeIDUnknown)", func() {
 		dataValue := &ua.DataValue{
 			Status: ua.StatusBadNodeIDUnknown,
 			Value:  ua.MustVariant(int32(42)),
@@ -66,6 +66,19 @@ var _ = Describe("getBytesFromValue", func() {
 		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
 		Expect(b).To(BeNil())
 		Expect(tagType).To(BeEmpty())
+	})
+
+	It("should still emit bytes for UNCERTAIN status with a valid value", func() {
+		// UNCERTAIN codes (top bits 0b01) carry usable data per OPC UA Part 8
+		// and must not be silently dropped alongside BAD codes.
+		dataValue := &ua.DataValue{
+			Status: ua.StatusUncertain,
+			Value:  ua.MustVariant(int32(42)),
+		}
+
+		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+		Expect(b).To(Equal([]byte("42")))
+		Expect(tagType).To(Equal("number"))
 	})
 
 	It("should return bytes for OK status with int32 value", func() {
@@ -219,5 +232,84 @@ var _ = Describe("getBytesFromValue", func() {
 			Expect(string(b)).To(HavePrefix("["))
 			Expect(string(b)).To(ContainSubstring("DeadbandValue"))
 		})
+	})
+})
+
+var _ = Describe("createMessageFromValue tag group derivation", func() {
+	BeforeEach(func() {
+		if os.Getenv("TEST_OPCUA_UNIT") == "" {
+			Skip("Skipping OPC UA unit tests: TEST_OPCUA_UNIT not set")
+		}
+	})
+
+	var input *OPCUAInput
+
+	BeforeEach(func() {
+		logger := service.MockResources().Logger()
+		input = &OPCUAInput{
+			OPCUAConnection: &OPCUAConnection{Log: logger},
+		}
+	})
+
+	// makeMsg builds a minimal valid DataValue + NodeDef and runs the message
+	// through createMessageFromValue, returning the (sanitized) tag_name,
+	// tag_group, and tag_path metadata so the tests can focus on the tag-group
+	// derivation.
+	makeMsg := func(path, browseName string) (tagName, tagGroup, tagPath string) {
+		dv := &ua.DataValue{
+			Status: ua.StatusOK,
+			Value:  ua.MustVariant(int32(42)),
+		}
+		nd := NodeDef{
+			NodeID:     ua.NewNumericNodeID(2, 1),
+			NodeClass:  ua.NodeClassVariable,
+			BrowseName: browseName,
+			Path:       path,
+		}
+		msg := input.createMessageFromValue(dv, nd)
+		Expect(msg).NotTo(BeNil())
+
+		tagName, _ = msg.MetaGet("opcua_tag_name")
+		tagGroup, _ = msg.MetaGet("opcua_tag_group")
+		tagPath, _ = msg.MetaGet("opcua_tag_path")
+		return
+	}
+
+	It("strips the sanitized tag name from a normal nested path", func() {
+		tagName, tagGroup, tagPath := makeMsg("Plant.Line.Sensor", "Sensor")
+		Expect(tagName).To(Equal("Sensor"))
+		Expect(tagGroup).To(Equal("Plant.Line"))
+		Expect(tagPath).To(Equal("Plant.Line"))
+	})
+
+	It("only strips the trailing occurrence when the tag name repeats in the path", func() {
+		// Regression: the previous implementation used strings.Replace with n=1,
+		// which removed the FIRST match anywhere in the path. The trailing-suffix
+		// approach must keep the leading "Temperature" segment intact so it
+		// remains part of the tag group.
+		tagName, tagGroup, tagPath := makeMsg("Plant.Temperature.Sensor.Temperature", "Temperature")
+		Expect(tagName).To(Equal("Temperature"))
+		Expect(tagGroup).To(Equal("Plant.Temperature.Sensor"))
+		Expect(tagPath).To(Equal("Plant.Temperature.Sensor"))
+	})
+
+	It("treats a root-level node (path == tag name) as its own group with empty tag path", func() {
+		// When the path equals the sanitized tag name, the trimmed group is
+		// empty, so the code falls back to tagGroup = tagName and signals
+		// "root" by setting opcua_tag_path to an empty string.
+		tagName, tagGroup, tagPath := makeMsg("Sensor", "Sensor")
+		Expect(tagName).To(Equal("Sensor"))
+		Expect(tagGroup).To(Equal("Sensor"))
+		Expect(tagPath).To(BeEmpty())
+	})
+
+	It("matches the sanitized tag name against the sanitized path", func() {
+		// Regression: the path is built from sanitized BrowseNames in the browse
+		// phase, so the raw BrowseName ("My Sensor") will never appear verbatim
+		// in the path. The fix sanitizes the BrowseName before stripping it.
+		tagName, tagGroup, tagPath := makeMsg("My_Folder.My_Sensor", "My Sensor")
+		Expect(tagName).To(Equal("My_Sensor"))
+		Expect(tagGroup).To(Equal("My_Folder"))
+		Expect(tagPath).To(Equal("My_Folder"))
 	})
 })

--- a/opcua_plugin/core_read_test.go
+++ b/opcua_plugin/core_read_test.go
@@ -1,0 +1,223 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opcua_plugin
+
+import (
+	"os"
+
+	"github.com/gopcua/opcua/ua"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+var _ = Describe("getBytesFromValue", func() {
+	BeforeEach(func() {
+		if os.Getenv("TEST_OPCUA_UNIT") == "" {
+			Skip("Skipping OPC UA unit tests: TEST_OPCUA_UNIT not set")
+		}
+	})
+
+	var (
+		conn    *OPCUAConnection
+		nodeDef NodeDef
+	)
+
+	BeforeEach(func() {
+		logger := service.MockResources().Logger()
+		conn = &OPCUAConnection{
+			Log: logger,
+		}
+		nodeDef = NodeDef{
+			NodeID:     ua.NewNumericNodeID(0, 1001),
+			BrowseName: "TestNode",
+		}
+	})
+
+	It("should return nil for non-OK status (StatusBadDataTypeIDUnknown)", func() {
+		dataValue := &ua.DataValue{
+			Status: ua.StatusBadDataTypeIDUnknown,
+			Value:  ua.MustVariant(&ua.ExtensionObject{Value: nil}),
+		}
+
+		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+		Expect(b).To(BeNil())
+		Expect(tagType).To(BeEmpty())
+	})
+
+	It("should return nil for any non-OK status", func() {
+		dataValue := &ua.DataValue{
+			Status: ua.StatusBadNodeIDUnknown,
+			Value:  ua.MustVariant(int32(42)),
+		}
+
+		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+		Expect(b).To(BeNil())
+		Expect(tagType).To(BeEmpty())
+	})
+
+	It("should return bytes for OK status with int32 value", func() {
+		dataValue := &ua.DataValue{
+			Status: ua.StatusOK,
+			Value:  ua.MustVariant(int32(42)),
+		}
+
+		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+		Expect(b).To(Equal([]byte("42")))
+		Expect(tagType).To(Equal("number"))
+	})
+
+	It("should return bytes for OK status with float64 value", func() {
+		dataValue := &ua.DataValue{
+			Status: ua.StatusOK,
+			Value:  ua.MustVariant(float64(3.14)),
+		}
+
+		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+		Expect(b).To(Equal([]byte("3.14")))
+		Expect(tagType).To(Equal("number"))
+	})
+
+	It("should return bytes for OK status with string value", func() {
+		dataValue := &ua.DataValue{
+			Status: ua.StatusOK,
+			Value:  ua.MustVariant("hello"),
+		}
+
+		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+		Expect(b).To(Equal([]byte("hello")))
+		Expect(tagType).To(Equal("string"))
+	})
+
+	It("should return bytes for OK status with bool value", func() {
+		dataValue := &ua.DataValue{
+			Status: ua.StatusOK,
+			Value:  ua.MustVariant(true),
+		}
+
+		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+		Expect(b).To(Equal([]byte("true")))
+		Expect(tagType).To(Equal("bool"))
+	})
+
+	It("should return nil when variant is nil", func() {
+		dataValue := &ua.DataValue{
+			Status: ua.StatusOK,
+			Value:  nil,
+		}
+
+		b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+		Expect(b).To(BeNil())
+		Expect(tagType).To(BeEmpty())
+	})
+
+	Context("ExtensionObject handling", func() {
+		It("should return nil for ExtensionObject with nil Value (undecodable UDT)", func() {
+			extObj := &ua.ExtensionObject{
+				TypeID: &ua.ExpandedNodeID{
+					NodeID: ua.NewNumericNodeID(4, 202),
+				},
+				EncodingMask: ua.ExtensionObjectBinary,
+				Value:        nil,
+			}
+			dataValue := &ua.DataValue{
+				Status: ua.StatusOK,
+				Value:  ua.MustVariant(extObj),
+			}
+
+			b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+			Expect(b).To(BeNil())
+			Expect(tagType).To(BeEmpty())
+		})
+
+		It("should return JSON bytes for ExtensionObject with decoded Value", func() {
+			decodedValue := &ua.DataChangeFilter{
+				Trigger:       ua.DataChangeTriggerStatusValue,
+				DeadbandType:  uint32(ua.DeadbandTypeAbsolute),
+				DeadbandValue: 0.5,
+			}
+			extObj := &ua.ExtensionObject{
+				TypeID: &ua.ExpandedNodeID{
+					NodeID: ua.NewNumericNodeID(0, 724),
+				},
+				EncodingMask: ua.ExtensionObjectBinary,
+				Value:        decodedValue,
+			}
+			dataValue := &ua.DataValue{
+				Status: ua.StatusOK,
+				Value:  ua.MustVariant(extObj),
+			}
+
+			b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+			Expect(b).NotTo(BeNil())
+			Expect(tagType).To(Equal("string"))
+			Expect(string(b)).To(ContainSubstring("DeadbandValue"))
+		})
+
+		It("should return nil for array of ExtensionObjects all with nil Values", func() {
+			extObjs := []*ua.ExtensionObject{
+				{
+					TypeID:       &ua.ExpandedNodeID{NodeID: ua.NewNumericNodeID(4, 202)},
+					EncodingMask: ua.ExtensionObjectBinary,
+					Value:        nil,
+				},
+				{
+					TypeID:       &ua.ExpandedNodeID{NodeID: ua.NewNumericNodeID(4, 203)},
+					EncodingMask: ua.ExtensionObjectBinary,
+					Value:        nil,
+				},
+			}
+			dataValue := &ua.DataValue{
+				Status: ua.StatusOK,
+				Value:  ua.MustVariant(extObjs),
+			}
+
+			b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+			Expect(b).To(BeNil())
+			Expect(tagType).To(BeEmpty())
+		})
+
+		It("should return JSON array with only decoded values from mixed ExtensionObject array", func() {
+			decodedValue := &ua.DataChangeFilter{
+				Trigger:       ua.DataChangeTriggerStatusValue,
+				DeadbandType:  uint32(ua.DeadbandTypeAbsolute),
+				DeadbandValue: 1.5,
+			}
+			extObjs := []*ua.ExtensionObject{
+				{
+					TypeID:       &ua.ExpandedNodeID{NodeID: ua.NewNumericNodeID(4, 202)},
+					EncodingMask: ua.ExtensionObjectBinary,
+					Value:        nil, // undecodable
+				},
+				{
+					TypeID:       &ua.ExpandedNodeID{NodeID: ua.NewNumericNodeID(0, 724)},
+					EncodingMask: ua.ExtensionObjectBinary,
+					Value:        decodedValue, // decoded
+				},
+			}
+			dataValue := &ua.DataValue{
+				Status: ua.StatusOK,
+				Value:  ua.MustVariant(extObjs),
+			}
+
+			b, tagType := conn.getBytesFromValue(dataValue, nodeDef)
+			Expect(b).NotTo(BeNil())
+			Expect(tagType).To(Equal("string"))
+			// Should be a JSON array with exactly one element (the decoded one)
+			Expect(string(b)).To(HavePrefix("["))
+			Expect(string(b)).To(ContainSubstring("DeadbandValue"))
+		})
+	})
+})

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -499,6 +499,11 @@ func (g *OPCUAInput) ReadBatchPull(ctx context.Context) (service.MessageBatch, s
 			g.Log.Debugf("Received nil in item structure on node %s. This can occur when subscribing to an OPC UA folder and may be ignored.", node.NodeID.String())
 			continue
 		}
+		if value.Status != ua.StatusOK {
+			g.Log.Warnf("Skipping node %s: received status %v (unsupported data type?)",
+				node.NodeID.String(), value.Status)
+			continue
+		}
 		message := g.createMessageFromValue(value, node)
 		if message != nil {
 			msgs = append(msgs, message)
@@ -610,12 +615,14 @@ func (g *OPCUAInput) createMessageFromValue(dataValue *ua.DataValue, nodeDef Nod
 
 	tagName := sanitize(nodeDef.BrowseName)
 
-	// Tag Group
-	tagGroup := nodeDef.Path
-	// remove nodeDef.BrowseName from tagGroup
-	tagGroup = strings.Replace(tagGroup, nodeDef.BrowseName, "", 1)
-	// remove trailing dot
-	tagGroup = strings.TrimSuffix(tagGroup, ".")
+	// Tag Group: the path is built using sanitized browse names (see core_browse_global_pool.go),
+	// so we must remove the sanitized name from the end of the path, not the raw BrowseName.
+	// Using TrimSuffix ensures we only remove from the end, avoiding accidental mid-path matches.
+	tagGroup := strings.TrimSuffix(nodeDef.Path, "."+tagName)
+	if tagGroup == nodeDef.Path {
+		// No dot-prefixed suffix found — the path might equal the tag name (root-level node)
+		tagGroup = strings.TrimSuffix(tagGroup, tagName)
+	}
 
 	// if the node is the CurrentTime node, mark is as a heartbeat message
 	if g.HeartbeatNodeId != nil && nodeDef.NodeID.Namespace() == g.HeartbeatNodeId.Namespace() && nodeDef.NodeID.IntID() == g.HeartbeatNodeId.IntID() && g.UseHeartbeat {

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -499,11 +499,8 @@ func (g *OPCUAInput) ReadBatchPull(ctx context.Context) (service.MessageBatch, s
 			g.Log.Debugf("Received nil in item structure on node %s. This can occur when subscribing to an OPC UA folder and may be ignored.", node.NodeID.String())
 			continue
 		}
-		if value.Status != ua.StatusOK {
-			g.Log.Warnf("Skipping node %s: received status %v (unsupported data type?)",
-				node.NodeID.String(), value.Status)
-			continue
-		}
+		// Status handling is delegated to createMessageFromValue → getBytesFromValue,
+		// which is the single source of truth for deciding whether to emit a value.
 		message := g.createMessageFromValue(value, node)
 		if message != nil {
 			msgs = append(msgs, message)

--- a/opcua_plugin/read_discover.go
+++ b/opcua_plugin/read_discover.go
@@ -604,7 +604,10 @@ func (g *OPCUAInput) MonitorBatched(ctx context.Context, nodes []NodeDef) (int, 
 		}
 
 		for i, result := range response.Results {
-			if !errors.Is(result.StatusCode, ua.StatusOK) {
+			// Treat only BAD severity as a subscription failure; GOOD variants
+			// (e.g. GoodClamped) and UNCERTAIN codes still indicate the monitored
+			// item was created and should not be dropped here.
+			if statusIsBad(result.StatusCode) {
 				failedNode := batch[i].NodeID.String()
 
 				// Trial-and-retry logic (Hardware-Validated on S7-1200 PLCs)

--- a/opcua_plugin/read_server_info.go
+++ b/opcua_plugin/read_server_info.go
@@ -148,6 +148,7 @@ func (g *OPCUAInput) GetOPCUAServerInformation(ctx context.Context) (ServerInfo,
 		value := resp.Results[i]
 		if value == nil || value.Value == nil {
 			g.Log.Debugf("Received nil in item structure for OPC UA Server Information")
+			continue
 		}
 
 		message := g.createMessageFromValue(value, node)
@@ -244,9 +245,7 @@ func (g *OPCUAInput) queryOperationLimits(ctx context.Context) (*ServerCapabilit
 		TimestampsToReturn: ua.TimestampsToReturnBoth,
 	}
 
-	// Mark this as a capability probe - failures are expected for servers without OperationLimits
-	probeCtx := WithCapabilityProbe(ctx)
-	resp, err := g.Read(probeCtx, req)
+	resp, err := g.Read(ctx, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Problem**
- In pull mode, a single bad-status DataValue (e.g. StatusBadDataTypeIDUnknown from an undecodable Siemens UDT / custom Extension Object) was failing the entire batch read:


```
ERRO  Status not OK: ... StatusBadDataTypeIDUnknown (0x80110000)
ERRO  Read failed: status not OK: ...
ERRO  Failed to read message: status not OK: ...
```
Worse, every other valid tag in the same batch was also dropped silently. On top of that, the browse phase was throwing away legitimate data-bearing Variable nodes simply because they had HasProperty/HasComponent children, and tag-group derivation had a couple of subtle path-sanitization bugs.

***Changes***
**Unified status handling across the read pipeline**
- New statusIsBad() helper that checks BAD severity per OPC UA Part 8 (top 2 bits of StatusCode), instead of exact equality with StatusOK.
- GOOD variants (GoodClamped, GoodLocalOverride, …) and UNCERTAIN codes are no longer silently dropped.
- Applied in getBytesFromValue (pull) and MonitorBatched (subscribe) for consistency.
- Removed the duplicate StatusOK check in ReadBatchPull — getBytesFromValue is now the single source of truth for "is this value emit-worthy?". This is what actually fixes the batch-failure cascade above.
- Documented Read()'s per-result-status contract in its doc comment so future callers don't have to rediscover it.


**Browse: stop dropping Variables that happen to have children**
- Removed the "skip Variable if len(children) > 0" branch in core_browse_global_pool.go. The browse follows HierarchicalReferences, so a typed Variable with HasProperty/HasComponent metadata children is a normal data-bearing tag, not a container. Filtering of bad/undecodable values is delegated downstream to getBytesFromValue.
**Extension Objects**
- Decodable extension objects are marshalled to JSON (including arrays).
- Undecodable / nil-valued extension objects are skipped with a single warning instead of erroring.

**Tag-group derivation fixes**
- Use TrimSuffix so a tag name appearing earlier in the path isn't accidentally stripped.
- Sanitize the BrowseName before stripping, since the path is built from sanitized names.
- Handle root-level nodes correctly (path equals tag name).

**Tests**
- getBytesFromValue: focused BAD case (StatusBadNodeIDUnknown) + positive UNCERTAIN case.
- createMessageFromValue tag-group derivation: nested path, repeated tag name, root-level node, raw-vs-sanitized BrowseName.
- ExtensionObject scenarios: decodable, undecodable, mixed arrays.

**Docs**
- Rewrote the Extension Objects section in docs/input/opc-ua-input.md to reflect that browsing follows HierarchicalReferences (Organizes, HasComponent, HasProperty, HasNotifier, …), and that opaque ExtensionObject members need an explicit NodeId only when the server does not expose them.
- Removed the obsolete "Browse Hierarchical References (option until v0.5.2)" section — that flag was removed in v0.6.0.