### PR TITLE
chore(CI): changelog refactor

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -20,13 +20,13 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
         cache-dependency-path: |
           go.sum
     - name: Setup GoReleaser
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
       with:
         install-only: true
         version: "~> v2"

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -23,6 +23,8 @@ runs:
       uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
+        cache-dependency-path: |
+          go.sum
     - name: Setup GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/.github/actions/setup-test/action.yml
+++ b/.github/actions/setup-test/action.yml
@@ -13,20 +13,14 @@
 # limitations under the License.
 
 ---
-name: Test Stream Processor
+name: Setup Test Environment
+description: Setup Go and install Ginkgo test framework.
 
-on:
-  workflow_call:
-
-jobs:
-  test:
-    name: Stream Processor Unittest
-    runs-on: depot-ubuntu-24.04
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup Test Environment
-        uses: ./.github/actions/setup-test
-      - name: Test
-        run: make test-stream-processor
+runs:
+  using: composite
+  steps:
+    - name: Setup Go
+      uses: ./.github/actions/setup-go
+    - name: Install Ginkgo
+      shell: bash
+      run: go install github.com/onsi/ginkgo/v2/ginkgo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-opcua.yml
     with:
-      test_plc: ${{ needs.detect-changes.outputs.test_plc }}
+      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
     secrets: inherit
 
   test-modbus:
@@ -161,7 +161,7 @@ jobs:
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-modbus.yml
     with:
-      test_plc: ${{ needs.detect-changes.outputs.test_plc }}
+      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
     secrets: inherit
 
   test-s7:
@@ -174,7 +174,7 @@ jobs:
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-s7.yml
     with:
-      test_plc: ${{ needs.detect-changes.outputs.test_plc }}
+      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
     secrets: inherit
 
   test-sparkplug:
@@ -210,7 +210,7 @@ jobs:
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-sensorconnect.yml
     with:
-      test_plc: ${{ needs.detect-changes.outputs.test_plc }}
+      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
     secrets: inherit
 
   test-tag-processor:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, main, staging]
   pull_request:
-    branches: [master]
+    branches: [master, main, staging]
+  merge_group:
 
 permissions:
   contents: read
@@ -31,6 +32,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      test_plc: ${{ steps.plc-check.outputs.test_plc }}
       opcua: ${{ steps.filter.outputs.opcua }}
       modbus: ${{ steps.filter.outputs.modbus }}
       s7: ${{ steps.filter.outputs.s7 }}
@@ -50,6 +52,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check if PLC tests should run
+        id: plc-check
+        run: echo "test_plc=${{ github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref == 'main') }}" >> "$GITHUB_OUTPUT"
       - name: Detect changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
@@ -142,6 +147,8 @@ jobs:
        needs.detect-changes.outputs.gomod == 'true' ||
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-opcua.yml
+    with:
+      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
     secrets: inherit
 
   test-modbus:
@@ -153,6 +160,8 @@ jobs:
        needs.detect-changes.outputs.gomod == 'true' ||
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-modbus.yml
+    with:
+      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
     secrets: inherit
 
   test-s7:
@@ -164,6 +173,8 @@ jobs:
        needs.detect-changes.outputs.gomod == 'true' ||
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-s7.yml
+    with:
+      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
     secrets: inherit
 
   test-sparkplug:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-opcua.yml
     with:
-      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
+      test_plc: ${{ needs.detect-changes.outputs.test_plc }}
     secrets: inherit
 
   test-modbus:
@@ -161,7 +161,7 @@ jobs:
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-modbus.yml
     with:
-      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
+      test_plc: ${{ needs.detect-changes.outputs.test_plc }}
     secrets: inherit
 
   test-s7:
@@ -174,7 +174,7 @@ jobs:
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-s7.yml
     with:
-      test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
+      test_plc: ${{ needs.detect-changes.outputs.test_plc }}
     secrets: inherit
 
   test-sparkplug:
@@ -209,6 +209,8 @@ jobs:
        needs.detect-changes.outputs.gomod == 'true' ||
        needs.detect-changes.outputs.cmd == 'true')
     uses: ./.github/workflows/test-sensorconnect.yml
+    with:
+      test_plc: ${{ needs.detect-changes.outputs.test_plc }}
     secrets: inherit
 
   test-tag-processor:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request && github.head_ref || github.ref_name }}
 
@@ -42,7 +42,7 @@ jobs:
         uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -97,7 +97,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request && github.head_ref || github.ref_name }}
 
