### PR TITLE
ENG-4974: filter Sparkplug B input by identity.group_id by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,5 @@ cmd/schema-export/schema-export
 
 # macOS
 .DS_Store
+
+.self-review/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Sparkplug B input: `identity.group_id` now filters the MQTT subscription by default. Previously an empty `subscription.groups` caused the plugin to subscribe to every Sparkplug group on the broker (`spBv1.0/+/#`) regardless of `identity.group_id`. To restore the old behavior, set `subscription.groups: ["+"]` explicitly.
+- Sparkplug B input: field descriptions and the primary-role startup log now state that `identity.edge_node_id` is used as the Sparkplug v3.0-compatible `host_id` in the STATE topic (`spBv1.0/STATE/<host_id>`).
+
 ## [0.12.5]
 
 ### Fixes

--- a/config/sparkplug-device-level-primary-host.yaml
+++ b/config/sparkplug-device-level-primary-host.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 # Sparkplug B Primary Host Configuration - Minimal Setup
-# Subscribes to all Sparkplug B messages and displays them
+# Subscribes to the "DeviceLevelTest" group (filtered by identity.group_id) and displays each message.
+# To subscribe to every group on the broker instead, add `subscription: { groups: ["+"] }`.
 # Requires: docker run -d --name mosquitto -p 1883:1883 eclipse-mosquitto:1.6
 
 input:

--- a/docs/input/sparkplug-b-input.md
+++ b/docs/input/sparkplug-b-input.md
@@ -89,7 +89,9 @@ output:
   uns: {}
 ```
 
-This configuration safely reads all Sparkplug B messages and converts them to UMH-Core format. The default `secondary_passive` role is read-only and won't interfere with existing Sparkplug infrastructure, making it safe to run multiple instances for load balancing and redundancy.
+This configuration reads Sparkplug B messages from the configured group and converts them to UMH-Core format. The default `secondary_passive` role is read-only and won't interfere with existing Sparkplug infrastructure, making it safe to run multiple instances for load balancing and redundancy.
+
+> `identity.group_id` is also the subscription filter. By default the plugin subscribes to `spBv1.0/<group_id>/#`, so the example above ingests only the `DeviceLevelTest` group. To listen to multiple groups, use `subscription.groups: ["GroupA", "GroupB"]`. To subscribe to every group on the broker, use the MQTT wildcard: `subscription.groups: ["+"]`. The subscribed topics are printed at startup (for example, `Operating as secondary_passive - subscribing to: [spBv1.0/DeviceLevelTest/#]`).
 
 **To publish data as Sparkplug B**: After processing in the UNS, use the [Sparkplug B Output plugin](../output/sparkplug-b-output.md) to convert UMH-Core data back to Sparkplug B format for external systems.
 
@@ -157,8 +159,8 @@ Here's how a Sparkplug B message maps to UMH-Core using the Modified Parris Meth
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `identity.group_id` | `string` | **required** | Sparkplug B Group ID |
-| `identity.edge_node_id` | `string` | `""` | Required only for `primary` role (used as host_id for STATE topic) |
+| `identity.group_id` | `string` | **required** | Sparkplug B Group ID. Also acts as the default subscription filter (`spBv1.0/<group_id>/#`). Override via `subscription.groups`. |
+| `identity.edge_node_id` | `string` | `""` | Required for the `primary` role, where it is used as the Sparkplug v3.0 `host_id` in the STATE topic (`spBv1.0/STATE/<host_id>`). Optional for secondary roles. |
 
 ### Role Section
 
@@ -194,7 +196,7 @@ The Sparkplug B input plugin offers three operating roles that automatically con
 - **Does NOT send rebirth commands** (fully passive)
 - Does NOT publish STATE messages
 - Safe to run multiple instances for scalability
-- Consumes all Sparkplug B messages without interfering
+- Consumes Sparkplug B messages from the configured group without interfering (set `subscription.groups: ["+"]` to consume every group)
 
 **When to use:**
 - ✅ **Default choice** - Safest option for any deployment
@@ -264,9 +266,11 @@ input:
       urls: ["tcp://localhost:1883"]
     identity:
       group_id: "FactoryA"
-      edge_node_id: "UMH_Primary"  # Required for STATE topic
+      edge_node_id: "UMH_Primary"  # Used as the Sparkplug v3.0 host_id
     role: "primary"
 ```
+
+> For the `primary` role, `identity.edge_node_id` is the Sparkplug v3.0 `host_id`. With the config above, the plugin publishes STATE messages on `spBv1.0/STATE/UMH_Primary`. The startup logs make this explicit: `Primary Host: using identity.edge_node_id='UMH_Primary' as Sparkplug v3.0 host_id for STATE topic spBv1.0/STATE/UMH_Primary`. The field is named `edge_node_id` for consistency with the secondary roles, but in `primary` mode it identifies the host.
 
 **Technical behavior:** Full Primary Host with STATE publishing and session management.
 
@@ -310,7 +314,7 @@ A cascading effect that occurs when multiple Secondary Hosts simultaneously requ
 
 ### Advanced Configuration Options
 
-For users who need fine-grained control beyond the simplified roles, additional configuration options are available:
+For users who need to override the default subscription behavior, `subscription.groups` lets you listen to multiple groups or to every group on the broker:
 
 ```yaml
 input:
