### PR TITLE
fix(opcua): demote variant to debug as this is status-only-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - OPC-UA input could get stuck while browsing when a configured NodeID did not exist on the server, requiring a manual restart. Browse failures now trigger a clean reconnect
+- OPC-UA input no longer spams `Variant is nil` errors when a node sends a status update without a value. These are harmless and now logged at debug level with the NodeID and status code
 
 ## 0.12.4
 

--- a/opcua_plugin/core_read.go
+++ b/opcua_plugin/core_read.go
@@ -50,7 +50,7 @@ func isCapabilityProbe(ctx context.Context) bool {
 func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef NodeDef) ([]byte, string) {
 	variant := dataValue.Value
 	if variant == nil || variant.Value() == nil {
-		g.Log.Errorf("Variant is nil")
+		g.Log.Debugf("Status-only update for node %s without value, Status: %v", nodeDef.NodeID.String(), dataValue.Status)
 		return nil, ""
 	}
 


### PR DESCRIPTION
# Description

When we introduced the last gopcua-dependency-update we managed to throw this error. This error can be demoted to debug-level, since it only refers to a node, which gets an update to it's status but not to it's value.
Could be e.g. a "directory"-node, which doesn't even have any value.