### PR TITLE
fix(opcua): close browse-routine succesfully and handle errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- OPC-UA input could get stuck while browsing when a configured NodeID did not exist on the server, requiring a manual restart. Browse failures now trigger a clean reconnect
+
 ## 0.12.4
 
 ### Improvements

--- a/opcua_plugin/core_connection.go
+++ b/opcua_plugin/core_connection.go
@@ -225,7 +225,6 @@ func (g *OPCUAConnection) Close(ctx context.Context) error {
 	g.cleanupBrowsing()
 	err := g.closeConnection(ctx)
 	if err != nil {
-		g.Log.Infof("Error closing OPC UA client: %v", err)
 		return err
 	}
 	g.Log.Infof("OPC UA client closed successfully.")

--- a/opcua_plugin/core_connection.go
+++ b/opcua_plugin/core_connection.go
@@ -203,7 +203,7 @@ func (g *OPCUAConnection) cleanupBrowsing() {
 }
 
 // closeConnection handles the actual connection closure
-func (g *OPCUAConnection) closeConnection(ctx context.Context) {
+func (g *OPCUAConnection) closeConnection(ctx context.Context) error {
 	// Call the custom cleanup function if set
 	if g.cleanup_func != nil {
 		g.cleanup_func(ctx)
@@ -211,19 +211,23 @@ func (g *OPCUAConnection) closeConnection(ctx context.Context) {
 
 	g.visited.Clear()
 
+	var err error
 	if g.Client != nil {
-		if err := g.Client.Close(ctx); err != nil {
-			g.Log.Infof("Error closing OPC UA client: %v", err)
-		}
+		err = g.Client.Close(ctx)
 		g.Client = nil
 	}
+	return err
 }
 
 // Close terminates the OPC UA connection with error logging
 func (g *OPCUAConnection) Close(ctx context.Context) error {
 	g.Log.Errorf("Initiating closure of OPC UA client...")
 	g.cleanupBrowsing()
-	g.closeConnection(ctx)
+	err := g.closeConnection(ctx)
+	if err != nil {
+		g.Log.Infof("Error closing OPC UA client: %v", err)
+		return err
+	}
 	g.Log.Infof("OPC UA client closed successfully.")
 	return nil
 }
@@ -232,6 +236,6 @@ func (g *OPCUAConnection) Close(ctx context.Context) error {
 func (g *OPCUAConnection) CloseExpected(ctx context.Context) {
 	g.Log.Infof("Initiating expected closure of OPC UA client...")
 	g.cleanupBrowsing()
-	g.closeConnection(ctx)
+	_ = g.closeConnection(ctx)
 	g.Log.Infof("OPC UA client closed successfully.")
 }

--- a/opcua_plugin/opcua_kepware_test.go
+++ b/opcua_plugin/opcua_kepware_test.go
@@ -132,6 +132,44 @@ var _ = Describe("Test against KepServer EX6", FlakeAttempts(3), func() {
 		}, false, nil, true),
 	)
 
+	// deadlock test, where goroutine from browsing wasn't able to kill itself
+	// it now should be successfully closed and try to reconnect
+	It("does not deadlock when subscribed NodeID does not exist", func() {
+		input = &OPCUAInput{
+			NodeIDs:          ParseNodeIDs([]string{"ns=2;s=NodeThatDoesNotExist.OnKepware"}),
+			SubscribeEnabled: true,
+			OPCUAConnection: &OPCUAConnection{
+				Endpoint:           endpoint,
+				Username:           username,
+				Password:           password,
+				ServerCertificates: make(map[*ua.EndpointDescription]string),
+				SecurityMode:       "None",
+				SecurityPolicy:     "None",
+			},
+		}
+
+		err := input.Connect(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Browse runs async. After it fails on Kepware (BadNodeIDUnknown),
+		// the next ReadBatch must surface service.ErrNotConnected so
+		// benthos triggers a reconnect.
+		Eventually(func() error {
+			_, _, readErr := input.ReadBatch(ctx)
+			return readErr
+		}, 15*time.Second, 100*time.Millisecond).Should(MatchError(service.ErrNotConnected))
+
+		// Close must complete in bounded time. Pre-fix this hung forever
+		// because the browse goroutine had called Close on itself.
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			_ = input.Close(ctx)
+			close(done)
+		}()
+		Eventually(done, 15*time.Second).Should(BeClosed())
+	})
+
 	// This should successfully connect to Kepware since we already trusted the
 	// generated certificates.
 	DescribeTable("Selecting a custom SecurityPolicy", func(input *OPCUAInput) {

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -402,10 +402,13 @@ func (g *OPCUAInput) ReadBatch(ctx context.Context) (service.MessageBatch, servi
 		err     error
 	)
 
-	browseErr := g.getBrowseErr()
-	if browseErr != nil {
-		g.Log.Errorf("Browse failed asynchronously: %v, closing connection for reconnect", browseErr)
-		_ = g.Close(ctx)
+	err = g.getBrowseErr()
+	if err != nil {
+		g.Log.Errorf("Browse failed asynchronously: %v, closing connection for reconnect", err)
+		err = g.Close(ctx)
+		if err != nil {
+			g.Log.Errorf("Gentle closure failed: %v, reconnecting", err)
+		}
 		return nil, nil, service.ErrNotConnected
 	}
 

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -258,6 +259,10 @@ type OPCUAInput struct {
 	DeadbandType                 string
 	DeadbandValue                float64
 	ServerCapabilities           *ServerCapabilities
+
+	// browseErr signals async browse failure to ReadBatch (avoids self-Close deadlock).
+	browseErrMu sync.Mutex
+	browseErr   error
 }
 
 // unsubscribeAndResetHeartbeat unsubscribes from the OPC UA subscription and resets the heartbeat
@@ -275,6 +280,22 @@ func (g *OPCUAInput) unsubscribeAndResetHeartbeat(ctx context.Context) {
 	g.LastMessageReceived.Store(uint32(0))
 }
 
+// setBrowseErr stores the async browse failure for ReadBatch to consume.
+func (g *OPCUAInput) setBrowseErr(err error) {
+	g.browseErrMu.Lock()
+	defer g.browseErrMu.Unlock()
+	g.browseErr = err
+}
+
+// getBrowseErr returns and clears the pending browse failure, if any.
+func (g *OPCUAInput) getBrowseErr() error {
+	g.browseErrMu.Lock()
+	defer g.browseErrMu.Unlock()
+	err := g.browseErr
+	g.browseErr = nil
+	return err
+}
+
 // startBrowsing initiates the browsing process and handles errors
 func (g *OPCUAInput) startBrowsing(ctx context.Context) {
 	browseCtx, cancel := context.WithCancel(ctx)
@@ -286,8 +307,9 @@ func (g *OPCUAInput) startBrowsing(ctx context.Context) {
 		g.Log.Infof("Please note that browsing large node trees can take some time")
 
 		if err := g.BrowseAndSubscribeIfNeeded(browseCtx); err != nil {
+			// Do not call g.Close here: cleanupBrowsing would Wait on this goroutine itself.
 			g.Log.Errorf("Failed to subscribe: %v", err)
-			g.Close(ctx) // Safe to call Close here as we're in a separate goroutine
+			g.setBrowseErr(err)
 			return
 		}
 
@@ -379,6 +401,13 @@ func (g *OPCUAInput) ReadBatch(ctx context.Context) (service.MessageBatch, servi
 		ackFunc service.AckFunc
 		err     error
 	)
+
+	browseErr := g.getBrowseErr()
+	if browseErr != nil {
+		g.Log.Errorf("Browse failed asynchronously: %v, closing connection for reconnect", browseErr)
+		_ = g.Close(ctx)
+		return nil, nil, service.ErrNotConnected
+	}
 
 	if len(g.NodeList) == 0 {
 		g.Log.Debug("ReadBatch is called with empty nodelists. returning early from ReadBatch")

--- a/opcua_plugin/read.go
+++ b/opcua_plugin/read.go
@@ -306,7 +306,11 @@ func (g *OPCUAInput) startBrowsing(ctx context.Context) {
 		defer g.browseWaitGroup.Done()
 		g.Log.Infof("Please note that browsing large node trees can take some time")
 
-		if err := g.BrowseAndSubscribeIfNeeded(browseCtx); err != nil {
+		err := g.BrowseAndSubscribeIfNeeded(browseCtx)
+		if err != nil {
+			if browseCtx.Err() != nil {
+				return
+			}
 			// Do not call g.Close here: cleanupBrowsing would Wait on this goroutine itself.
 			g.Log.Errorf("Failed to subscribe: %v", err)
 			g.setBrowseErr(err)


### PR DESCRIPTION
# Description

While browsing there were scenarios where errors could happen, e.g. `StatusBadNodeID` (could be a misconfigured NodeID). This lead to benthos-umh trying to kill the browse routine, but it wasn't able to succesfully close. Therefore we introduce here a "better" error handling as well as a correct closure of the browsing.
This then leads to a full reconnect as it should. 


Fixes ENG-4195

### Outlook

It might make sense to introduce some general backoff handling as it might happen that opc-servers get hammered with reconnect-tries if someone defines a wrong nodeID.
-> tracked in ENG-4912