@@ -322,13 +326,16 @@ input:
       edge_node_id: "CustomHost"  # Optional for secondary role
     role: "secondary_passive"
 
-    # Advanced options (usually not needed)
+    # Override the default subscription filter
     subscription:
-      groups: ["GroupA", "GroupB"]  # Specific groups instead of all
+      groups: ["FactoryA", "FactoryB"]   # Listen to several groups
+      # groups: ["+"]                      # Or: subscribe to every group (MQTT wildcard)
 
     # Future options (planned):
     # include_data_contract_in_device_id: true  # Add data contract to device ID
 ```
+
+When `subscription.groups` is omitted or empty, the plugin filters to `identity.group_id` (`spBv1.0/<group_id>/#`). Set this field only when you need to listen to groups other than your identity, or to opt back into the all-groups behavior with `["+"]`.
 
 ### STATE Topic Behavior (primary role only)
 

--- a/sparkplug_plugin/config.go
+++ b/sparkplug_plugin/config.go
@@ -44,9 +44,9 @@ type Identity struct {
 	DeviceID     string `yaml:"device_id"`     // Optional: Static device ID override. If empty and location_path provided, auto-generated via PARRIS
 }
 
-// Subscription configuration for primary_host role
+// Subscription configuration for host roles
 type Subscription struct {
-	Groups []string `yaml:"groups"` // Groups to subscribe to. Empty means all groups (+)
+	Groups []string `yaml:"groups"` // Groups to subscribe to. Empty defaults to [Identity.GroupID]; set ["+"] to subscribe to every group.
 }
 
 // Role defines the Sparkplug behavior mode for INPUT plugin (Host-only)
