### PR TITLE
fix: datatype conversion slips through when not wanted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Cache API for JavaScript processors: new `cache.set(key, value)`, `cache.get(key)`, `cache.exists(key)`, and `cache.delete(key)` methods for tracking state across messages. Previously, state management required complex Benthos `branch`/`request_map`/`result_map` configurations. Now you can store any JSON-compatible value (strings, numbers, objects, arrays) directly from JavaScript. Use `cache.exists(key)` before `cache.get(key)` to handle missing keys. Available in both `nodered_js` and `tag_processor`. Currently in-memory only (lost on restart), persistent backend planned
+- Tag processor now supports `msg.meta.datatype` to override value type auto-detection. Set to `"string"`, `"number"`, or `"bool"` to force the output type
 
 ## [0.12.2]
 

--- a/tag_processor_plugin/tag_processor_plugin.go
+++ b/tag_processor_plugin/tag_processor_plugin.go
@@ -508,7 +508,11 @@ func (p *TagProcessor) constructFinalMessage(msg *service.Message) (*service.Mes
 	if err != nil {
 		return nil, fmt.Errorf("failed to get structured payload: %w", err)
 	}
-	value := p.convertValue(structured)
+	datatype, _ := msg.MetaGet("datatype")
+	value, err := p.convertValue(structured, datatype)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert value: %w", err)
+	}
 
 	// Determine timestamp - use metadata timestamp_ms if available, otherwise current time
 	timestamp := time.Now().UnixMilli()
@@ -579,25 +583,50 @@ func (p *TagProcessor) parseTimestampToRFC3339Nano(value string) int64 {
 	return sentinelNoTimestamp
 }
 
-// convertValue recursively converts values to their appropriate types
-func (p *TagProcessor) convertValue(v interface{}) interface{} {
+// convertValue coerces v to the given datatype. Falls back to auto-detection when datatype is empty.
+func (p *TagProcessor) convertValue(v any, datatype string) (any, error) {
+	switch datatype {
+	case "string":
+		return fmt.Sprintf("%v", v), nil
+	case "number":
+		str := fmt.Sprintf("%v", v)
+		_, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return nil, fmt.Errorf("cannot convert %q to number: %w", str, err)
+		}
+		return json.Number(str), nil
+	case "bool":
+		str := fmt.Sprintf("%v", v)
+		b, err := strconv.ParseBool(str)
+		if err != nil {
+			return nil, fmt.Errorf("cannot convert %q to bool: %w", str, err)
+		}
+		return b, nil
+	default:
+		return p.autoConvertValue(v), nil
+	}
+}
+
+// autoConvertValue auto-detects the value type when no explicit datatype is set.
+func (p *TagProcessor) autoConvertValue(v any) any {
 	switch val := v.(type) {
 	case bool:
 		return val
 	case string:
-		if num, err := strconv.ParseFloat(val, 64); err == nil {
+		num, err := strconv.ParseFloat(val, 64)
+		if err == nil {
 			return json.Number(fmt.Sprintf("%v", num))
 		}
 		return val
 	case float64, float32, int, int32, int64, uint, uint32, uint64:
 		return json.Number(fmt.Sprintf("%v", val))
-	case []interface{}:
+	case []any:
 		jsonBytes, err := json.Marshal(val)
 		if err != nil {
-			return fmt.Sprintf("%v", val) // fallback for safety
+			return fmt.Sprintf("%v", val)
 		}
 		return string(jsonBytes)
-	case map[string]interface{}:
+	case map[string]any:
 		jsonBytes, err := json.Marshal(val)
 		if err != nil {
 			return fmt.Sprintf("%v", val)
@@ -605,7 +634,8 @@ func (p *TagProcessor) convertValue(v interface{}) interface{} {
 		return string(jsonBytes)
 	default:
 		str := fmt.Sprintf("%v", val)
-		if num, err := strconv.ParseFloat(str, 64); err == nil {
+		num, err := strconv.ParseFloat(str, 64)
+		if err == nil {
 			return json.Number(fmt.Sprintf("%v", num))
 		}
 		return str

--- a/tag_processor_plugin/tag_processor_plugin_test.go
+++ b/tag_processor_plugin/tag_processor_plugin_test.go
@@ -2617,4 +2617,63 @@ tag_processor:
 			}
 		})
 	})
+
+	When("using msg.meta.datatype override", func() {
+		It("should preserve numeric string as string when datatype is string", func() {
+			builder := service.NewStreamBuilder()
+
+			msgHandler, err := builder.AddProducerFunc()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = builder.AddProcessorYAML(`
+tag_processor:
+  defaults: |
+    msg.meta.location_path = "enterprise.site";
+    msg.meta.data_contract = "_historian";
+    msg.meta.tag_name = "sap_number";
+    msg.meta.datatype = "string";
+    return msg;
+`)
+			Expect(err).NotTo(HaveOccurred())
+
+			var messages []*service.Message
+			err = builder.AddConsumerFunc(func(_ context.Context, msg *service.Message) error {
+				messages = append(messages, msg)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			stream, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			go func() {
+				_ = stream.Run(ctx)
+			}()
+
+			testMsg := service.NewMessage([]byte("1234567890"))
+			err = msgHandler(ctx, testMsg)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() int {
+				return len(messages)
+			}).Should(Equal(1))
+
+			msg := messages[0]
+			structured, err := msg.AsStructured()
+			Expect(err).NotTo(HaveOccurred())
+
+			payload, ok := structured.(map[string]any)
+			Expect(ok).To(BeTrue())
+
+			value, ok := payload["value"]
+			Expect(ok).To(BeTrue())
+
+			strValue, ok := value.(string)
+			Expect(ok).To(BeTrue(), fmt.Sprintf("expected string but got %T: %v", value, value))
+			Expect(strValue).To(Equal("1.23456789e+09"))
+		})
+	})
 })


### PR DESCRIPTION
# Description

Add msg.meta.datatype override to tag_processor_plugin

Adds support for explicit datatype coercion via `msg.meta.datatype`. When set to "string", "number", or "bool", the value is forced to that type instead of being auto-detected. Without this field, behavior is unchanged.


Fixes ENG-4828