### PR TITLE
feat(noderedjs): add cache.set/get/delete api in-memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ web_modules/
 .env.test.local
 .env.production.local
 .env.local
+mise.toml
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Improvements
+
+- Cache API for JavaScript processors: new `cache.set(key, value)`, `cache.get(key, default)`, and `cache.delete(key)` methods for tracking state across messages. Previously, state management required complex Benthos `branch`/`request_map`/`result_map` configurations. Now you can store any JSON-compatible value (strings, numbers, objects, arrays) directly from JavaScript. `cache.get` requires a default value to prevent silent undefined bugs. Available in both `nodered_js` and `tag_processor`. Currently in-memory only (lost on restart), persistent backend planned
+
 ## [0.12.2]
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Cache API for JavaScript processors: new `cache.set(key, value)`, `cache.get(key, default)`, and `cache.delete(key)` methods for tracking state across messages. Previously, state management required complex Benthos `branch`/`request_map`/`result_map` configurations. Now you can store any JSON-compatible value (strings, numbers, objects, arrays) directly from JavaScript. `cache.get` requires a default value to prevent silent undefined bugs. Available in both `nodered_js` and `tag_processor`. Currently in-memory only (lost on restart), persistent backend planned
+- Cache API for JavaScript processors: new `cache.set(key, value)`, `cache.get(key)`, `cache.exists(key)`, and `cache.delete(key)` methods for tracking state across messages. Previously, state management required complex Benthos `branch`/`request_map`/`result_map` configurations. Now you can store any JSON-compatible value (strings, numbers, objects, arrays) directly from JavaScript. Use `cache.exists(key)` before `cache.get(key)` to handle missing keys. Available in both `nodered_js` and `tag_processor`. Currently in-memory only (lost on restart), persistent backend planned
 
 ## [0.12.2]
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
   - [Topic Browser](processing/topic-browser.md)
   - [Stream Processor](processing/stream-processor.md)
   - [Node-RED JavaScript Processor](processing/node-red-javascript-processor.md)