@@ -118,12 +118,14 @@ func (c *Config) getHostSubscriptionTopics() []string {
 	if len(c.Subscription.Groups) > 0 {
 		topics := make([]string, 0, len(c.Subscription.Groups))
 		for _, group := range c.Subscription.Groups {
+			// "+" sentinel passes through to spBv1.0/+/# (subscribe to all groups)
 			topics = append(topics, "spBv1.0/"+group+"/#")
 		}
 		return topics
 	}
-	// Default: listen to all groups
-	return []string{"spBv1.0/+/#"}
+	// Default: filter to identity.group_id (matches the publishing identity).
+	// To subscribe to all groups instead, set subscription.groups: ["+"].
+	return []string{"spBv1.0/" + c.Identity.GroupID + "/#"}
 }
 
 func (c *Config) GetSubscriptionTopics() []string {

--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -104,10 +104,10 @@ Key features:
 		// Sparkplug Identity Configuration
 		Field(service.NewObjectField("identity",
 			service.NewStringField("group_id").
-				Description("Sparkplug Group ID (e.g., 'FactoryA')").
+				Description("Sparkplug Group ID (e.g., 'FactoryA'). Serves two purposes: it is the publishing identity, and it is the default subscription filter (subscribes to spBv1.0/<group_id>/#). Set subscription.groups to override the filter.").
 				Example("FactoryA"),
 			service.NewStringField("edge_node_id").
-				Description("For Primary Host: used as host_id for STATE topic (spBv1.0/STATE/<host_id>). For Secondary Host: optional.").
+				Description("For the 'primary' role this field is required and is used as the Sparkplug v3.0 host_id in the STATE topic (spBv1.0/STATE/<host_id>). For the 'secondary_passive' and 'secondary_active' roles it is optional and used only for identification.").
 				Example("PrimaryHost").
 				Optional(),
 			service.NewStringField("device_id").
@@ -131,11 +131,11 @@ Key features:
 		// Subscription Configuration
 		Field(service.NewObjectField("subscription",
 			service.NewStringListField("groups").
-				Description("Specific groups to subscribe to for primary_host role. Empty means all groups (+)").
+				Description("Groups to subscribe to. When empty (the default), the plugin filters to identity.group_id. Set multiple group IDs to listen to several groups, or [\"+\"] to subscribe to every group via the MQTT wildcard.").
 				Example([]string{"benthos", "factory1", "test"}).
 				Default([]string{}).
 				Optional()).
-			Description("Subscription filtering configuration for primary_host role").
+			Description("Subscription filtering configuration. Defaults to filtering by `identity.group_id`. Set `subscription.groups` to listen to multiple groups or to `[\"+\"]` to subscribe to every group.").
 			Optional())
 
 	err := service.RegisterBatchInput(
@@ -474,6 +474,8 @@ func (s *sparkplugInput) onConnect(client mqtt.Client) {
 	// Publish STATE ONLINE for primary host role
 	if s.config.Role == RolePrimaryHost {
 		stateTopic := s.config.GetStateTopic()
+		s.logger.Infof("Primary Host: using identity.edge_node_id='%s' as Sparkplug v3.0 host_id for STATE topic %s",
+			s.config.Identity.EdgeNodeID, stateTopic)
 		err := s.mqttClientBuilder.PublishWithMetrics(client, stateTopic, s.config.MQTT.QoS, false, "ONLINE")
 		if err != nil {
 			s.logger.Errorf("Failed to publish STATE ONLINE: %v", err)

--- a/sparkplug_plugin/unit_test.go
+++ b/sparkplug_plugin/unit_test.go
@@ -915,6 +915,74 @@ var _ = Describe("Configuration Unit Tests", func() {
 			}
 		})
 	})
+
+	Context("Subscription Topic Defaulting", func() {
+		// ENG-4974: empty subscription.groups must filter to identity.group_id
+		// instead of subscribing to spBv1.0/+/# (all groups). The MQTT wildcard
+		// "+" is preserved as an explicit opt-in for the old all-groups behavior.
+
+		hostRoles := []sparkplugplugin.Role{
+			sparkplugplugin.RoleSecondaryPassive,
+			sparkplugplugin.RoleSecondaryActive,
+			sparkplugplugin.RolePrimaryHost,
+		}
+
+		It("should default to identity.group_id when subscription.groups is empty", func() {
+			for _, role := range hostRoles {
+				By(fmt.Sprintf("role=%s defaults to spBv1.0/<group_id>/#", role), func() {
+					config := &sparkplugplugin.Config{
+						Role: role,
+						Identity: sparkplugplugin.Identity{
+							GroupID:    "FactoryA",
+							EdgeNodeID: "HostNode", // satisfies primary's required field
+						},
+					}
+					Expect(config.GetSubscriptionTopics()).To(Equal([]string{"spBv1.0/FactoryA/#"}))
+				})
+			}
+		})
+
+		It("should subscribe to all groups when subscription.groups is ['+']", func() {
+			config := &sparkplugplugin.Config{
+				Role: sparkplugplugin.RoleSecondaryPassive,
+				Identity: sparkplugplugin.Identity{
+					GroupID: "FactoryA",
+				},
+				Subscription: sparkplugplugin.Subscription{
+					Groups: []string{"+"},
+				},
+			}
+			Expect(config.GetSubscriptionTopics()).To(Equal([]string{"spBv1.0/+/#"}))
+		})
+
+		It("should honor explicit subscription.groups overriding identity.group_id", func() {
+			config := &sparkplugplugin.Config{
+				Role: sparkplugplugin.RoleSecondaryPassive,
+				Identity: sparkplugplugin.Identity{
+					GroupID: "FactoryA",
+				},
+				Subscription: sparkplugplugin.Subscription{
+					Groups: []string{"FactoryB", "FactoryC"},
+				},
+			}
+			Expect(config.GetSubscriptionTopics()).To(Equal([]string{
+				"spBv1.0/FactoryB/#",
+				"spBv1.0/FactoryC/#",
+			}))
+		})
+
+		It("should produce the correct STATE topic from edge_node_id for primary role", func() {
+			// ENG-4974: edge_node_id is the Sparkplug v3.0 host_id for primary role
+			config := &sparkplugplugin.Config{
+				Role: sparkplugplugin.RolePrimaryHost,
+				Identity: sparkplugplugin.Identity{
+					GroupID:    "FactoryA",
+					EdgeNodeID: "UMH_Primary",
+				},
+			}
+			Expect(config.GetStateTopic()).To(Equal("spBv1.0/STATE/UMH_Primary"))
+		})
+	})
 })
 
 var _ = Describe("MessageProcessor Unit Tests", func() {


### PR DESCRIPTION
## Summary

- Sparkplug B input now defaults to `spBv1.0/<identity.group_id>/#` instead of `spBv1.0/+/#`, so the Quick Start config actually filters to the configured group as users expect. Set `subscription.groups: ["+"]` to restore the old all-groups behavior.
- Field descriptions, docs, and a new primary-role startup log clarify that `identity.edge_node_id` is used as the Sparkplug v3.0-compatible `host_id` in the STATE topic (`spBv1.0/STATE/<host_id>`).
- No config schema changes; existing YAML still parses. CHANGELOG documents the behavior change and migration.

## Test plan

- [x] `make test-sparkplug` — 237/237 specs pass (4 new under `Subscription Topic Defaulting`)
- [x] `go build ./...` clean
- [ ] Manual smoke: run `config/sparkplug-device-level-primary-host.yaml` against the example publisher; confirm startup logs show `Operating as primary - subscribing to: [spBv1.0/DeviceLevelTest/#]` and the new `Primary Host: using identity.edge_node_id='PrimaryHost' as Sparkplug v3.0 host_id ...` line
- [ ] Smoke the `["+"]` opt-back-in: set `subscription.groups: ["+"]` and confirm logs show `spBv1.0/+/#`

Closes ENG-4974

🤖 Generated with [Claude Code](https://claude.com/claude-code)