### PR TITLE
chore(CI): handle Fossa license scanning on depot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
   fossa:
     name: FOSSA License Scan
     needs: detect-changes
-    if: github.event_name != 'merge_group' && secrets.FOSSA_API_KEY != ''
+    if: github.event_name != 'merge_group'
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,21 @@ jobs:
               - 'cmd/**'
             gomod:
               - 'go.{mod,sum}'
+  fossa:
+    name: FOSSA License Scan
+    needs: detect-changes
+    if: github.event_name != 'merge_group'
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: FOSSA Analyze and Test
+        uses: fossas/fossa-action@c528632729602c1aedb89e1cbe36e459f0576e25 # v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
+
   license-eye:
     needs: detect-changes
     runs-on: depot-ubuntu-24.04
@@ -297,6 +312,7 @@ jobs:
     name: Check Required Steps
     needs:
       - detect-changes
+      - fossa
       - license-eye
       - lint
       - test-opcua

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,12 @@ jobs:
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
+          project: benthos-umh
       - name: FOSSA Test
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
+          project: benthos-umh
           run-tests: true
 
   license-eye:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: FOSSA Analyze and Test
-        uses: fossas/fossa-action@c528632729602c1aedb89e1cbe36e459f0576e25 # v1
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           run-tests: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: FOSSA Analyze and Test
+      - name: FOSSA Analyze
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+      - name: FOSSA Test
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
   fossa:
     name: FOSSA License Scan
     needs: detect-changes
-    if: github.event_name != 'merge_group'
+    if: github.event_name != 'merge_group' && secrets.FOSSA_API_KEY != ''
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     needs: detect-changes
     if: github.event_name != 'merge_group'
     runs-on: depot-ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,28 @@ jobs:
           provenance: false
           file: ./Dockerfile
 
+  fossa-container:
+    name: FOSSA Container Scan
+    needs: build-docker
+    if: github.ref == 'refs/heads/main'
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      packages: read
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: FOSSA Container Analyze and Test
+        uses: fossas/fossa-action@c528632729602c1aedb89e1cbe36e459f0576e25 # v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+          run-tests: true
+
   build-binaries:
     if: startsWith(github.ref, 'refs/tags/')
     timeout-minutes: 20

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,11 @@ jobs:
   fossa-container:
     name: FOSSA Container Scan
     needs: build-docker
-    if: github.ref == 'refs/heads/main'
+    # Container license scan runs on staging so issues are caught
+    # before the staging -> main promotion PR. Source-level scanning
+    # (ci.yml) covers Go dependencies on every PR; this covers
+    # base image (Alpine) OS packages.
+    if: github.ref == 'refs/heads/staging'
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -95,12 +99,12 @@ jobs:
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
-          container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+          container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
       - name: FOSSA Container Test
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
-          container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+          container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
           run-tests: true
 
   build-binaries:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,11 +99,13 @@ jobs:
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
+          project: benthos-umh
           container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
       - name: FOSSA Container Test
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
+          project: benthos-umh
           container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
           run-tests: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: FOSSA Container Analyze and Test
-        uses: fossas/fossa-action@c528632729602c1aedb89e1cbe36e459f0576e25 # v1
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: FOSSA Container Analyze and Test
+      - name: FOSSA Container Analyze
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+      - name: FOSSA Container Test
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
# Description

Since some of our last CI-runs showed a bad response-time as well as issues with Fossa running in the merge-queue, this PR introduces the fossa-action to handle fossa by ourselves.
The report then will be uploaded in our organization.

We distinguish here between the scan of the source-code, which should run on each PR and on push to `staging` and `main` and the scan of the container-image.
For the image we only tag the `main` branch, as this would otherwise be overhead and is only needed for license scans which e.g. should handle `Alpine` images or sth like that.