@@ -132,7 +132,7 @@ jobs:
             cmd/benthos/main.go
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: artifact-${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ./dist/${{ env.OUTPUT_NAME }}
@@ -145,7 +145,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: 'artifact-*-${{ github.run_id }}-${{ github.run_attempt }}'
           path: ./artifacts

--- a/.github/workflows/test-classic-to-core.yml
+++ b/.github/workflows/test-classic-to-core.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-classic-to-core.yml
+++ b/.github/workflows/test-classic-to-core.yml
@@ -26,10 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_CLASSIC_TO_CORE: 1

--- a/.github/workflows/test-downsampler.yml
+++ b/.github/workflows/test-downsampler.yml
@@ -26,10 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_DOWNSAMPLER: 1

--- a/.github/workflows/test-downsampler.yml
+++ b/.github/workflows/test-downsampler.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-eip.yml
+++ b/.github/workflows/test-eip.yml
@@ -26,9 +26,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         run: make test-eip

--- a/.github/workflows/test-eip.yml
+++ b/.github/workflows/test-eip.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-modbus.yml
+++ b/.github/workflows/test-modbus.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Install Tcping

--- a/.github/workflows/test-modbus.yml
+++ b/.github/workflows/test-modbus.yml
@@ -17,10 +17,34 @@ name: Test Modbus
 
 on:
   workflow_call:
+    inputs:
+      test_plc:
+        description: run plc if running in merge_queue
+        default: true
+        required: true
+        type: boolean
 
 jobs:
-  test:
+  test-unit:
+    name: Modbus Unittest
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Install Ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Test
+        env:
+          TEST_MODBUS_UNITTEST: true
+        run: make test-modbus
+
+  test-plc:
     name: Modbus PLC
+    needs: [test-unit]
+    if: ${{ inputs.test_plc == true }}
     concurrency:
       group: modbus-plc
       cancel-in-progress: false

--- a/.github/workflows/test-modbus.yml
+++ b/.github/workflows/test-modbus.yml
@@ -32,10 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_MODBUS_UNITTEST: true
@@ -53,10 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
 

--- a/.github/workflows/test-modbus.yml
+++ b/.github/workflows/test-modbus.yml
@@ -20,7 +20,6 @@ on:
     inputs:
       test_plc:
         description: run plc if running in merge_queue
-        default: true
         required: true
         type: boolean
 

--- a/.github/workflows/test-nodered-js.yml
+++ b/.github/workflows/test-nodered-js.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-nodered-js.yml
+++ b/.github/workflows/test-nodered-js.yml
@@ -26,9 +26,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         run: make test-noderedjs

--- a/.github/workflows/test-opcua.yml
+++ b/.github/workflows/test-opcua.yml
@@ -17,9 +17,15 @@ name: Test OPC UA
 
 on:
   workflow_call:
+    inputs:
+      test_plc:
+        description: run plc if running in merge_queue
+        default: true
+        required: true
+        type: boolean
 
 jobs:
-  test:
+  test-unit:
     name: OPCUA Unittest
     runs-on: depot-ubuntu-24.04
     steps:
@@ -34,7 +40,8 @@ jobs:
 
   test-plc:
     name: OPCUA PLCs
-    needs: [test]
+    needs: [test-unit]
+    if: ${{ inputs.test_plc == true }}
     concurrency:
       group: opcua-plc
       cancel-in-progress: false
@@ -180,6 +187,7 @@ jobs:
   test-kepware:
     name: OPCUA Kepware
     needs: [test-plc]
+    if: ${{ inputs.test_plc == true }}
     concurrency:
       group: opcua-plc
       cancel-in-progress: false

--- a/.github/workflows/test-opcua.yml
+++ b/.github/workflows/test-opcua.yml
@@ -31,10 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Run OPC UA Unit Tests
         run: make test-unit-opc
 
@@ -50,10 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
       - name: Check S7 port availability
@@ -196,10 +192,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
 

--- a/.github/workflows/test-opcua.yml
+++ b/.github/workflows/test-opcua.yml
@@ -27,9 +27,10 @@ jobs:
   test-unit:
     name: OPCUA Unittest
     runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Run OPC UA Unit Tests
@@ -46,7 +47,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Install Tcping
@@ -190,7 +191,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Install Tcping

--- a/.github/workflows/test-opcua.yml
+++ b/.github/workflows/test-opcua.yml
@@ -20,7 +20,6 @@ on:
     inputs:
       test_plc:
         description: run plc if running in merge_queue
-        default: true
         required: true
         type: boolean
 

--- a/.github/workflows/test-s7.yml
+++ b/.github/workflows/test-s7.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Install Tcping

--- a/.github/workflows/test-s7.yml
+++ b/.github/workflows/test-s7.yml
@@ -17,9 +17,15 @@ name: Test S7
 
 on:
   workflow_call:
+    inputs:
+      test_plc:
+        description: run plc if running in merge_queue
+        default: true
+        required: true
+        type: boolean
 
 jobs:
-  test:
+  test-unit:
     name: S7 Unittest
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 30
@@ -37,7 +43,8 @@ jobs:
 
   test-plc:
     name: S7 PLC
-    needs: [test]
+    needs: [test-unit]
+    if: ${{ inputs.test_plc == true }}
     concurrency:
       group: s7-plc
       cancel-in-progress: false
@@ -84,7 +91,6 @@ jobs:
         env:
           TEST_S7_RACK: 0
           TEST_S7_SLOT: 1
-          TEST_S7COMM_UNITTEST: true
         run: |
           if [ -z "$TEST_S7_TCPDEVICE" ]; then
             echo "no s7 device available for testing"

--- a/.github/workflows/test-s7.yml
+++ b/.github/workflows/test-s7.yml
@@ -20,7 +20,6 @@ on:
     inputs:
       test_plc:
         description: run plc if running in merge_queue
-        default: true
         required: true
         type: boolean
 

--- a/.github/workflows/test-s7.yml
+++ b/.github/workflows/test-s7.yml
@@ -32,10 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_S7COMM_UNITTEST: true
@@ -53,10 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
 

--- a/.github/workflows/test-sensorconnect.yml
+++ b/.github/workflows/test-sensorconnect.yml
@@ -32,10 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_SENSORCONNECT_UNITTEST: true
@@ -50,10 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_DEBUG_IFM_ENDPOINT: ${{ secrets.TEST_DEBUG_IFM_ENDPOINT }}

--- a/.github/workflows/test-sensorconnect.yml
+++ b/.github/workflows/test-sensorconnect.yml
@@ -17,10 +17,34 @@ name: Test Sensorconnect
 
 on:
   workflow_call:
+    inputs:
+      test_plc:
+        description: run plc if running in merge_queue
+        default: true
+        required: true
+        type: boolean
 
 jobs:
-  test:
+  test-unit:
     name: Sensorconnect Unittest
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Install Ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Test
+        env:
+          TEST_SENSORCONNECT_UNITTEST: true
+        run: make test-sensorconnect
+
+  test-plc:
+    name: Sensorconnect PLC
+    needs: [test-unit]
+    if: ${{ inputs.test_plc == true }}
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/test-sensorconnect.yml
+++ b/.github/workflows/test-sensorconnect.yml
@@ -20,7 +20,6 @@ on:
     inputs:
       test_plc:
         description: run plc if running in merge_queue
-        default: true
         required: true
         type: boolean
 
@@ -43,6 +42,9 @@ jobs:
     name: Sensorconnect PLC
     needs: [test-unit]
     if: ${{ inputs.test_plc == true }}
+    concurrency:
+      group: sensorconnect-plc
+      cancel-in-progress: false
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/test-sensorconnect.yml
+++ b/.github/workflows/test-sensorconnect.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-sparkplug.yml
+++ b/.github/workflows/test-sparkplug.yml
@@ -26,10 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_SPARKPLUG_UNIT: true

--- a/.github/workflows/test-sparkplug.yml
+++ b/.github/workflows/test-sparkplug.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-stream-processor.yml
+++ b/.github/workflows/test-stream-processor.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-tag-processor.yml
+++ b/.github/workflows/test-tag-processor.yml
@@ -26,10 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_TAG_PROCESSOR: true

--- a/.github/workflows/test-tag-processor.yml
+++ b/.github/workflows/test-tag-processor.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-topic-browser.yml
+++ b/.github/workflows/test-topic-browser.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-topic-browser.yml
+++ b/.github/workflows/test-topic-browser.yml
@@ -26,10 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         env:
           TEST_TOPIC_BROWSER: 1

--- a/.github/workflows/test-uns.yml
+++ b/.github/workflows/test-uns.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test
       - name: Test

--- a/.github/workflows/test-uns.yml
+++ b/.github/workflows/test-uns.yml
@@ -26,9 +26,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
       - name: Test
         run: make test-uns

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -30,14 +30,14 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.PR_APP_ID }}
           private-key: ${{ secrets.PR_APP_PK }}
           repositories: united-manufacturing-hub
 
       - name: Checkout united-manufacturing-hub Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: united-manufacturing-hub/united-manufacturing-hub
           ref: staging