+  - [JavaScript API Reference](processing/javascript-api.md)
   - [More](https://docs.redpanda.com/redpanda-connect/components/processors/about/)
 - [Output](output/README.md)
   - [Sparkplug B (Output)](output/sparkplug-b-output.md)

--- a/docs/processing/javascript-api.md
+++ b/docs/processing/javascript-api.md
@@ -1,0 +1,114 @@
+# JavaScript API Reference
+
+This page documents the global objects available in the JavaScript environment shared by the `nodered_js` and `tag_processor` processors. The engine is goja (ES5.1 with some ES6 features) — no Node.js APIs are available.
+
+## msg
+
+The message object. Contains the payload and metadata of the current message.
+
+```javascript
+msg.payload    // The message content (any JSON type)
+msg.meta       // Metadata key-value pairs (strings)
+```
+
+**Return behavior:**
+- `return msg;` — pass the message through (modified or not)
+- `return null;` or `return undefined;` — drop the message
+- `return { payload: ..., meta: ... };` — create a new message
+
+**Example:**
+```javascript
+msg.payload = msg.payload * 2;
+msg.meta.processed = "true";
+return msg;
+```
+
+## console
+
+Logging functions that write to the Benthos logger.
+
+```javascript
+console.debug(...)  // DEBUG level
+console.log(...)    // INFO level
+console.info(...)   // INFO level
+console.warn(...)   // WARN level
+console.error(...)  // ERROR level
+```
+
+Accepts multiple arguments: `console.log("value is", msg.payload.value)`
+
+## cache
+
+Key-value store for maintaining state across messages. Values persist for the lifetime of the processor. Supports any JSON-compatible type: strings, numbers, booleans, objects, arrays.
+
+```javascript
+cache.set(key, value)    // Store a value under key (string)
+cache.get(key)           // Retrieve a value, returns undefined if not found
+cache.delete(key)        // Remove a key
+```
+
+### Counter
+
+```javascript
+var count = cache.get("counter") || 0;
+count++;
+cache.set("counter", count);
+msg.payload = count;
+return msg;
+```
+
+### Previous value comparison
+
+```javascript
+var prev = cache.get("last_value");
+var delta = (typeof prev !== "undefined") ? msg.payload.value - prev : 0;
+cache.set("last_value", msg.payload.value);
+msg.payload.delta = delta;
+return msg;
+```
+
+### History (last N values)
+
+```javascript
+var history = cache.get("history") || [];
+history.push(msg.payload.value);
+if (history.length > 10) history.shift();
+cache.set("history", history);
+```
+
+### Alarm state tracking
+
+```javascript
+var alarmed = cache.get("alarm_active") || false;
+if (msg.payload > 100 && !alarmed) {
+  cache.set("alarm_active", true);
+  msg.meta.alarm = "triggered";
+  return msg;
+}
+if (msg.payload <= 100 && alarmed) {
+  cache.set("alarm_active", false);
+  msg.meta.alarm = "cleared";
+  return msg;
+}
+return msg;
+```
+
+### Configuration
+
+The cache backend and expiration can be configured in the processor YAML. By default, the cache uses the `memory` backend with no expiration.
+
+```yaml
+pipeline:
+  processors:
+    - nodered_js:
+        code: |
+          // your code
+        cache:
+          backend: memory
+          expiration: 0s    # 0s = no expiration (default)
+```
+
+### Limitations
+
+- **Memory backend only** — state is lost on process restart. A persistent backend is planned.
+- **No size limits** — the number of keys is bounded by your code. Use `cache.delete` to clean up unused keys.

--- a/docs/processing/javascript-api.md
+++ b/docs/processing/javascript-api.md
@@ -39,20 +39,30 @@ Accepts multiple arguments: `console.log("value is", msg.payload.value)`
 
 ## cache
 
-Key-value store for maintaining state across messages. Values persist for the lifetime of the processor. Supports any JSON-compatible type: strings, numbers, booleans, objects, arrays.
+Key-value store for maintaining state across messages. Persists across all messages for the lifetime of the Benthos process. In-memory only, lost on restart. Supports any JSON-compatible type: strings, numbers, booleans, objects, arrays.
+
+The cache is automatic and requires no configuration.
 
 ```javascript
-cache.set(key, value)    // Store a value under key (string)
-cache.get(key)           // Retrieve a value, returns undefined if not found
-cache.delete(key)        // Remove a key
+cache.set(key, value)           // Store a value under key (string)
+cache.get(key, default)         // Retrieve a value, returns default if not found
+cache.delete(key)               // Remove a key
+```
+
+`cache.get` requires two arguments. The second argument is the default value returned when the key does not exist. This prevents silent `undefined` bugs in counters, alarm flags, and other state.
+
+```javascript
+cache.get("counter", 0)         // returns 0 if missing
+cache.get("alarm_active", false)// returns false if missing
+cache.get("counter")            // TypeError — must provide default
 ```
 
 ### Counter
 
 ```javascript
-var count = cache.get("counter") || 0;
+var count = cache.get("count", 0);
 count++;
-cache.set("counter", count);
+cache.set("count", count);
 msg.payload = count;
 return msg;
 ```
@@ -60,8 +70,8 @@ return msg;
 ### Previous value comparison
 
 ```javascript
-var prev = cache.get("last_value");
-var delta = (typeof prev !== "undefined") ? msg.payload.value - prev : 0;
+var prev = cache.get("last_value", null);
+var delta = (prev !== null) ? msg.payload.value - prev : 0;
 cache.set("last_value", msg.payload.value);
 msg.payload.delta = delta;
 return msg;
@@ -70,22 +80,23 @@ return msg;
 ### History (last N values)
 
 ```javascript
-var history = cache.get("history") || [];
+var history = cache.get("history", []);
 history.push(msg.payload.value);
 if (history.length > 10) history.shift();
 cache.set("history", history);
+return msg;
 ```
 
 ### Alarm state tracking
 
 ```javascript
-var alarmed = cache.get("alarm_active") || false;
-if (msg.payload > 100 && !alarmed) {
+var alarmed = cache.get("alarm_active", false);
+if (msg.payload.value > 100 && !alarmed) {
   cache.set("alarm_active", true);
   msg.meta.alarm = "triggered";
   return msg;
 }
-if (msg.payload <= 100 && alarmed) {
+if (msg.payload.value <= 100 && alarmed) {
   cache.set("alarm_active", false);
   msg.meta.alarm = "cleared";
   return msg;
@@ -93,22 +104,19 @@ if (msg.payload <= 100 && alarmed) {
 return msg;
 ```
 
-### Configuration
+### Cycle time between events
 
-The cache backend and expiration can be configured in the processor YAML. By default, the cache uses the `memory` backend with no expiration.
-
-```yaml
-pipeline:
-  processors:
-    - nodered_js:
-        code: |
-          // your code
-        cache:
-          backend: memory
-          expiration: 0s    # 0s = no expiration (default)
+```javascript
+var lastMs = cache.get("last_event_ms", null);
+if (lastMs !== null) {
+  msg.payload.cycle_time_ms = Date.now() - lastMs;
+}
+cache.set("last_event_ms", Date.now());
+return msg;
 ```
 
 ### Limitations
 
-- **Memory backend only** — state is lost on process restart. A persistent backend is planned.
-- **No size limits** — the number of keys is bounded by your code. Use `cache.delete` to clean up unused keys.
+- **In-memory only** — state is lost when the Benthos process restarts. A persistent backend is planned.
+- **No size limits** — the cache grows unboundedly if keys are never deleted. Use `cache.delete` to clean up unused keys. A memory safeguard (threshold, eviction) is planned.
+- **Cache scope in `tag_processor`** — the cache is shared across all stages (`defaults`, `conditions`, `advancedProcessing`). A value set in `defaults` is visible in `advancedProcessing` within the same message.

--- a/docs/processing/javascript-api.md
+++ b/docs/processing/javascript-api.md
@@ -44,23 +44,27 @@ Key-value store for maintaining state across messages. Persists across all messa
 The cache is automatic and requires no configuration.
 
 ```javascript
-cache.set(key, value)           // Store a value under key (string)
-cache.get(key, default)         // Retrieve a value, returns default if not found
-cache.delete(key)               // Remove a key
+cache.set(key, value)    // Store a value under key (string)
+cache.get(key)           // Retrieve a value, logs error if key not found
+cache.exists(key)        // Returns true if key exists, false otherwise
+cache.delete(key)        // Remove a key
 ```
 
-`cache.get` requires two arguments. The second argument is the default value returned when the key does not exist. This prevents silent `undefined` bugs in counters, alarm flags, and other state.
+Always use `cache.exists(key)` before `cache.get(key)` to avoid error logs on missing keys.
 
 ```javascript
-cache.get("counter", 0)         // returns 0 if missing
-cache.get("alarm_active", false)// returns false if missing
-cache.get("counter")            // TypeError — must provide default
+if (cache.exists("counter")) {
+  var count = cache.get("counter");
+} else {
+  var count = 0;
+}
 ```
 
 ### Counter
 
 ```javascript
-var count = cache.get("count", 0);
+var count = 0;
+if (cache.exists("count")) { count = cache.get("count"); }
 count++;
 cache.set("count", count);
 msg.payload = count;
@@ -70,7 +74,7 @@ return msg;
 ### Previous value comparison
 
 ```javascript
-var prev = cache.get("last_value", null);
+var prev = cache.exists("last_value") ? cache.get("last_value") : null;
 var delta = (prev !== null) ? msg.payload.value - prev : 0;
 cache.set("last_value", msg.payload.value);
 msg.payload.delta = delta;
@@ -80,7 +84,7 @@ return msg;
 ### History (last N values)
 
 ```javascript
-var history = cache.get("history", []);
+var history = cache.exists("history") ? cache.get("history") : [];
 history.push(msg.payload.value);
 if (history.length > 10) history.shift();
 cache.set("history", history);
@@ -90,7 +94,7 @@ return msg;
 ### Alarm state tracking
 
 ```javascript
-var alarmed = cache.get("alarm_active", false);
+var alarmed = cache.exists("alarm_active") ? cache.get("alarm_active") : false;
 if (msg.payload.value > 100 && !alarmed) {
   cache.set("alarm_active", true);
   msg.meta.alarm = "triggered";
@@ -107,7 +111,7 @@ return msg;
 ### Cycle time between events
 
 ```javascript
-var lastMs = cache.get("last_event_ms", null);
+var lastMs = cache.exists("last_event_ms") ? cache.get("last_event_ms") : null;
 if (lastMs !== null) {
   msg.payload.cycle_time_ms = Date.now() - lastMs;
 }

--- a/docs/processing/javascript-api.md
+++ b/docs/processing/javascript-api.md
@@ -74,8 +74,14 @@ return msg;
 ### Previous value comparison
 
 ```javascript
-var prev = cache.exists("last_value") ? cache.get("last_value") : null;
-var delta = (prev !== null) ? msg.payload.value - prev : 0;
+var prev = null;
+if (cache.exists("last_value")) {
+  prev = cache.get("last_value");
+}
+var delta = 0;
+if (prev !== null) {
+  delta = msg.payload.value - prev;
+}
 cache.set("last_value", msg.payload.value);
 msg.payload.delta = delta;
 return msg;
@@ -84,7 +90,10 @@ return msg;
 ### History (last N values)
 
 ```javascript
-var history = cache.exists("history") ? cache.get("history") : [];
+var history = [];
+if (cache.exists("history")) {
+  history = cache.get("history");
+}
 history.push(msg.payload.value);
 if (history.length > 10) history.shift();
 cache.set("history", history);
@@ -94,7 +103,10 @@ return msg;
 ### Alarm state tracking
 
 ```javascript
-var alarmed = cache.exists("alarm_active") ? cache.get("alarm_active") : false;
+var alarmed = false;
+if (cache.exists("alarm_active")) {
+  alarmed = cache.get("alarm_active");
+}
 if (msg.payload.value > 100 && !alarmed) {
   cache.set("alarm_active", true);
   msg.meta.alarm = "triggered";
@@ -111,7 +123,10 @@ return msg;
 ### Cycle time between events
 
 ```javascript
-var lastMs = cache.exists("last_event_ms") ? cache.get("last_event_ms") : null;
+var lastMs = null;
+if (cache.exists("last_event_ms")) {
+  lastMs = cache.get("last_event_ms");
+}
 if (lastMs !== null) {
   msg.payload.cycle_time_ms = Date.now() - lastMs;
 }

--- a/docs/processing/node-red-javascript-processor.md
+++ b/docs/processing/node-red-javascript-processor.md
@@ -4,6 +4,8 @@ The Node-RED JavaScript processor allows you to write JavaScript code to process
 
 Use the `nodered_js` processor instead of the `tag_processor` when you need full control over the payload and require custom processing logic that goes beyond standard tag or time series data handling. This processor allows you to write custom JavaScript code to manipulate both the payload and metadata, providing the flexibility to implement complex transformations, conditional logic, or integrate with other systems.
 
+For the full list of available JavaScript globals (`msg`, `console`, `cache`), see the [JavaScript API Reference](javascript-api.md).
+
 **Configuration**
 
 ```yaml

--- a/docs/processing/tag-processor.md
+++ b/docs/processing/tag-processor.md
@@ -4,6 +4,8 @@ The Tag Processor is designed to prepare incoming data for the UMH data model. I
 
 Use the `tag_processor` compared to the `nodered_js` when you are processing tags or time series data and converting them to the UMH data model within the `_historian` data contract. This processor is optimized for handling structured time series data, automatically formats messages, and generates appropriate metadata.
 
+The JavaScript stages use the same environment as the `nodered_js` processor. For the full list of available globals (`msg`, `console`, `cache`), see the [JavaScript API Reference](javascript-api.md).
+
 **Message Formatting Behavior**
 
 The processor automatically formats different input types into a consistent structure with a "value" field:

--- a/nodered_js_plugin/cache/cache.go
+++ b/nodered_js_plugin/cache/cache.go
@@ -22,8 +22,6 @@ type Cache interface {
 	Set(ctx context.Context, key string, value any) error
 	// Get returns the value stored under key and if it even exists.
 	Get(ctx context.Context, key string) (any, bool)
-	// Exists returns true if key is present and not expired.
-	Exists(ctx context.Context, key string) bool
 	// Delete removes the entry for key. No-op when key does not exist.
 	Delete(ctx context.Context, key string) error
 	// Close releases any resources held by the store.

--- a/nodered_js_plugin/cache/cache.go
+++ b/nodered_js_plugin/cache/cache.go
@@ -22,6 +22,8 @@ type Cache interface {
 	Set(ctx context.Context, key string, value any) error
 	// Get returns the value stored under key and if it even exists.
 	Get(ctx context.Context, key string) (any, bool)
+	// Exists returns true if key is present and not expired.
+	Exists(ctx context.Context, key string) bool
 	// Delete removes the entry for key. No-op when key does not exist.
 	Delete(ctx context.Context, key string) error
 	// Close releases any resources held by the store.

--- a/nodered_js_plugin/cache/cache_suite_test.go
+++ b/nodered_js_plugin/cache/cache_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cache Suite")
+}

--- a/nodered_js_plugin/cache/memory.go
+++ b/nodered_js_plugin/cache/memory.go
@@ -14,39 +14,129 @@
 
 package cache
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Item wraps a cached value with an optional expiration timestamp.
+type Item struct {
+	Value      any
+	Expiration int64 // UnixNano; 0 means no expiration
+}
+
+// Expired returns true if the item has a set expiration that is in the past.
+func (item Item) Expired() bool {
+	if item.Expiration == 0 {
+		return false
+	}
+	return time.Now().UnixNano() > item.Expiration
+}
 
 // MemoryStore is used as key/value store for the first cache implementation.
 type MemoryStore struct {
-	mu    sync.RWMutex
-	items map[string]any
+	mu                sync.RWMutex
+	items             map[string]Item
+	defaultExpiration time.Duration
+	janitor           *janitor
 }
+
+var _ Cache = (*MemoryStore)(nil)
 
 // NewMemoryStore returns a ready-to-use, empty MemoryStore.
-func NewMemoryStore() *MemoryStore {
-	return &MemoryStore{items: make(map[string]any)}
+func NewMemoryStore(defaultExpiration time.Duration) *MemoryStore {
+	m := &MemoryStore{
+		items:             make(map[string]Item),
+		defaultExpiration: defaultExpiration,
+	}
+	if defaultExpiration > 0 {
+		j := newJanitor(1 * time.Hour)
+		m.janitor = j
+		go j.run(m)
+	}
+	return m
 }
 
-func (m *MemoryStore) Set(key string, value any) {
+func (m *MemoryStore) Set(key string, value any) error {
+	if key == "" {
+		return fmt.Errorf("cache: key must not be empty")
+	}
+	var expiration int64
+	if m.defaultExpiration > 0 {
+		expiration = time.Now().Add(m.defaultExpiration).UnixNano()
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.items[key] = value
+	m.items[key] = Item{
+		Value:      value,
+		Expiration: expiration,
+	}
+	return nil
 }
 
 func (m *MemoryStore) Get(key string) (any, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	v, ok := m.items[key]
-	return v, ok
+	item, ok := m.items[key]
+	if !ok {
+		return nil, false
+	}
+	if item.Expired() {
+		return nil, false
+	}
+	return item.Value, true
 }
 
-func (m *MemoryStore) Delete(key string) {
+func (m *MemoryStore) Delete(key string) error {
+	if key == "" {
+		return fmt.Errorf("cache: key must not be empty")
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.items, key)
+	return nil
 }
 
-// Close is a no-op for MemoryStore (nothing to release).
+// Close stops the janitor and releases resources.
 func (m *MemoryStore) Close() error {
+	if m.janitor != nil {
+		close(m.janitor.stop)
+	}
 	return nil
+}
+
+func (m *MemoryStore) deleteExpired() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, item := range m.items {
+		if item.Expired() {
+			delete(m.items, k)
+		}
+	}
+}
+
+type janitor struct {
+	interval time.Duration
+	stop     chan struct{}
+}
+
+func newJanitor(interval time.Duration) *janitor {
+	return &janitor{
+		interval: interval,
+		stop:     make(chan struct{}),
+	}
+}
+
+func (j *janitor) run(m *MemoryStore) {
+	ticker := time.NewTicker(j.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.deleteExpired()
+		case <-j.stop:
+			return
+		}
+	}
 }

--- a/nodered_js_plugin/cache/memory.go
+++ b/nodered_js_plugin/cache/memory.go
@@ -40,6 +40,7 @@ type MemoryStore struct {
 	items             map[string]Item
 	defaultExpiration time.Duration
 	janitor           *janitor
+	closeOnce         sync.Once
 }
 
 var _ Cache = (*MemoryStore)(nil)
@@ -100,9 +101,11 @@ func (m *MemoryStore) Delete(key string) error {
 
 // Close stops the janitor and releases resources.
 func (m *MemoryStore) Close() error {
-	if m.janitor != nil {
-		close(m.janitor.stop)
-	}
+	m.closeOnce.Do(func() {
+		if m.janitor != nil {
+			close(m.janitor.stop)
+		}
+	})
 	return nil
 }
 

--- a/nodered_js_plugin/cache/memory.go
+++ b/nodered_js_plugin/cache/memory.go
@@ -15,6 +15,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -59,7 +60,7 @@ func NewMemoryStore(defaultExpiration time.Duration) *MemoryStore {
 	return m
 }
 
-func (m *MemoryStore) Set(key string, value any) error {
+func (m *MemoryStore) Set(_ context.Context, key string, value any) error {
 	if key == "" {
 		return fmt.Errorf("cache: key must not be empty")
 	}
@@ -76,7 +77,7 @@ func (m *MemoryStore) Set(key string, value any) error {
 	return nil
 }
 
-func (m *MemoryStore) Get(key string) (any, bool) {
+func (m *MemoryStore) Get(_ context.Context, key string) (any, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	item, ok := m.items[key]
@@ -89,7 +90,7 @@ func (m *MemoryStore) Get(key string) (any, bool) {
 	return item.Value, true
 }
 
-func (m *MemoryStore) Delete(key string) error {
+func (m *MemoryStore) Delete(_ context.Context, key string) error {
 	if key == "" {
 		return fmt.Errorf("cache: key must not be empty")
 	}

--- a/nodered_js_plugin/cache/memory.go
+++ b/nodered_js_plugin/cache/memory.go
@@ -1,0 +1,52 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import "sync"
+
+// MemoryStore is used as key/value store for the first cache implementation.
+type MemoryStore struct {
+	mu    sync.RWMutex
+	items map[string]any
+}
+
+// NewMemoryStore returns an initialised, empty MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{items: make(map[string]any)}
+}
+
+func (m *MemoryStore) Set(key string, value any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items[key] = value
+}
+
+func (m *MemoryStore) Get(key string) (any, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.items[key]
+	return v, ok
+}
+
+func (m *MemoryStore) Delete(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.items, key)
+}
+
+// Close is a no-op for MemoryStore (nothing to release).
+func (m *MemoryStore) Close() error {
+	return nil
+}

--- a/nodered_js_plugin/cache/memory.go
+++ b/nodered_js_plugin/cache/memory.go
@@ -90,11 +90,6 @@ func (m *MemoryStore) Get(_ context.Context, key string) (any, bool) {
 	return item.Value, true
 }
 
-func (m *MemoryStore) Exists(ctx context.Context, key string) bool {
-	_, ok := m.Get(ctx, key)
-	return ok
-}
-
 func (m *MemoryStore) Delete(_ context.Context, key string) error {
 	if key == "" {
 		return fmt.Errorf("cache: key must not be empty")

--- a/nodered_js_plugin/cache/memory.go
+++ b/nodered_js_plugin/cache/memory.go
@@ -22,7 +22,7 @@ type MemoryStore struct {
 	items map[string]any
 }
 
-// NewMemoryStore returns an initialised, empty MemoryStore.
+// NewMemoryStore returns a ready-to-use, empty MemoryStore.
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{items: make(map[string]any)}
 }

--- a/nodered_js_plugin/cache/memory.go
+++ b/nodered_js_plugin/cache/memory.go
@@ -90,6 +90,11 @@ func (m *MemoryStore) Get(_ context.Context, key string) (any, bool) {
 	return item.Value, true
 }
 
+func (m *MemoryStore) Exists(ctx context.Context, key string) bool {
+	_, ok := m.Get(ctx, key)
+	return ok
+}
+
 func (m *MemoryStore) Delete(_ context.Context, key string) error {
 	if key == "" {
 		return fmt.Errorf("cache: key must not be empty")

--- a/nodered_js_plugin/cache/memory_test.go
+++ b/nodered_js_plugin/cache/memory_test.go
@@ -1,0 +1,99 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache_test
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/cache"
+)
+
+var _ = Describe("MemoryStore", func() {
+	var store *cache.MemoryStore
+
+	BeforeEach(func() {
+		store = cache.NewMemoryStore()
+	})
+
+	Describe("Get on a missing key", func() {
+		It("returns false", func() {
+			_, ok := store.Get("missing")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("returns nil value", func() {
+			v, _ := store.Get("missing")
+			Expect(v).To(BeNil())
+		})
+	})
+
+	DescribeTable("Set then Get round-trips",
+		func(key string, value any, matcher OmegaMatcher) {
+			store.Set(key, value)
+			v, ok := store.Get(key)
+			Expect(ok).To(BeTrue())
+			Expect(v).To(matcher)
+		},
+		Entry("string value", "k", "hello", Equal("hello")),
+		Entry("numeric value", "n", float64(42), Equal(float64(42))),
+		Entry("boolean true", "b", true, BeTrue()),
+		Entry("boolean false", "b2", false, BeFalse()),
+		Entry("map value", "obj", map[string]any{"foo": "bar"}, Equal(map[string]any{"foo": "bar"})),
+		Entry("explicit nil value", "null", nil, BeNil()),
+	)
+
+	It("overwrites an existing key", func() {
+		store.Set("k", "first")
+		store.Set("k", "second")
+		v, ok := store.Get("k")
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal("second"))
+	})
+
+	It("deletes an existing key", func() {
+		store.Set("k", "v")
+		store.Delete("k")
+		_, ok := store.Get("k")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("delete is a no-op for a missing key", func() {
+		Expect(func() { store.Delete("nope") }).NotTo(Panic())
+	})
+
+	It("is safe for concurrent Set and Get", func() {
+		const goroutines = 50
+		var wg sync.WaitGroup
+		wg.Add(goroutines * 2)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				store.Set("shared", 1)
+			}()
+			go func() {
+				defer wg.Done()
+				store.Get("shared") //nolint:errcheck
+			}()
+		}
+		wg.Wait()
+	})
+
+	It("satisfies the Store interface", func() {
+		var _ cache.Store = cache.NewMemoryStore()
+	})
+})

--- a/nodered_js_plugin/cache/memory_test.go
+++ b/nodered_js_plugin/cache/memory_test.go
@@ -15,6 +15,7 @@
 package cache_test
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 
 var _ = Describe("MemoryStore", func() {
 	var store *cache.MemoryStore
+	ctx := context.Background()
 
 	BeforeEach(func() {
 		store = cache.NewMemoryStore(0)
@@ -33,20 +35,20 @@ var _ = Describe("MemoryStore", func() {
 
 	Describe("Get on a missing key", func() {
 		It("returns false", func() {
-			_, ok := store.Get("missing")
+			_, ok := store.Get(ctx, "missing")
 			Expect(ok).To(BeFalse())
 		})
 
 		It("returns nil value", func() {
-			v, _ := store.Get("missing")
+			v, _ := store.Get(ctx, "missing")
 			Expect(v).To(BeNil())
 		})
 	})
 
 	DescribeTable("Set then Get round-trips",
 		func(key string, value any, matcher OmegaMatcher) {
-			Expect(store.Set(key, value)).To(Succeed())
-			v, ok := store.Get(key)
+			Expect(store.Set(context.Background(), key, value)).To(Succeed())
+			v, ok := store.Get(context.Background(), key)
 			Expect(ok).To(BeTrue())
 			Expect(v).To(matcher)
 		},
@@ -59,22 +61,22 @@ var _ = Describe("MemoryStore", func() {
 	)
 
 	It("overwrites an existing key", func() {
-		Expect(store.Set("k", "first")).To(Succeed())
-		Expect(store.Set("k", "second")).To(Succeed())
-		v, ok := store.Get("k")
+		Expect(store.Set(ctx, "k", "first")).To(Succeed())
+		Expect(store.Set(ctx, "k", "second")).To(Succeed())
+		v, ok := store.Get(ctx, "k")
 		Expect(ok).To(BeTrue())
 		Expect(v).To(Equal("second"))
 	})
 
 	It("deletes an existing key", func() {
-		Expect(store.Set("k", "v")).To(Succeed())
-		Expect(store.Delete("k")).To(Succeed())
-		_, ok := store.Get("k")
+		Expect(store.Set(ctx, "k", "v")).To(Succeed())
+		Expect(store.Delete(ctx, "k")).To(Succeed())
+		_, ok := store.Get(ctx, "k")
 		Expect(ok).To(BeFalse())
 	})
 
 	It("delete is a no-op for a missing key", func() {
-		Expect(store.Delete("nope")).To(Succeed())
+		Expect(store.Delete(ctx, "nope")).To(Succeed())
 	})
 
 	It("is safe for concurrent Set and Get", func() {
@@ -84,22 +86,22 @@ var _ = Describe("MemoryStore", func() {
 		for i := 0; i < goroutines; i++ {
 			go func() {
 				defer wg.Done()
-				store.Set("shared", 1)
+				store.Set(ctx, "shared", 1)
 			}()
 			go func() {
 				defer wg.Done()
-				store.Get("shared")
+				store.Get(ctx, "shared")
 			}()
 		}
 		wg.Wait()
 	})
 
 	It("returns error for empty key on Set and Delete", func() {
-		err := store.Set("", "value")
+		err := store.Set(ctx, "", "value")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("key must not be empty"))
 
-		err = store.Delete("")
+		err = store.Delete(ctx, "")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("key must not be empty"))
 	})
@@ -109,23 +111,23 @@ var _ = Describe("MemoryStore", func() {
 			expStore := cache.NewMemoryStore(50 * time.Millisecond)
 			defer expStore.Close()
 
-			Expect(expStore.Set("k", "v")).To(Succeed())
+			Expect(expStore.Set(ctx, "k", "v")).To(Succeed())
 
-			v, ok := expStore.Get("k")
+			v, ok := expStore.Get(ctx, "k")
 			Expect(ok).To(BeTrue())
 			Expect(v).To(Equal("v"))
 
 			time.Sleep(100 * time.Millisecond)
 
-			_, ok = expStore.Get("k")
+			_, ok = expStore.Get(ctx, "k")
 			Expect(ok).To(BeFalse())
 		})
 
 		It("does not expire items when expiration is 0", func() {
-			Expect(store.Set("k", "v")).To(Succeed())
+			Expect(store.Set(ctx, "k", "v")).To(Succeed())
 			time.Sleep(10 * time.Millisecond)
 
-			v, ok := store.Get("k")
+			v, ok := store.Get(ctx, "k")
 			Expect(ok).To(BeTrue())
 			Expect(v).To(Equal("v"))
 		})

--- a/nodered_js_plugin/cache/memory_test.go
+++ b/nodered_js_plugin/cache/memory_test.go
@@ -16,6 +16,7 @@ package cache_test
 
 import (
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,7 +28,7 @@ var _ = Describe("MemoryStore", func() {
 	var store *cache.MemoryStore
 
 	BeforeEach(func() {
-		store = cache.NewMemoryStore()
+		store = cache.NewMemoryStore(0)
 	})
 
 	Describe("Get on a missing key", func() {
@@ -44,7 +45,7 @@ var _ = Describe("MemoryStore", func() {
 
 	DescribeTable("Set then Get round-trips",
 		func(key string, value any, matcher OmegaMatcher) {
-			store.Set(key, value)
+			Expect(store.Set(key, value)).To(Succeed())
 			v, ok := store.Get(key)
 			Expect(ok).To(BeTrue())
 			Expect(v).To(matcher)
@@ -58,22 +59,22 @@ var _ = Describe("MemoryStore", func() {
 	)
 
 	It("overwrites an existing key", func() {
-		store.Set("k", "first")
-		store.Set("k", "second")
+		Expect(store.Set("k", "first")).To(Succeed())
+		Expect(store.Set("k", "second")).To(Succeed())
 		v, ok := store.Get("k")
 		Expect(ok).To(BeTrue())
 		Expect(v).To(Equal("second"))
 	})
 
 	It("deletes an existing key", func() {
-		store.Set("k", "v")
-		store.Delete("k")
+		Expect(store.Set("k", "v")).To(Succeed())
+		Expect(store.Delete("k")).To(Succeed())
 		_, ok := store.Get("k")
 		Expect(ok).To(BeFalse())
 	})
 
 	It("delete is a no-op for a missing key", func() {
-		Expect(func() { store.Delete("nope") }).NotTo(Panic())
+		Expect(store.Delete("nope")).To(Succeed())
 	})
 
 	It("is safe for concurrent Set and Get", func() {
@@ -93,7 +94,40 @@ var _ = Describe("MemoryStore", func() {
 		wg.Wait()
 	})
 
-	It("satisfies the Store interface", func() {
-		var _ cache.Store = cache.NewMemoryStore()
+	It("returns error for empty key on Set and Delete", func() {
+		err := store.Set("", "value")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("key must not be empty"))
+
+		err = store.Delete("")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("key must not be empty"))
+	})
+
+	Describe("expiration", func() {
+		It("expires items after the default expiration", func() {
+			expStore := cache.NewMemoryStore(50 * time.Millisecond)
+			defer expStore.Close()
+
+			Expect(expStore.Set("k", "v")).To(Succeed())
+
+			v, ok := expStore.Get("k")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("v"))
+
+			time.Sleep(100 * time.Millisecond)
+
+			_, ok = expStore.Get("k")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("does not expire items when expiration is 0", func() {
+			Expect(store.Set("k", "v")).To(Succeed())
+			time.Sleep(10 * time.Millisecond)
+
+			v, ok := store.Get("k")
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("v"))
+		})
 	})
 })

--- a/nodered_js_plugin/cache/memory_test.go
+++ b/nodered_js_plugin/cache/memory_test.go
@@ -87,7 +87,7 @@ var _ = Describe("MemoryStore", func() {
 			}()
 			go func() {
 				defer wg.Done()
-				store.Get("shared") //nolint:errcheck
+				store.Get("shared")
 			}()
 		}
 		wg.Wait()

--- a/nodered_js_plugin/cache/store.go
+++ b/nodered_js_plugin/cache/store.go
@@ -14,14 +14,14 @@
 
 package cache
 
-// Store is used as the caching interface for nodered_js.
-type Store interface {
+// Cache is used as the caching interface for nodered_js.
+type Cache interface {
 	// Set stores value under key, overwriting any existing entry.
-	Set(key string, value any)
+	Set(key string, value any) error
 	// Get returns the value stored under key and if it even exists.
 	Get(key string) (any, bool)
 	// Delete removes the entry for key. No-op when key does not exist.
-	Delete(key string)
+	Delete(key string) error
 	// Close releases any resources held by the store.
 	Close() error
 }

--- a/nodered_js_plugin/cache/store.go
+++ b/nodered_js_plugin/cache/store.go
@@ -14,14 +14,16 @@
 
 package cache
 
+import "context"
+
 // Cache is used as the caching interface for nodered_js.
 type Cache interface {
 	// Set stores value under key, overwriting any existing entry.
-	Set(key string, value any) error
+	Set(ctx context.Context, key string, value any) error
 	// Get returns the value stored under key and if it even exists.
-	Get(key string) (any, bool)
+	Get(ctx context.Context, key string) (any, bool)
 	// Delete removes the entry for key. No-op when key does not exist.
-	Delete(key string) error
+	Delete(ctx context.Context, key string) error
 	// Close releases any resources held by the store.
 	Close() error
 }

--- a/nodered_js_plugin/cache/store.go
+++ b/nodered_js_plugin/cache/store.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+// Store is used as the caching interface for nodered_js.
+type Store interface {
+	// Set stores value under key, overwriting any existing entry.
+	Set(key string, value any)
+	// Get returns the value stored under key and if it even exists.
+	Get(key string) (any, bool)
+	// Delete removes the entry for key. No-op when key does not exist.
+	Delete(key string)
+	// Close releases any resources held by the store.
+	Close() error
+}

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/redpanda-data/benthos/v4/public/service"
+
+	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/cache"
 )
 
 // NodeREDJSProcessor defines the processor that wraps the JavaScript processor.
@@ -37,6 +39,7 @@ type NodeREDJSProcessor struct {
 	originalCode      string
 	vmpool            sync.Pool
 	logger            *service.Logger
+	cache             cache.Store
 	messagesProcessed *service.MetricCounter
 	messagesErrored   *service.MetricCounter
 	messagesDropped   *service.MetricCounter
@@ -57,6 +60,7 @@ func NewNodeREDJSProcessor(code string, logger *service.Logger, metrics *service
 		originalCode:      code,
 		vmpool:            sync.Pool{}, // No New function - Get() will return nil when pool is empty
 		logger:            logger,
+		cache:             cache.NewMemoryStore(),
 		messagesProcessed: metrics.NewCounter("messages_processed"),
 		messagesErrored:   metrics.NewCounter("messages_errored"),
 		messagesDropped:   metrics.NewCounter("messages_dropped"),
@@ -312,8 +316,30 @@ func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[stri
 		"error": func(data ...any) { u.logger.Error(FormatConsoleLogMsg(data)) },
 	}
 
-	if err := vm.Set("console", console); err != nil {
+	err := vm.Set("console", console)
+	if err != nil {
 		return fmt.Errorf("failed to set console in JS environment: %w", err)
+	}
+
+	cacheObj := map[string]any{
+		"set": func(key string, value any) {
+			u.cache.Set(key, value)
+		},
+		"get": func(key string) any {
+			v, ok := u.cache.Get(key)
+			if !ok {
+				return goja.Undefined()
+			}
+			return v
+		},
+		"delete": func(key string) {
+			u.cache.Delete(key)
+		},
+	}
+
+	err = vm.Set("cache", cacheObj)
+	if err != nil {
+		return fmt.Errorf("failed to set cache in JS environment: %w", err)
 	}
 
 	return nil
@@ -468,7 +494,7 @@ Message content: %v`,
 
 // Close gracefully shuts down the processor.
 func (u *NodeREDJSProcessor) Close(_ context.Context) error {
-	return nil
+	return u.cache.Close()
 }
 
 func init() {
@@ -501,6 +527,25 @@ console.log("Message metadata:", msg.meta);
 // Example 6: Modify metadata
 msg.meta.processed = true;
 msg.meta.count = (msg.meta.count || 0) + 1;
+return msg;
+
+// Example 7: Persistent counter across messages using cache
+var count = cache.get("count") || 0;
+count++;
+cache.set("count", count);
+msg.payload = count;
+return msg;
+
+// Example 8: Alarm state that only fires once per active condition
+var alarmed = cache.get("alarm_active") || false;
+if (msg.payload > 100 && !alarmed) {
+  cache.set("alarm_active", true);
+  msg.meta.alarm = "triggered";
+  return msg;
+}
+if (msg.payload <= 100 && alarmed) {
+  cache.set("alarm_active", false);
+}
 return msg;`))
 
 	err := service.RegisterBatchProcessor(

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -302,12 +302,13 @@ func stringify(data any, depth uint8) (string, error) {
 
 // SetupJSEnvironment sets up the JavaScript VM environment.
 func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[string]interface{}) error {
-	// Set up the msg variable in the JS environment
-	if err := vm.Set("msg", jsMsg); err != nil {
+	var err error
+
+	err = vm.Set("msg", jsMsg)
+	if err != nil {
 		return fmt.Errorf("failed to set message in JS environment: %w", err)
 	}
 
-	// Set up console for logging that uses Benthos logger
 	console := map[string]any{
 		"debug": func(data ...any) { u.logger.Debug(FormatConsoleLogMsg(data)) },
 		"log":   func(data ...any) { u.logger.Info(FormatConsoleLogMsg(data)) },
@@ -316,7 +317,7 @@ func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[stri
 		"error": func(data ...any) { u.logger.Error(FormatConsoleLogMsg(data)) },
 	}
 
-	err := vm.Set("console", console)
+	err = vm.Set("console", console)
 	if err != nil {
 		return fmt.Errorf("failed to set console in JS environment: %w", err)
 	}

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -39,7 +39,7 @@ type NodeREDJSProcessor struct {
 	originalCode      string
 	vmpool            sync.Pool
 	logger            *service.Logger
-	cache             cache.Store
+	cache             cache.Cache
 	messagesProcessed *service.MetricCounter
 	messagesErrored   *service.MetricCounter
 	messagesDropped   *service.MetricCounter
@@ -48,7 +48,7 @@ type NodeREDJSProcessor struct {
 }
 
 // NewNodeREDJSProcessor creates a new NodeREDJSProcessor instance.
-func NewNodeREDJSProcessor(code string, logger *service.Logger, metrics *service.Metrics) (*NodeREDJSProcessor, error) {
+func NewNodeREDJSProcessor(code string, logger *service.Logger, metrics *service.Metrics, c cache.Cache) (*NodeREDJSProcessor, error) {
 	// Compile the JavaScript code once
 	program, err := goja.Compile("nodered-fn.js", code, false)
 	if err != nil {
@@ -60,7 +60,7 @@ func NewNodeREDJSProcessor(code string, logger *service.Logger, metrics *service
 		originalCode:      code,
 		vmpool:            sync.Pool{}, // No New function - Get() will return nil when pool is empty
 		logger:            logger,
-		cache:             cache.NewMemoryStore(),
+		cache:             c,
 		messagesProcessed: metrics.NewCounter("messages_processed"),
 		messagesErrored:   metrics.NewCounter("messages_errored"),
 		messagesDropped:   metrics.NewCounter("messages_dropped"),
@@ -323,7 +323,10 @@ func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[stri
 
 	cacheObj := map[string]any{
 		"set": func(key string, value any) {
-			u.cache.Set(key, value)
+			err := u.cache.Set(key, value)
+			if err != nil {
+				u.logger.Errorf("cache.set failed: %v", err)
+			}
 		},
 		"get": func(key string) any {
 			v, ok := u.cache.Get(key)
@@ -333,7 +336,10 @@ func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[stri
 			return v
 		},
 		"delete": func(key string) {
-			u.cache.Delete(key)
+			err := u.cache.Delete(key)
+			if err != nil {
+				u.logger.Errorf("cache.delete failed: %v", err)
+			}
 		},
 	}
 
@@ -497,14 +503,14 @@ func (u *NodeREDJSProcessor) Close(_ context.Context) error {
 	return u.cache.Close()
 }
 
-func init() {
-	spec := service.NewConfigSpec().
-		Version("1.0.0").
-		Summary("A Node-RED style JavaScript processor.").
-		Description("Executes user-defined JavaScript code to process messages in a format similar to Node-RED functions.").
-		Field(service.NewStringField("code").
-			Description("The JavaScript code to execute. The code should be a function that processes the message.").
-			Example(`// Node-RED style function that returns the modified message
+// NodeREDJSConfigSpec defines the configuration options for the nodered_js processor.
+var NodeREDJSConfigSpec = service.NewConfigSpec().
+	Version("1.0.0").
+	Summary("A Node-RED style JavaScript processor.").
+	Description("Executes user-defined JavaScript code to process messages in a format similar to Node-RED functions.").
+	Field(service.NewStringField("code").
+		Description("The JavaScript code to execute. The code should be a function that processes the message.").
+		Example(`// Node-RED style function that returns the modified message
 // Example 1: Return message as-is
 return msg;
 
@@ -546,28 +552,62 @@ if (msg.payload > 100 && !alarmed) {
 if (msg.payload <= 100 && alarmed) {
   cache.set("alarm_active", false);
 }
-return msg;`))
+return msg;`)).
+	Field(service.NewObjectField("cache",
+		service.NewStringField("backend").
+			Description("Cache backend to use.").
+			Default("memory").
+			Examples("memory"),
+		service.NewDurationField("expiration").
+			Description("Default expiration duration for cached items. Items are automatically removed after expiration.").
+			Default("48h"),
+	).Description("Cache configuration for persistent state across messages.").
+		Default(map[string]any{
+			"backend":    "memory",
+			"expiration": "48h",
+		}).
+		Advanced())
 
+func newNodeREDJSProcessor(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchProcessor, error) {
+	code, err := conf.FieldString("code")
+	if err != nil {
+		return nil, err
+	}
+
+	backend, err := conf.FieldString("cache", "backend")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cache backend: %w", err)
+	}
+
+	expiration, err := conf.FieldDuration("cache", "expiration")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cache expiration: %w", err)
+	}
+
+	var c cache.Cache
+	switch backend {
+	case "memory":
+		c = cache.NewMemoryStore(expiration)
+	default:
+		return nil, fmt.Errorf("unsupported cache backend: %q (supported: memory)", backend)
+	}
+
+	wrappedCode := fmt.Sprintf(`
+		(function(){
+			'use strict';
+			%s
+		})()
+	`, code)
+
+	return NewNodeREDJSProcessor(wrappedCode, mgr.Logger(), mgr.Metrics(), c)
+}
+
+func init() {
 	err := service.RegisterBatchProcessor(
 		"nodered_js",
-		spec,
+		NodeREDJSConfigSpec,
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchProcessor, error) {
-			code, err := conf.FieldString("code")
-			if err != nil {
-				return nil, err
-			}
-			// Wrap the user's code in a function that handles the return value
-			wrappedCode := fmt.Sprintf(`
-				(function(){
-					'use strict';
-					%s
-				})()
-			`, code)
-			processor, err := NewNodeREDJSProcessor(wrappedCode, mgr.Logger(), mgr.Metrics())
-			if err != nil {
-				return nil, err
-			}
-			return processor, nil
+			return newNodeREDJSProcessor(conf, mgr)
 		})
 	if err != nil {
 		panic(err)

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -339,16 +339,16 @@ func (u *NodeREDJSProcessor) setupCache(ctx context.Context, vm *goja.Runtime) e
 				u.logger.Errorf("cache.set failed: %v", err)
 			}
 		},
-		"get": func(call goja.FunctionCall) goja.Value {
-			if len(call.Arguments) < 2 {
-				panic(vm.NewTypeError("cache.get(key, default) requires 2 arguments"))
-			}
-			key := call.Arguments[0].String()
+		"get": func(key string) any {
 			v, ok := u.cache.Get(ctx, key)
 			if !ok {
-				return call.Arguments[1]
+				u.logger.Errorf("cache.get: key %q not found. Use cache.exists(key) to check before reading.", key)
+				return goja.Undefined()
 			}
-			return vm.ToValue(v)
+			return v
+		},
+		"exists": func(key string) bool {
+			return u.cache.Exists(ctx, key)
 		},
 		"delete": func(key string) {
 			err := u.cache.Delete(ctx, key)
@@ -544,14 +544,15 @@ msg.meta.count = (msg.meta.count || 0) + 1;
 return msg;
 
 // Example 7: Persistent counter across messages using cache
-var count = cache.get("count", 0);
+var count = 0;
+if (cache.exists("count")) { count = cache.get("count"); }
 count++;
 cache.set("count", count);
 msg.payload = count;
 return msg;
 
 // Example 8: Alarm state that only fires once per active condition
-var alarmed = cache.get("alarm_active", false);
+var alarmed = cache.exists("alarm_active") ? cache.get("alarm_active") : false;
 if (msg.payload.value > 100 && !alarmed) {
   cache.set("alarm_active", true);
   msg.meta.alarm = "triggered";

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -302,13 +302,25 @@ func stringify(data any, depth uint8) (string, error) {
 
 // SetupJSEnvironment sets up the JavaScript VM environment.
 func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[string]interface{}) error {
-	var err error
-
-	err = vm.Set("msg", jsMsg)
+	err := vm.Set("msg", jsMsg)
 	if err != nil {
 		return fmt.Errorf("failed to set message in JS environment: %w", err)
 	}
 
+	err = u.setupConsole(vm)
+	if err != nil {
+		return fmt.Errorf("failed to set console in JS environment: %w", err)
+	}
+
+	err = u.setupCache(vm)
+	if err != nil {
+		return fmt.Errorf("failed to set cache in JS environment: %w", err)
+	}
+
+	return nil
+}
+
+func (u *NodeREDJSProcessor) setupConsole(vm *goja.Runtime) error {
 	console := map[string]any{
 		"debug": func(data ...any) { u.logger.Debug(FormatConsoleLogMsg(data)) },
 		"log":   func(data ...any) { u.logger.Info(FormatConsoleLogMsg(data)) },
@@ -316,12 +328,10 @@ func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[stri
 		"warn":  func(data ...any) { u.logger.Warn(FormatConsoleLogMsg(data)) },
 		"error": func(data ...any) { u.logger.Error(FormatConsoleLogMsg(data)) },
 	}
+	return vm.Set("console", console)
+}
 
-	err = vm.Set("console", console)
-	if err != nil {
-		return fmt.Errorf("failed to set console in JS environment: %w", err)
-	}
-
+func (u *NodeREDJSProcessor) setupCache(vm *goja.Runtime) error {
 	cacheObj := map[string]any{
 		"set": func(key string, value any) {
 			err := u.cache.Set(key, value)
@@ -343,13 +353,7 @@ func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[stri
 			}
 		},
 	}
-
-	err = vm.Set("cache", cacheObj)
-	if err != nil {
-		return fmt.Errorf("failed to set cache in JS environment: %w", err)
-	}
-
-	return nil
+	return vm.Set("cache", cacheObj)
 }
 
 // HandleExecutionResult handles JavaScript execution results.
@@ -560,7 +564,7 @@ return msg;`)).
 			Default("memory").
 			Examples("memory"),
 		service.NewDurationField("expiration").
-			Description("Default expiration duration for cached items. Items are automatically removed after expiration.").
+			Description("Default expiration duration for cached items. Items are automatically removed after expiration. Set to 0s to disable expiration.").
 			Default("48h"),
 	).Description("Cache configuration for persistent state across messages.").
 		Default(map[string]any{
@@ -583,6 +587,9 @@ func newNodeREDJSProcessor(conf *service.ParsedConfig, mgr *service.Resources) (
 	expiration, err := conf.FieldDuration("cache", "expiration")
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse cache expiration: %w", err)
+	}
+	if expiration < 0 {
+		return nil, fmt.Errorf("cache expiration must be >= 0, got %v", expiration)
 	}
 
 	var c cache.Cache

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -301,7 +301,7 @@ func stringify(data any, depth uint8) (string, error) {
 }
 
 // SetupJSEnvironment sets up the JavaScript VM environment.
-func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[string]interface{}) error {
+func (u *NodeREDJSProcessor) SetupJSEnvironment(ctx context.Context, vm *goja.Runtime, jsMsg map[string]interface{}) error {
 	err := vm.Set("msg", jsMsg)
 	if err != nil {
 		return fmt.Errorf("failed to set message in JS environment: %w", err)
@@ -312,7 +312,7 @@ func (u *NodeREDJSProcessor) SetupJSEnvironment(vm *goja.Runtime, jsMsg map[stri
 		return fmt.Errorf("failed to set console in JS environment: %w", err)
 	}
 
-	err = u.setupCache(vm)
+	err = u.setupCache(ctx, vm)
 	if err != nil {
 		return fmt.Errorf("failed to set cache in JS environment: %w", err)
 	}
@@ -331,23 +331,23 @@ func (u *NodeREDJSProcessor) setupConsole(vm *goja.Runtime) error {
 	return vm.Set("console", console)
 }
 
-func (u *NodeREDJSProcessor) setupCache(vm *goja.Runtime) error {
+func (u *NodeREDJSProcessor) setupCache(ctx context.Context, vm *goja.Runtime) error {
 	cacheObj := map[string]any{
 		"set": func(key string, value any) {
-			err := u.cache.Set(key, value)
+			err := u.cache.Set(ctx, key, value)
 			if err != nil {
 				u.logger.Errorf("cache.set failed: %v", err)
 			}
 		},
 		"get": func(key string) any {
-			v, ok := u.cache.Get(key)
+			v, ok := u.cache.Get(ctx, key)
 			if !ok {
 				return goja.Undefined()
 			}
 			return v
 		},
 		"delete": func(key string) {
-			err := u.cache.Delete(key)
+			err := u.cache.Delete(ctx, key)
 			if err != nil {
 				u.logger.Errorf("cache.delete failed: %v", err)
 			}
@@ -402,14 +402,13 @@ func FormatConsoleLogMsg(data []any) string {
 }
 
 // ProcessBatch applies the JavaScript code to each message in the batch.
-func (u *NodeREDJSProcessor) ProcessBatch(_ context.Context, batch service.MessageBatch) ([]service.MessageBatch, error) {
+func (u *NodeREDJSProcessor) ProcessBatch(ctx context.Context, batch service.MessageBatch) ([]service.MessageBatch, error) {
 	var resultBatch service.MessageBatch
 
 	for _, msg := range batch {
 		u.messagesProcessed.Incr(1)
 
-		// Process single message and return VM to pool immediately
-		processedMsg, shouldKeep, err := u.processSingleMessage(msg)
+		processedMsg, shouldKeep, err := u.processSingleMessage(ctx, msg)
 		if err != nil {
 			return nil, err
 		}
@@ -426,7 +425,7 @@ func (u *NodeREDJSProcessor) ProcessBatch(_ context.Context, batch service.Messa
 }
 
 // processSingleMessage processes a single message using a VM from the pool
-func (u *NodeREDJSProcessor) processSingleMessage(msg *service.Message) (*service.Message, bool, error) {
+func (u *NodeREDJSProcessor) processSingleMessage(ctx context.Context, msg *service.Message) (*service.Message, bool, error) {
 	vm := u.getVM()
 	defer u.putVM(vm)
 
@@ -451,7 +450,7 @@ func (u *NodeREDJSProcessor) processSingleMessage(msg *service.Message) (*servic
 	jsMsg["meta"] = meta
 
 	// Setup JS environment
-	if err = u.SetupJSEnvironment(vm, jsMsg); err != nil {
+	if err = u.SetupJSEnvironment(ctx, vm, jsMsg); err != nil {
 		u.messagesErrored.Incr(1)
 		u.logger.Errorf("%v\nMessage content: %v", err, jsMsg)
 		return nil, false, nil
@@ -556,6 +555,8 @@ if (msg.payload > 100 && !alarmed) {
 }
 if (msg.payload <= 100 && alarmed) {
   cache.set("alarm_active", false);
+  msg.meta.alarm = "cleared";
+  return msg;
 }
 return msg;`)).
 	Field(service.NewObjectField("cache",
@@ -564,12 +565,12 @@ return msg;`)).
 			Default("memory").
 			Examples("memory"),
 		service.NewDurationField("expiration").
-			Description("Default expiration duration for cached items. Items are automatically removed after expiration. Set to 0s to disable expiration.").
-			Default("48h"),
+			Description("Expiration duration for cached items. Items are automatically removed after expiration. Default 0s means no expiration.").
+			Default("0s"),
 	).Description("Cache configuration for maintaining state across messages. Currently only supports the memory backend, which is lost on restart.").
 		Default(map[string]any{
 			"backend":    "memory",
-			"expiration": "48h",
+			"expiration": "0s",
 		}).
 		Advanced())
 

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -339,12 +339,16 @@ func (u *NodeREDJSProcessor) setupCache(ctx context.Context, vm *goja.Runtime) e
 				u.logger.Errorf("cache.set failed: %v", err)
 			}
 		},
-		"get": func(key string) any {
+		"get": func(call goja.FunctionCall) goja.Value {
+			if len(call.Arguments) < 2 {
+				panic(vm.NewTypeError("cache.get(key, default) requires 2 arguments"))
+			}
+			key := call.Arguments[0].String()
 			v, ok := u.cache.Get(ctx, key)
 			if !ok {
-				return goja.Undefined()
+				return call.Arguments[1]
 			}
-			return v
+			return vm.ToValue(v)
 		},
 		"delete": func(key string) {
 			err := u.cache.Delete(ctx, key)
@@ -540,65 +544,30 @@ msg.meta.count = (msg.meta.count || 0) + 1;
 return msg;
 
 // Example 7: Persistent counter across messages using cache
-var count = cache.get("count") || 0;
+var count = cache.get("count", 0);
 count++;
 cache.set("count", count);
 msg.payload = count;
 return msg;
 
 // Example 8: Alarm state that only fires once per active condition
-var alarmed = cache.get("alarm_active") || false;
-if (msg.payload > 100 && !alarmed) {
+var alarmed = cache.get("alarm_active", false);
+if (msg.payload.value > 100 && !alarmed) {
   cache.set("alarm_active", true);
   msg.meta.alarm = "triggered";
   return msg;
 }
-if (msg.payload <= 100 && alarmed) {
+if (msg.payload.value <= 100 && alarmed) {
   cache.set("alarm_active", false);
   msg.meta.alarm = "cleared";
   return msg;
 }
-return msg;`)).
-	Field(service.NewObjectField("cache",
-		service.NewStringField("backend").
-			Description("Cache backend to use.").
-			Default("memory").
-			Examples("memory"),
-		service.NewDurationField("expiration").
-			Description("Expiration duration for cached items. Items are automatically removed after expiration. Default 0s means no expiration.").
-			Default("0s"),
-	).Description("Cache configuration for maintaining state across messages. Currently only supports the memory backend, which is lost on restart.").
-		Default(map[string]any{
-			"backend":    "memory",
-			"expiration": "0s",
-		}).
-		Advanced())
+return msg;`))
 
 func newNodeREDJSProcessor(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchProcessor, error) {
 	code, err := conf.FieldString("code")
 	if err != nil {
 		return nil, err
-	}
-
-	backend, err := conf.FieldString("cache", "backend")
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cache backend: %w", err)
-	}
-
-	expiration, err := conf.FieldDuration("cache", "expiration")
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cache expiration: %w", err)
-	}
-	if expiration < 0 {
-		return nil, fmt.Errorf("cache expiration must be >= 0, got %v", expiration)
-	}
-
-	var c cache.Cache
-	switch backend {
-	case "memory":
-		c = cache.NewMemoryStore(expiration)
-	default:
-		return nil, fmt.Errorf("unsupported cache backend: %q (supported: memory)", backend)
 	}
 
 	wrappedCode := fmt.Sprintf(`
@@ -608,7 +577,7 @@ func newNodeREDJSProcessor(conf *service.ParsedConfig, mgr *service.Resources) (
 		})()
 	`, code)
 
-	return NewNodeREDJSProcessor(wrappedCode, mgr.Logger(), mgr.Metrics(), c)
+	return NewNodeREDJSProcessor(wrappedCode, mgr.Logger(), mgr.Metrics(), cache.NewMemoryStore(0))
 }
 
 func init() {

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -566,7 +566,7 @@ return msg;`)).
 		service.NewDurationField("expiration").
 			Description("Default expiration duration for cached items. Items are automatically removed after expiration. Set to 0s to disable expiration.").
 			Default("48h"),
-	).Description("Cache configuration for persistent state across messages.").
+	).Description("Cache configuration for maintaining state across messages. Currently only supports the memory backend, which is lost on restart.").
 		Default(map[string]any{
 			"backend":    "memory",
 			"expiration": "48h",

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -348,7 +348,8 @@ func (u *NodeREDJSProcessor) setupCache(ctx context.Context, vm *goja.Runtime) e
 			return v
 		},
 		"exists": func(key string) bool {
-			return u.cache.Exists(ctx, key)
+			_, exists := u.cache.Get(ctx, key)
+			return exists
 		},
 		"delete": func(key string) {
 			err := u.cache.Delete(ctx, key)

--- a/nodered_js_plugin/nodered_js_plugin_test.go
+++ b/nodered_js_plugin/nodered_js_plugin_test.go
@@ -1074,7 +1074,7 @@ func payloadFloat(msgs []*service.Message, i int) float64 {
 }
 
 // indentLines prepends prefix to every line of s.
-func indentLines(s, prefix string) string {
+func indentLines(s string, prefix string) string {
 	lines := strings.Split(s, "\n")
 	for i, l := range lines {
 		if l != "" {

--- a/nodered_js_plugin/nodered_js_plugin_test.go
+++ b/nodered_js_plugin/nodered_js_plugin_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"math/big"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -846,6 +847,242 @@ nodered_js:
 		})
 	})
 })
+
+var _ = Describe("NodeREDJS cache", func() {
+	BeforeEach(func() {
+		if os.Getenv("TEST_NODERED_JS") == "" {
+			Skip("Skipping Node-RED JS tests: TEST_NODERED_JS not set")
+		}
+	})
+
+	buildStream := func(code string) (service.MessageHandlerFunc, *[]*service.Message, context.CancelFunc) {
+		builder := service.NewStreamBuilder()
+		handler, err := builder.AddProducerFunc()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = builder.AddProcessorYAML("nodered_js:\n  code: |\n" + indentLines(code, "    "))
+		Expect(err).NotTo(HaveOccurred())
+
+		var msgs []*service.Message
+		err = builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+			msgs = append(msgs, m)
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		stream, err := builder.Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		go func() { _ = stream.Run(ctx) }()
+		return handler, &msgs, cancel
+	}
+
+	When("using cache", func() {
+		It("set then get returns the stored value", func() {
+			handler, msgs, cancel := buildStream(`
+cache.set("k", 42);
+msg.payload = cache.get("k");
+return msg;
+`)
+			defer cancel()
+
+			err := handler(context.Background(), newMsg("ignored"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
+			Expect(payloadFloat(*msgs, 0)).To(Equal(float64(42)))
+		})
+
+		It("get on unknown key returns undefined (falsy)", func() {
+			handler, msgs, cancel := buildStream(`
+var v = cache.get("nope");
+msg.payload = (v === undefined) ? "undefined" : "defined";
+return msg;
+`)
+			defer cancel()
+
+			err := handler(context.Background(), newMsg("ignored"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
+			Expect(payloadString(*msgs, 0)).To(Equal("undefined"))
+		})
+
+		It("delete removes a key", func() {
+			handler, msgs, cancel := buildStream(`
+cache.set("x", 1);
+cache.delete("x");
+var v = cache.get("x");
+msg.payload = (v === undefined) ? "gone" : "present";
+return msg;
+`)
+			defer cancel()
+
+			err := handler(context.Background(), newMsg("ignored"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
+			Expect(payloadString(*msgs, 0)).To(Equal("gone"))
+		})
+
+		It("value persists across consecutive messages", func() {
+			handler, msgs, cancel := buildStream(`
+var count = cache.get("count");
+if (count === undefined) { count = 0; }
+count++;
+cache.set("count", count);
+msg.payload = count;
+return msg;
+`)
+			defer cancel()
+
+			ctx := context.Background()
+			for i := 0; i < 3; i++ {
+				err := handler(ctx, newMsg("tick"))
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Eventually(func() int { return len(*msgs) }).Should(Equal(3))
+			Expect(payloadFloat(*msgs, 2)).To(Equal(float64(3)))
+		})
+
+		It("stores and retrieves an object value", func() {
+			handler, msgs, cancel := buildStream(`
+cache.set("obj", { temperature: 42.5, unit: "C" });
+var obj = cache.get("obj");
+msg.payload = obj.temperature;
+return msg;
+`)
+			defer cancel()
+
+			err := handler(context.Background(), newMsg("ignored"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
+			Expect(payloadFloat(*msgs, 0)).To(Equal(42.5))
+		})
+
+		It("is safe under concurrent message processing", func() {
+			handler, msgs, cancel := buildStream(`
+var n = cache.get("n");
+if (n === undefined) { n = 0; }
+cache.set("n", n + 1);
+msg.payload = "ok";
+return msg;
+`)
+			defer cancel()
+
+			const numMsgs = 30
+			ctx := context.Background()
+			var wg sync.WaitGroup
+			wg.Add(numMsgs)
+			for i := 0; i < numMsgs; i++ {
+				go func() {
+					defer wg.Done()
+					_ = handler(ctx, newMsg("concurrent"))
+				}()
+			}
+			wg.Wait()
+			Eventually(func() int { return len(*msgs) }).Should(Equal(numMsgs))
+		})
+
+		It("cache is shared across VM pool instances", func() {
+			handler, msgs, cancel := buildStream(`
+var v = cache.get("shared");
+if (v === undefined) {
+  cache.set("shared", "seeded");
+  msg.payload = "first";
+} else {
+  msg.payload = v;
+}
+return msg;
+`)
+			defer cancel()
+
+			ctx := context.Background()
+			for i := 0; i < 5; i++ {
+				err := handler(ctx, newMsg("x"))
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Eventually(func() int { return len(*msgs) }).Should(Equal(5))
+			// Every message after the first must see "seeded".
+			for i := 1; i < 5; i++ {
+				Expect(payloadString(*msgs, i)).To(Equal("seeded"))
+			}
+		})
+
+		It("numeric key coercion: number passed as key is coerced to string", func() {
+			handler, msgs, cancel := buildStream(`
+cache.set("42", "byStringKey");
+msg.payload = cache.get("42");
+return msg;
+`)
+			defer cancel()
+
+			err := handler(context.Background(), newMsg("ignored"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
+			Expect(payloadString(*msgs, 0)).To(Equal("byStringKey"))
+		})
+
+		It("fallback pattern works without panicking", func() {
+			handler, msgs, cancel := buildStream(`
+var state = cache.get("state") || { alarm: false, count: 0 };
+state.count++;
+cache.set("state", state);
+msg.payload = state.count;
+return msg;
+`)
+			defer cancel()
+
+			ctx := context.Background()
+			for i := 0; i < 2; i++ {
+				err := handler(ctx, newMsg("tick"))
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Eventually(func() int { return len(*msgs) }).Should(Equal(2))
+			Expect(payloadFloat(*msgs, 1)).To(Equal(float64(2)))
+		})
+	})
+})
+
+// newMsg creates a service.Message with the given string payload.
+func newMsg(payload string) *service.Message {
+	return service.NewMessage([]byte(payload))
+}
+
+// payloadString extracts the string payload from messages[i].
+func payloadString(msgs []*service.Message, i int) string {
+	s, err := msgs[i].AsStructured()
+	Expect(err).NotTo(HaveOccurred())
+	str, ok := s.(string)
+	Expect(ok).To(BeTrue(), "expected string payload, got %T: %v", s, s)
+	return str
+}
+
+// payloadFloat extracts a numeric payload as float64 (goja may return int64 for whole numbers).
+func payloadFloat(msgs []*service.Message, i int) float64 {
+	s, err := msgs[i].AsStructured()
+	Expect(err).NotTo(HaveOccurred())
+	switch v := s.(type) {
+	case float64:
+		return v
+	case int64:
+		return float64(v)
+	case int:
+		return float64(v)
+	default:
+		Fail(fmt.Sprintf("expected numeric payload, got %T: %v", s, s))
+		return 0
+	}
+}
+
+// indentLines prepends prefix to every line of s.
+func indentLines(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		if l != "" {
+			lines[i] = prefix + l
+		}
+	}
+	return strings.Join(lines, "\n")
+}
 
 var _ = Describe("js logmessage", func() {
 	DescribeTable("format",

--- a/nodered_js_plugin/nodered_js_plugin_test.go
+++ b/nodered_js_plugin/nodered_js_plugin_test.go
@@ -882,7 +882,7 @@ var _ = Describe("NodeREDJS cache", func() {
 		It("set then get returns the stored value", func() {
 			handler, msgs, cancel := buildStream(`
 cache.set("k", 42);
-msg.payload = cache.get("k");
+msg.payload = cache.get("k", null);
 return msg;
 `)
 			defer cancel()
@@ -893,10 +893,10 @@ return msg;
 			Expect(payloadFloat(*msgs, 0)).To(Equal(float64(42)))
 		})
 
-		It("get on unknown key returns undefined (falsy)", func() {
+		It("get on unknown key returns the default", func() {
 			handler, msgs, cancel := buildStream(`
-var v = cache.get("nope");
-msg.payload = (v === undefined) ? "undefined" : "defined";
+var v = cache.get("nope", "fallback");
+msg.payload = v;
 return msg;
 `)
 			defer cancel()
@@ -904,15 +904,28 @@ return msg;
 			err := handler(context.Background(), newMsg("ignored"))
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
-			Expect(payloadString(*msgs, 0)).To(Equal("undefined"))
+			Expect(payloadString(*msgs, 0)).To(Equal("fallback"))
+		})
+
+		It("get with 1 argument throws TypeError", func() {
+			handler, msgs, cancel := buildStream(`
+cache.get("nope");
+msg.payload = "should not reach";
+return msg;
+`)
+			defer cancel()
+
+			err := handler(context.Background(), newMsg("ignored"))
+			Expect(err).NotTo(HaveOccurred())
+			Consistently(func() int { return len(*msgs) }, "500ms").Should(Equal(0))
 		})
 
 		It("delete removes a key", func() {
 			handler, msgs, cancel := buildStream(`
 cache.set("x", 1);
 cache.delete("x");
-var v = cache.get("x");
-msg.payload = (v === undefined) ? "gone" : "present";
+var v = cache.get("x", "gone");
+msg.payload = v;
 return msg;
 `)
 			defer cancel()
@@ -925,8 +938,7 @@ return msg;
 
 		It("value persists across consecutive messages", func() {
 			handler, msgs, cancel := buildStream(`
-var count = cache.get("count");
-if (count === undefined) { count = 0; }
+var count = cache.get("count", 0);
 count++;
 cache.set("count", count);
 msg.payload = count;
@@ -946,7 +958,7 @@ return msg;
 		It("stores and retrieves an object value", func() {
 			handler, msgs, cancel := buildStream(`
 cache.set("obj", { temperature: 42.5, unit: "C" });
-var obj = cache.get("obj");
+var obj = cache.get("obj", null);
 msg.payload = obj.temperature;
 return msg;
 `)
@@ -960,8 +972,7 @@ return msg;
 
 		It("is safe under concurrent message processing", func() {
 			handler, msgs, cancel := buildStream(`
-var n = cache.get("n");
-if (n === undefined) { n = 0; }
+var n = cache.get("n", 0);
 cache.set("n", n + 1);
 msg.payload = "ok";
 return msg;
@@ -984,8 +995,8 @@ return msg;
 
 		It("cache is shared across VM pool instances", func() {
 			handler, msgs, cancel := buildStream(`
-var v = cache.get("shared");
-if (v === undefined) {
+var v = cache.get("shared", null);
+if (v === null) {
   cache.set("shared", "seeded");
   msg.payload = "first";
 } else {
@@ -1001,7 +1012,6 @@ return msg;
 				Expect(err).NotTo(HaveOccurred())
 			}
 			Eventually(func() int { return len(*msgs) }).Should(Equal(5))
-			// Every message after the first must see "seeded".
 			for i := 1; i < 5; i++ {
 				Expect(payloadString(*msgs, i)).To(Equal("seeded"))
 			}
@@ -1010,7 +1020,7 @@ return msg;
 		It("numeric key coercion: number passed as key is coerced to string", func() {
 			handler, msgs, cancel := buildStream(`
 cache.set("42", "byStringKey");
-msg.payload = cache.get("42");
+msg.payload = cache.get("42", null);
 return msg;
 `)
 			defer cancel()
@@ -1021,9 +1031,9 @@ return msg;
 			Expect(payloadString(*msgs, 0)).To(Equal("byStringKey"))
 		})
 
-		It("fallback pattern works without panicking", func() {
+		It("default value works with object fallback", func() {
 			handler, msgs, cancel := buildStream(`
-var state = cache.get("state") || { alarm: false, count: 0 };
+var state = cache.get("state", { alarm: false, count: 0 });
 state.count++;
 cache.set("state", state);
 msg.payload = state.count;
@@ -1038,6 +1048,22 @@ return msg;
 			}
 			Eventually(func() int { return len(*msgs) }).Should(Equal(2))
 			Expect(payloadFloat(*msgs, 1)).To(Equal(float64(2)))
+		})
+
+		It("default value preserves falsy values like 0 and false", func() {
+			handler, msgs, cancel := buildStream(`
+cache.set("zero", 0);
+cache.set("falseVal", false);
+var z = cache.get("zero", 99);
+var f = cache.get("falseVal", true);
+msg.payload = { zero: z, falseVal: f };
+return msg;
+`)
+			defer cancel()
+
+			err := handler(context.Background(), newMsg("ignored"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
 		})
 	})
 })

--- a/nodered_js_plugin/nodered_js_plugin_test.go
+++ b/nodered_js_plugin/nodered_js_plugin_test.go
@@ -882,7 +882,7 @@ var _ = Describe("NodeREDJS cache", func() {
 		It("set then get returns the stored value", func() {
 			handler, msgs, cancel := buildStream(`
 cache.set("k", 42);
-msg.payload = cache.get("k", null);
+msg.payload = cache.get("k");
 return msg;
 `)
 			defer cancel()
@@ -893,10 +893,10 @@ return msg;
 			Expect(payloadFloat(*msgs, 0)).To(Equal(float64(42)))
 		})
 
-		It("get on unknown key returns the default", func() {
+		It("get on unknown key returns undefined", func() {
 			handler, msgs, cancel := buildStream(`
-var v = cache.get("nope", "fallback");
-msg.payload = v;
+var v = cache.get("nope");
+msg.payload = (typeof v === "undefined") ? "is_undefined" : "not_undefined";
 return msg;
 `)
 			defer cancel()
@@ -904,28 +904,45 @@ return msg;
 			err := handler(context.Background(), newMsg("ignored"))
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
-			Expect(payloadString(*msgs, 0)).To(Equal("fallback"))
+			Expect(payloadString(*msgs, 0)).To(Equal("is_undefined"))
 		})
 
-		It("get with 1 argument throws TypeError", func() {
+		It("exists returns false for missing key", func() {
 			handler, msgs, cancel := buildStream(`
-cache.get("nope");
-msg.payload = "should not reach";
+msg.payload = cache.exists("nope");
 return msg;
 `)
 			defer cancel()
 
 			err := handler(context.Background(), newMsg("ignored"))
 			Expect(err).NotTo(HaveOccurred())
-			Consistently(func() int { return len(*msgs) }, "500ms").Should(Equal(0))
+			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
+			s, sErr := (*msgs)[0].AsStructured()
+			Expect(sErr).NotTo(HaveOccurred())
+			Expect(s).To(Equal(false))
+		})
+
+		It("exists returns true for existing key", func() {
+			handler, msgs, cancel := buildStream(`
+cache.set("k", "v");
+msg.payload = cache.exists("k");
+return msg;
+`)
+			defer cancel()
+
+			err := handler(context.Background(), newMsg("ignored"))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
+			s, sErr := (*msgs)[0].AsStructured()
+			Expect(sErr).NotTo(HaveOccurred())
+			Expect(s).To(Equal(true))
 		})
 
 		It("delete removes a key", func() {
 			handler, msgs, cancel := buildStream(`
 cache.set("x", 1);
 cache.delete("x");
-var v = cache.get("x", "gone");
-msg.payload = v;
+msg.payload = cache.exists("x");
 return msg;
 `)
 			defer cancel()
@@ -933,12 +950,17 @@ return msg;
 			err := handler(context.Background(), newMsg("ignored"))
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
-			Expect(payloadString(*msgs, 0)).To(Equal("gone"))
+			s, sErr := (*msgs)[0].AsStructured()
+			Expect(sErr).NotTo(HaveOccurred())
+			Expect(s).To(Equal(false))
 		})
 
 		It("value persists across consecutive messages", func() {
 			handler, msgs, cancel := buildStream(`
-var count = cache.get("count", 0);
+var count = 0;
+if (cache.exists("count")) {
+  count = cache.get("count");
+}
 count++;
 cache.set("count", count);
 msg.payload = count;
@@ -958,7 +980,7 @@ return msg;
 		It("stores and retrieves an object value", func() {
 			handler, msgs, cancel := buildStream(`
 cache.set("obj", { temperature: 42.5, unit: "C" });
-var obj = cache.get("obj", null);
+var obj = cache.get("obj");
 msg.payload = obj.temperature;
 return msg;
 `)
@@ -972,7 +994,8 @@ return msg;
 
 		It("is safe under concurrent message processing", func() {
 			handler, msgs, cancel := buildStream(`
-var n = cache.get("n", 0);
+var n = 0;
+if (cache.exists("n")) { n = cache.get("n"); }
 cache.set("n", n + 1);
 msg.payload = "ok";
 return msg;
@@ -995,12 +1018,11 @@ return msg;
 
 		It("cache is shared across VM pool instances", func() {
 			handler, msgs, cancel := buildStream(`
-var v = cache.get("shared", null);
-if (v === null) {
+if (!cache.exists("shared")) {
   cache.set("shared", "seeded");
   msg.payload = "first";
 } else {
-  msg.payload = v;
+  msg.payload = cache.get("shared");
 }
 return msg;
 `)
@@ -1020,7 +1042,7 @@ return msg;
 		It("numeric key coercion: number passed as key is coerced to string", func() {
 			handler, msgs, cancel := buildStream(`
 cache.set("42", "byStringKey");
-msg.payload = cache.get("42", null);
+msg.payload = cache.get("42");
 return msg;
 `)
 			defer cancel()
@@ -1031,9 +1053,12 @@ return msg;
 			Expect(payloadString(*msgs, 0)).To(Equal("byStringKey"))
 		})
 
-		It("default value works with object fallback", func() {
+		It("exists + get pattern with object", func() {
 			handler, msgs, cancel := buildStream(`
-var state = cache.get("state", { alarm: false, count: 0 });
+if (!cache.exists("state")) {
+  cache.set("state", { alarm: false, count: 0 });
+}
+var state = cache.get("state");
 state.count++;
 cache.set("state", state);
 msg.payload = state.count;
@@ -1048,22 +1073,6 @@ return msg;
 			}
 			Eventually(func() int { return len(*msgs) }).Should(Equal(2))
 			Expect(payloadFloat(*msgs, 1)).To(Equal(float64(2)))
-		})
-
-		It("default value preserves falsy values like 0 and false", func() {
-			handler, msgs, cancel := buildStream(`
-cache.set("zero", 0);
-cache.set("falseVal", false);
-var z = cache.get("zero", 99);
-var f = cache.get("falseVal", true);
-msg.payload = { zero: z, falseVal: f };
-return msg;
-`)
-			defer cancel()
-
-			err := handler(context.Background(), newMsg("ignored"))
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
 		})
 	})
 })

--- a/nodered_js_plugin/nodered_js_plugin_test.go
+++ b/nodered_js_plugin/nodered_js_plugin_test.go
@@ -919,7 +919,7 @@ return msg;
 			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
 			s, sErr := (*msgs)[0].AsStructured()
 			Expect(sErr).NotTo(HaveOccurred())
-			Expect(s).To(Equal(false))
+			Expect(s).To(BeFalse())
 		})
 
 		It("exists returns true for existing key", func() {
@@ -935,7 +935,7 @@ return msg;
 			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
 			s, sErr := (*msgs)[0].AsStructured()
 			Expect(sErr).NotTo(HaveOccurred())
-			Expect(s).To(Equal(true))
+			Expect(s).To(BeTrue())
 		})
 
 		It("delete removes a key", func() {
@@ -952,7 +952,7 @@ return msg;
 			Eventually(func() int { return len(*msgs) }).Should(Equal(1))
 			s, sErr := (*msgs)[0].AsStructured()
 			Expect(sErr).NotTo(HaveOccurred())
-			Expect(s).To(Equal(false))
+			Expect(s).To(BeFalse())
 		})
 
 		It("value persists across consecutive messages", func() {

--- a/tag_processor_plugin/tag_processor_plugin.go
+++ b/tag_processor_plugin/tag_processor_plugin.go
@@ -237,7 +237,7 @@ func (p *TagProcessor) clearVMState(vm *goja.Runtime) error {
 }
 
 // setupMessageForVM prepares a VM with message data for execution
-func (p *TagProcessor) setupMessageForVM(vm *goja.Runtime, msg *service.Message, jsMsg map[string]interface{}) error {
+func (p *TagProcessor) setupMessageForVM(ctx context.Context, vm *goja.Runtime, msg *service.Message, jsMsg map[string]interface{}) error {
 	// Initialize meta if it doesn't exist
 	if _, exists := jsMsg["meta"]; !exists {
 		jsMsg["meta"] = make(map[string]interface{})
@@ -253,7 +253,7 @@ func (p *TagProcessor) setupMessageForVM(vm *goja.Runtime, msg *service.Message,
 	}
 
 	// Setup JS environment using helper from NodeREDJSProcessor
-	if err := p.jsProcessor.SetupJSEnvironment(vm, jsMsg); err != nil {
+	if err := p.jsProcessor.SetupJSEnvironment(ctx, vm, jsMsg); err != nil {
 		return fmt.Errorf("JS environment setup failed: %w", err)
 	}
 
@@ -266,7 +266,7 @@ func (p *TagProcessor) setupMessageForVM(vm *goja.Runtime, msg *service.Message,
 }
 
 // TODO: Each time there is any execution error, output the code where the error happened as well as the message that caused it (see nodered_js_plugin). Double-check that it is not being outputted twice.
-func (p *TagProcessor) ProcessBatch(_ context.Context, batch service.MessageBatch) ([]service.MessageBatch, error) {
+func (p *TagProcessor) ProcessBatch(ctx context.Context, batch service.MessageBatch) ([]service.MessageBatch, error) {
 	// ───────────────── Store incoming metadata ────────────────────────────────
 	// For each message, capture its current meta fields and store them as JSON
 	// in msg.meta._initialMetadata. Also, record the original keys in _incomingKeys.
@@ -298,7 +298,7 @@ func (p *TagProcessor) ProcessBatch(_ context.Context, batch service.MessageBatc
 	// Process defaults with compiled program (Phase 2 optimization)
 	if p.defaultsProgram != nil {
 		var err error
-		batch, err = p.processMessageBatchWithProgram(batch, p.defaultsProgram, "defaults")
+		batch, err = p.processMessageBatchWithProgram(ctx, batch, p.defaultsProgram, "defaults")
 		if err != nil {
 			return nil, fmt.Errorf("error in defaults processing: %w", err)
 		}
@@ -309,7 +309,7 @@ func (p *TagProcessor) ProcessBatch(_ context.Context, batch service.MessageBatc
 		var newBatch service.MessageBatch
 
 		for _, msg := range batch {
-			processedMsgs, err := p.processConditionForMessageWithProgram(i, msg)
+			processedMsgs, err := p.processConditionForMessageWithProgram(ctx, i, msg)
 			if err != nil {
 				p.logError(err, "condition evaluation", msg)
 				continue
@@ -324,7 +324,7 @@ func (p *TagProcessor) ProcessBatch(_ context.Context, batch service.MessageBatc
 	// Process advanced processing with compiled program (Phase 2 optimization)
 	if p.advancedProgram != nil {
 		var err error
-		batch, err = p.processMessageBatchWithProgram(batch, p.advancedProgram, "advanced")
+		batch, err = p.processMessageBatchWithProgram(ctx, batch, p.advancedProgram, "advanced")
 		if err != nil {
 			return nil, fmt.Errorf("error in advanced processing: %w", err)
 		}
@@ -786,7 +786,7 @@ func (p *TagProcessor) executeCompiledProgram(vm *goja.Runtime, program *goja.Pr
 }
 
 // processMessageBatchWithProgram processes a batch using a compiled program for Phase 2 optimization
-func (p *TagProcessor) processMessageBatchWithProgram(batch service.MessageBatch, program *goja.Program, stageName string) (service.MessageBatch, error) {
+func (p *TagProcessor) processMessageBatchWithProgram(ctx context.Context, batch service.MessageBatch, program *goja.Program, stageName string) (service.MessageBatch, error) {
 	if program == nil {
 		return batch, nil
 	}
@@ -806,7 +806,7 @@ func (p *TagProcessor) processMessageBatchWithProgram(batch service.MessageBatch
 		}
 
 		// Setup VM environment
-		if err = p.setupMessageForVM(vm, msg, jsMsg); err != nil {
+		if err = p.setupMessageForVM(ctx, vm, msg, jsMsg); err != nil {
 			p.logError(err, "JS environment setup", jsMsg)
 			p.putVM(vm)
 			return nil, fmt.Errorf("failed to setup JavaScript environment: %w", err)
@@ -852,7 +852,7 @@ func (p *TagProcessor) processMessageBatchWithProgram(batch service.MessageBatch
 }
 
 // processConditionForMessageWithProgram evaluates a condition using compiled programs (Phase 2 optimization)
-func (p *TagProcessor) processConditionForMessageWithProgram(conditionIndex int, msg *service.Message) (service.MessageBatch, error) {
+func (p *TagProcessor) processConditionForMessageWithProgram(ctx context.Context, conditionIndex int, msg *service.Message) (service.MessageBatch, error) {
 	// Get VM from pool and ensure it's returned
 	vm := p.getVM()
 	defer p.putVM(vm)
@@ -864,7 +864,7 @@ func (p *TagProcessor) processConditionForMessageWithProgram(conditionIndex int,
 	}
 
 	// Setup VM environment using optimized helper method
-	if err = p.setupMessageForVM(vm, msg, jsMsg); err != nil {
+	if err = p.setupMessageForVM(ctx, vm, msg, jsMsg); err != nil {
 		return nil, fmt.Errorf("JS environment setup failed: %w", err)
 	}
 
@@ -878,6 +878,7 @@ func (p *TagProcessor) processConditionForMessageWithProgram(conditionIndex int,
 	// If condition is true, process the message with the compiled condition action
 	if ifResult.ToBoolean() {
 		conditionBatch, err := p.processMessageBatchWithProgram(
+			ctx,
 			service.MessageBatch{msg},
 			p.conditionThenPrograms[conditionIndex],
 			fmt.Sprintf("condition-%d-then", conditionIndex))

--- a/tag_processor_plugin/tag_processor_plugin.go
+++ b/tag_processor_plugin/tag_processor_plugin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin"
+	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/cache"
 	"github.com/united-manufacturing-hub/benthos-umh/pkg/umh/topic"
 )
 
@@ -161,8 +162,9 @@ type TagProcessor struct {
 }
 
 func newTagProcessor(config TagProcessorConfig, logger *service.Logger, metrics *service.Metrics) (*TagProcessor, error) {
-	// Create a NodeREDJSProcessor for SetupJSEnvironment helper
-	jsProcessor, err := nodered_js_plugin.NewNodeREDJSProcessor("", logger, metrics)
+	// TagProcessor only uses the JS processor for SetupJSEnvironment, not for caching.
+	// In-memory with no expiration is sufficient here.
+	jsProcessor, err := nodered_js_plugin.NewNodeREDJSProcessor("", logger, metrics, cache.NewMemoryStore(0))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create JS processor: %w", err)
 	}


### PR DESCRIPTION
# Description

This PR introduces the first iteration of caching in `noderedjs_plugin`. 
What is done here?

- added `cache.set()`, `cache.get()`, `cache.delete()` to the nodered_js JavaScript processor
- built a `cache.Store` interface for future persistent backends (e.g. sth like SQLite)

### Example Usage:

```yaml
input:
  generate:
    count: 5
    interval: 1s
    mapping: 'root.value = random_int(min: 0, max: 100)'
pipeline:
  processors:
    - nodered_js:
        code: |
          var prev = cache.get("last") || 0;
          cache.set("last", msg.payload.value);
          msg.payload.delta = msg.payload.value - prev;
          return msg;
output:
  stdout: {}
```

Fixes ENG-4751