### PR TITLE
fix(modbus): modbus resync after tid mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - OPC-UA input could get stuck while browsing when a configured NodeID did not exist on the server, requiring a manual restart. Browse failures now trigger a clean reconnect
 - OPC-UA input no longer spams `Variant is nil` errors when a node sends a status update without a value. These are harmless and now logged at debug level with the NodeID and status code
 - Modbus TCP input now reconnects immediately on any transport-level error (timeouts, resets, network failures), not just broken pipes. Previously these stuck the connection for up to 10 seconds
-- Modbus TCP input now recovers automatically from transaction-ID mismatches. Previously a missed or late Modbus response left the connection out of sync, every later poll failed, and it had to be restarted manually
+- Modbus TCP input now recovers automatically from transaction-ID mismatches. Previously, when a slow PLC reply arrived after its read timeout, the next poll picked up the stale frame and failed with `modbus: response transaction id 'X' does not match request 'Y'`. The connection thrashed (reconnect, mismatch, reconnect) and reads stalled until conditions cleared or the input was restarted
 
 ## [0.12.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Fixes
-
-- Modbus TCP input now recovers automatically from transaction-ID mismatches instead of staying permanently out of sync. Affected connections previously had to be restarted manually
-
 ## [0.12.5]
 
 ### Fixes
@@ -13,6 +9,7 @@
 - OPC-UA input could get stuck while browsing when a configured NodeID did not exist on the server, requiring a manual restart. Browse failures now trigger a clean reconnect
 - OPC-UA input no longer spams `Variant is nil` errors when a node sends a status update without a value. These are harmless and now logged at debug level with the NodeID and status code
 - Modbus TCP input now reconnects immediately on any transport-level error (timeouts, resets, network failures), not just broken pipes. Previously these stuck the connection for up to 10 seconds
+- Modbus TCP input now recovers automatically from transaction-ID mismatches. Previously a missed or late Modbus response left the connection out of sync, every later poll failed, and it had to be restarted manually
 
 ## [0.12.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Modbus TCP input now recovers automatically from transaction-ID mismatches instead of staying permanently out of sync. Affected connections previously had to be restarted manually
+
 ## [0.12.5]
 
 ### Fixes

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"hash/maphash"
 	"math"
-	"net"
 	"net/url"
 	"reflect"
 	"regexp"
@@ -569,22 +568,24 @@ func newModbusInput(conf *service.ParsedConfig, mgr *service.Resources) (service
 
 	switch u.Scheme {
 	case "tcp":
-		host, port, err := net.SplitHostPort(u.Host)
-		if err != nil {
-			return nil, err
-		}
 		switch m.TransmissionMode {
 		case "", "auto", "TCP":
-			handler := modbus.NewTCPClientHandler(host + ":" + port)
+			handler := modbus.NewTCPClientHandler(u.Host)
 			handler.Timeout = m.Timeout
+			handler.ProtocolRecoveryTimeout = m.Timeout
+			handler.LinkRecoveryTimeout = m.Timeout
 			m.Handler = handler
 		case "RTUoverTCP":
-			handler := modbus.NewRTUOverTCPClientHandler(host + ":" + port)
+			handler := modbus.NewRTUOverTCPClientHandler(u.Host)
 			handler.Timeout = m.Timeout
+			handler.ProtocolRecoveryTimeout = m.Timeout
+			handler.LinkRecoveryTimeout = m.Timeout
 			m.Handler = handler
 		case "ASCIIoverTCP":
-			handler := modbus.NewASCIIOverTCPClientHandler(host + ":" + port)
+			handler := modbus.NewASCIIOverTCPClientHandler(u.Host)
 			handler.Timeout = m.Timeout
+			handler.ProtocolRecoveryTimeout = m.Timeout
+			handler.LinkRecoveryTimeout = m.Timeout
 			m.Handler = handler
 		default:
 			return nil, fmt.Errorf("invalid transmission mode %q for %q", m.TransmissionMode, u.Scheme)


### PR DESCRIPTION
# Description

The `modbus_plugin` used to drift permanently out of sync when a device replied to a request after that request had already timed out, since the late response would sit in the socket buffer and every following read picked up the response for the previous transaction ID.

The Fix for this was pretty simple as the underlying `grid-x` library already supports this resync, therefore we just had to pass down the timeouts for whenever they're not zero. 

The `SplitHostPort` could ve dropped completely as it was afterwards recomposed again to the same pattern, which would break for IPv6 addresses. If anything goes wrong the underlying `net.Dial` call will anyway detect a potential pattern mismatch of IP & Port.

Fixes ENG-4549