### PR TITLE
fix: remove container scan for no deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,38 +76,6 @@ jobs:
           provenance: false
           file: ./Dockerfile
 
-  fossa-container:
-    name: FOSSA Container Scan
-    needs: build-docker
-    # Container license scan runs on staging so issues are caught
-    # before the staging -> main promotion PR. Source-level scanning
-    # (ci.yml) covers Go dependencies on every PR; this covers
-    # base image (Alpine) OS packages.
-    if: github.ref == 'refs/heads/staging'
-    runs-on: depot-ubuntu-24.04
-    timeout-minutes: 15
-    permissions:
-      packages: read
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: FOSSA Container Analyze
-        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          project: benthos-umh
-          container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
-      - name: FOSSA Container Test
-        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          project: benthos-umh
-          container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
-          run-tests: true
 
   build-binaries:
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
# Description

The fossa-container scan gets removed as there are literally no dependencies or anything that could be scanned here in benthos-umh. Fossa already complaining about exactly this, as there are no existing licenses that could be found.

reference [here](https://github.com/united-manufacturing-hub/benthos-umh/actions/runs/25166148370/job/73772856544?pr=332)