### PR TITLE
chore(ci): update to main, remove on push, label autoPRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,8 @@
 name: CI
 
 on:
-  push:
-    branches: [master, main, staging]
   pull_request:
-    branches: [master, main, staging]
+    branches: [main, staging]
   merge_group:
 
 permissions:

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -35,8 +35,6 @@ jobs:
           app-id: ${{ secrets.PR_APP_ID }}
           private-key: ${{ secrets.PR_APP_PK }}
           repositories: united-manufacturing-hub
-          labels: |
-            skip-changelog-guard
 
       - name: Checkout united-manufacturing-hub Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -78,7 +76,6 @@ jobs:
           labels: |
             auto-generated
             dependencies
-            skip-changelog-guard
           draft: false
 
   update-management-console:
@@ -172,4 +169,5 @@ jobs:
           labels: |
             auto-generated
             schemas
+            skip-changelog-guard
           draft: false

--- a/.github/workflows/update-umh-core-version.yml
+++ b/.github/workflows/update-umh-core-version.yml
@@ -35,6 +35,8 @@ jobs:
           app-id: ${{ secrets.PR_APP_ID }}
           private-key: ${{ secrets.PR_APP_PK }}
           repositories: united-manufacturing-hub
+          labels: |
+            skip-changelog-guard
 
       - name: Checkout united-manufacturing-hub Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -76,6 +78,7 @@ jobs:
           labels: |
             auto-generated
             dependencies
+            skip-changelog-guard
           draft: false
 
   update-management-console:


### PR DESCRIPTION
# Description

This PR removes the "on push" Ci runs, which are not needed for any relevant usecase.
Those tests already run in the original PR e.g. against `staging` and afterwards with PLCs in `merge_group`. 
Also PLC tests run whenever there is a `pull_request` targetting `main`. 

Secondly we add the `skip-changelog-guard` label, as this lead to multiple failures of CI within ManagementConsole.