@@ -85,14 +85,14 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.PR_APP_ID }}
           private-key: ${{ secrets.PR_APP_PK }}
           repositories: ManagementConsole
 
       - name: Checkout benthos-umh repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ env.VERSION }}
 
@@ -105,7 +105,7 @@ jobs:
           make generate-schema VERSION="${VERSION_CLEAN}"
 
       - name: Checkout ManagementConsole
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: united-manufacturing-hub/ManagementConsole
           token: ${{ steps.generate-token.outputs.token }}

--- a/modbus_plugin/modbus_test.go
+++ b/modbus_plugin/modbus_test.go
@@ -331,11 +331,11 @@ var _ = Describe("Test Against Wago-PLC", func() {
 
 var _ = Describe("Per-Slave Address Routing", func() {
 	BeforeEach(func() {
-		testActive := os.Getenv("TEST_MODBUS_UNITTEST")
+		testActive, ok := os.LookupEnv("TEST_MODBUS_UNITTEST")
 
-		// Check if environment variables are set
-		if testActive == "" {
-			Skip("Skipping test: environment variables are not set")
+		// Check if unit test variable is set
+		if !ok || testActive == "FALSE" {
+			Skip("Skipping test: TEST_MODBUS_UNITTEST env variable is not set or is FALSE")
 			return
 		}
 	})

--- a/modbus_plugin/modbus_test.go
+++ b/modbus_plugin/modbus_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grid-x/modbus"
@@ -334,7 +335,7 @@ var _ = Describe("Per-Slave Address Routing", func() {
 		testActive, ok := os.LookupEnv("TEST_MODBUS_UNITTEST")
 
 		// Check if unit test variable is set
-		if !ok || testActive == "FALSE" {
+		if !ok || strings.ToLower(testActive) == "false" {
 			Skip("Skipping test: TEST_MODBUS_UNITTEST env variable is not set or is FALSE")
 			return
 		}

--- a/modbus_plugin/modbus_test.go
+++ b/modbus_plugin/modbus_test.go
@@ -330,6 +330,15 @@ var _ = Describe("Test Against Wago-PLC", func() {
 })
 
 var _ = Describe("Per-Slave Address Routing", func() {
+	BeforeEach(func() {
+		testActive := os.Getenv("TEST_MODBUS_UNITTEST")
+
+		// Check if environment variables are set
+		if testActive == "" {
+			Skip("Skipping test: environment variables are not set")
+			return
+		}
+	})
 	// Helper to build per-slave RequestSets with validation and deduplication,
 	// mimicking the constructor logic. Optionally tracks deduplicated addresses.
 	buildPerSlaveRequestSets := func(input *ModbusInput, tracking map[byte][]ModbusDataItemWithAddress) error {

--- a/s7comm_plugin/s7comm_test.go
+++ b/s7comm_plugin/s7comm_test.go
@@ -31,11 +31,11 @@ import (
 
 var _ = Describe("S7Comm Plugin Unittests", func() {
 	BeforeEach(func() {
-		testActive := os.Getenv("TEST_S7COMM_UNITTEST")
+		testActive, ok := os.LookupEnv("TEST_S7COMM_UNITTEST")
 
-		// Check if environment variables are set
-		if testActive == "" {
-			Skip("Skipping test: environment variables are not set")
+		// Check if unit test variable is set
+		if !ok || testActive == "FALSE" {
+			Skip("Skipping test: TEST_S7COMM_UNITTEST env variable is not set or is FALSE")
 			return
 		}
 	})

--- a/s7comm_plugin/s7comm_test.go
+++ b/s7comm_plugin/s7comm_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,7 +35,7 @@ var _ = Describe("S7Comm Plugin Unittests", func() {
 		testActive, ok := os.LookupEnv("TEST_S7COMM_UNITTEST")
 
 		// Check if unit test variable is set
-		if !ok || testActive == "FALSE" {
+		if !ok || strings.ToLower(testActive) == "false" {
 			Skip("Skipping test: TEST_S7COMM_UNITTEST env variable is not set or is FALSE")
 			return
 		}

--- a/sensorconnect_plugin/connect_test.go
+++ b/sensorconnect_plugin/connect_test.go
@@ -36,11 +36,11 @@ var _ = Describe("SensorConnect Plugin Unittests", func() {
 	)
 
 	BeforeEach(func() {
-		testActive := os.Getenv("TEST_SENSORCONNECT_UNITTEST")
+		testActive, ok := os.LookupEnv("TEST_SENSORCONNECT_UNITTEST")
 
-		// Check if environment variables are set
-		if testActive == "" {
-			Skip("Skipping test: environment variables are not set")
+		// Check if unit test variable is set
+		if !ok || testActive == "FALSE" {
+			Skip("Skipping test: TEST_SENSORCONNECT_UNITTEST env variable is not set or is FALSE")
 			return
 		}
 

--- a/sensorconnect_plugin/connect_test.go
+++ b/sensorconnect_plugin/connect_test.go
@@ -36,11 +36,11 @@ var _ = Describe("SensorConnect Plugin Unittests", func() {
 	)
 
 	BeforeEach(func() {
-		endpoint := os.Getenv("TEST_DEBUG_IFM_ENDPOINT")
+		testActive := os.Getenv("TEST_SENSORCONNECT_UNITTEST")
 
 		// Check if environment variables are set
-		if endpoint == "" {
-			Skip("Skipping test: environment variables not set")
+		if testActive == "" {
+			Skip("Skipping test: environment variables are not set")
 			return
 		}
 

--- a/sensorconnect_plugin/connect_test.go
+++ b/sensorconnect_plugin/connect_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,7 +40,7 @@ var _ = Describe("SensorConnect Plugin Unittests", func() {
 		testActive, ok := os.LookupEnv("TEST_SENSORCONNECT_UNITTEST")
 
 		// Check if unit test variable is set
-		if !ok || testActive == "FALSE" {
+		if !ok || strings.ToLower(testActive) == "false" {
 			Skip("Skipping test: TEST_SENSORCONNECT_UNITTEST env variable is not set or is FALSE")
 			return
 		}

--- a/sensorconnect_plugin/customIodd_test.go
+++ b/sensorconnect_plugin/customIodd_test.go
@@ -37,11 +37,11 @@ var _ = Describe("FetchAndStoreCustomIODD", func() {
 	)
 
 	BeforeEach(func() {
-		endpoint := os.Getenv("TEST_DEBUG_IFM_ENDPOINT")
+		testActive := os.Getenv("TEST_SENSORCONNECT_UNITTEST")
 
 		// Check if environment variables are set
-		if endpoint == "" {
-			Skip("Skipping test: environment variables not set")
+		if testActive == "" {
+			Skip("Skipping test: environment variables are not set")
 			return
 		}
 

--- a/sensorconnect_plugin/customIodd_test.go
+++ b/sensorconnect_plugin/customIodd_test.go
@@ -37,11 +37,11 @@ var _ = Describe("FetchAndStoreCustomIODD", func() {
 	)
 
 	BeforeEach(func() {
-		testActive := os.Getenv("TEST_SENSORCONNECT_UNITTEST")
+		testActive, ok := os.LookupEnv("TEST_SENSORCONNECT_UNITTEST")
 
-		// Check if environment variables are set
-		if testActive == "" {
-			Skip("Skipping test: environment variables are not set")
+		// Check if unit test variable is set
+		if !ok || testActive == "FALSE" {
+			Skip("Skipping test: TEST_SENSORCONNECT_UNITTEST env variable is not set or is FALSE")
 			return
 		}
 

--- a/sensorconnect_plugin/customIodd_test.go
+++ b/sensorconnect_plugin/customIodd_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,7 +41,7 @@ var _ = Describe("FetchAndStoreCustomIODD", func() {
 		testActive, ok := os.LookupEnv("TEST_SENSORCONNECT_UNITTEST")
 
 		// Check if unit test variable is set
-		if !ok || testActive == "FALSE" {
+		if !ok || strings.ToLower(testActive) == "false" {
 			Skip("Skipping test: TEST_SENSORCONNECT_UNITTEST env variable is not set or is FALSE")
 			return
 		}

--- a/sensorconnect_plugin/processSensorData_test.go
+++ b/sensorconnect_plugin/processSensorData_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,7 +33,7 @@ var _ = Describe("ProcessSensorData", func() {
 		testActive, ok := os.LookupEnv("TEST_SENSORCONNECT_UNITTEST")
 
 		// Check if unit test variable is set
-		if !ok || testActive == "FALSE" {
+		if !ok || strings.ToLower(testActive) == "false" {
 			Skip("Skipping test: TEST_SENSORCONNECT_UNITTEST env variable is not set or is FALSE")
 			return
 		}
@@ -230,7 +231,7 @@ var _ = Describe("float32T bug (ENG-2010)", func() {
 		testActive, ok := os.LookupEnv("TEST_SENSORCONNECT_UNITTEST")
 
 		// Check if unit test variable is set
-		if !ok || testActive == "FALSE" {
+		if !ok || strings.ToLower(testActive) == "false" {
 			Skip("Skipping test: TEST_SENSORCONNECT_UNITTEST env variable is not set or is FALSE")
 			return
 		}

--- a/sensorconnect_plugin/processSensorData_test.go
+++ b/sensorconnect_plugin/processSensorData_test.go
@@ -29,11 +29,11 @@ var _ = Describe("ProcessSensorData", func() {
 	var s *sensorconnect_plugin.SensorConnectInput
 
 	BeforeEach(func() {
-		testActive := os.Getenv("TEST_SENSORCONNECT_UNITTEST")
+		testActive, ok := os.LookupEnv("TEST_SENSORCONNECT_UNITTEST")
 
-		// Check if environment variables are set
-		if testActive == "" {
-			Skip("Skipping test: environment variables are not set")
+		// Check if unit test variable is set
+		if !ok || testActive == "FALSE" {
+			Skip("Skipping test: TEST_SENSORCONNECT_UNITTEST env variable is not set or is FALSE")
 			return
 		}
 
@@ -227,11 +227,11 @@ var _ = Describe("float32T bug (ENG-2010)", func() {
 	var s *sensorconnect_plugin.SensorConnectInput
 
 	BeforeEach(func() {
-		testActive := os.Getenv("TEST_SENSORCONNECT_UNITTEST")
+		testActive, ok := os.LookupEnv("TEST_SENSORCONNECT_UNITTEST")
 
-		// Check if environment variables are set
-		if testActive == "" {
-			Skip("Skipping test: environment variables are not set")
+		// Check if unit test variable is set
+		if !ok || testActive == "FALSE" {
+			Skip("Skipping test: TEST_SENSORCONNECT_UNITTEST env variable is not set or is FALSE")
 			return
 		}
 

--- a/sensorconnect_plugin/processSensorData_test.go
+++ b/sensorconnect_plugin/processSensorData_test.go
@@ -29,11 +29,11 @@ var _ = Describe("ProcessSensorData", func() {
 	var s *sensorconnect_plugin.SensorConnectInput
 
 	BeforeEach(func() {
-		endpoint := os.Getenv("TEST_DEBUG_IFM_ENDPOINT")
+		testActive := os.Getenv("TEST_SENSORCONNECT_UNITTEST")
 
 		// Check if environment variables are set
-		if endpoint == "" {
-			Skip("Skipping test: environment variables not set")
+		if testActive == "" {
+			Skip("Skipping test: environment variables are not set")
 			return
 		}
 
@@ -227,11 +227,11 @@ var _ = Describe("float32T bug (ENG-2010)", func() {
 	var s *sensorconnect_plugin.SensorConnectInput
 
 	BeforeEach(func() {
-		endpoint := os.Getenv("TEST_DEBUG_IFM_ENDPOINT")
+		testActive := os.Getenv("TEST_SENSORCONNECT_UNITTEST")
 
 		// Check if environment variables are set
-		if endpoint == "" {
-			Skip("Skipping test: environment variables not set")
+		if testActive == "" {
+			Skip("Skipping test: environment variables are not set")
 			return
 		}
 


### PR DESCRIPTION
# Description

Fixes ENG-4617
and also
fixes ENG-4210

This PR is used to make `benthos-umh` according to the changelog-format of the other UMH-repositories.
Therefore we introduce the following architecture

- introduce `staging` branch
- introduce `merge_group`
- separate `plc-tests` and `unittests`, `plc-tests` only run in merge-queue
- therefore separate tests in `sensorconnect_plugin` and `modbus_plugin` as well as in the CI

### Upcoming

We will need to remove `master` as a targeted branch for PRs and pushes after we switched completely to main, but this will be tackled in another step and an additional PR. 