### PR TITLE
feat: snowflake_put_plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
             classic_to_core:
               - 'classic_to_core_plugin/**'
               - '!classic_to_core_plugin/**/*.md'
+            snowflake_put:
+              - 'snowflake_put_plugin/**'
+              - '!snowflake_put_plugin/**/*.md'
             pkg:
               - 'pkg/**'
             cmd:
@@ -312,6 +315,17 @@ jobs:
     uses: ./.github/workflows/test-classic-to-core.yml
     secrets: inherit
 
+  test-snowflake-put:
+    needs: [detect-changes, lint]
+    if: |
+      always() &&
+      needs.lint.result == 'success' &&
+      (needs.detect-changes.outputs.snowflake_put == 'true' ||
+       needs.detect-changes.outputs.gomod == 'true' ||
+       needs.detect-changes.outputs.cmd == 'true')
+    uses: ./.github/workflows/test-snowflake-put.yml
+    secrets: inherit
+
   result:
     name: Check Required Steps
     needs:
@@ -332,6 +346,7 @@ jobs:
       - test-stream-processor
       - test-downsampler
       - test-classic-to-core
+      - test-snowflake-put
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       stream_processor: ${{ steps.filter.outputs.stream_processor }}
       downsampler: ${{ steps.filter.outputs.downsampler }}
       classic_to_core: ${{ steps.filter.outputs.classic_to_core }}
+      snowflake_put: ${{ steps.filter.outputs.snowflake_put }}
       pkg: ${{ steps.filter.outputs.pkg }}
       cmd: ${{ steps.filter.outputs.cmd }}
       gomod: ${{ steps.filter.outputs.gomod }}

--- a/.github/workflows/test-snowflake-put.yml
+++ b/.github/workflows/test-snowflake-put.yml
@@ -1,0 +1,32 @@
+# Copyright 2025 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Test Snowflake PUT
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Snowflake PUT Unittest
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test
+      - name: Test
+        run: make test-snowflake-put

--- a/.github/workflows/test-snowflake-put.yml
+++ b/.github/workflows/test-snowflake-put.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 UMH Systems GmbH
+# Copyright 2026 UMH Systems GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ jobs:
   test:
     name: Snowflake PUT Unittest
     runs-on: depot-ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Sparkplug B input: field descriptions and the primary-role startup log now state that `identity.edge_node_id` is used as the Sparkplug v3.0-compatible `host_id` in the STATE topic (`spBv1.0/STATE/<host_id>`).
 - Sparkplug B input: bridges now request a rebirth when DATA references aliases the cache hasn't seen (typically after a bridge restart with no retained `NBIRTH`/`DBIRTH` on the broker). Previously tags surfaced as `…/_historian/alias_<n>` until something external triggered recovery. Related, `request_birth_on_connect` now defaults to `true`, so `secondary_active`/`primary` bridges also proactively rebirth newly seen nodes on connect; set it to `false` to keep the prior behavior (ignored under `secondary_passive`).
 
+### Improvements
+
+- New `snowflake_put` output: ports the [warpstreamlabs/bento Snowflake output](https://www.bento.dev/docs/components/outputs/snowflake_put) into benthos-umh for writing batched messages to Snowflake stages with optional Snowpipe ingestion. Supports user/password and key-pair auth, all gosnowflake compression modes, and per-message stage/Snowpipe interpolation
+
 ## [0.12.5]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Improvements
 
-- New `snowflake_put` output: ports the [warpstreamlabs/bento Snowflake output](https://www.bento.dev/docs/components/outputs/snowflake_put) into benthos-umh for writing batched messages to Snowflake stages with optional Snowpipe ingestion. Supports user/password and key-pair auth, all gosnowflake compression modes, and per-message stage/Snowpipe interpolation
+- New `snowflake_put` output: ports the [warpstreamlabs/bento Snowflake output](https://github.com/warpstreamlabs/bento/blob/main/website/docs/components/outputs/snowflake_put.md) into benthos-umh for writing batched messages to Snowflake stages with optional Snowpipe ingestion. Supports user/password and key-pair auth, all gosnowflake compression modes, and per-message stage/Snowpipe interpolation
 
 ## [0.12.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Improvements
 
-- New `snowflake_put` output: ports the [warpstreamlabs/bento Snowflake output](https://github.com/warpstreamlabs/bento/blob/main/website/docs/components/outputs/snowflake_put.md) into benthos-umh for writing batched messages to Snowflake stages with optional Snowpipe ingestion. Supports user/password and key-pair auth, all gosnowflake compression modes, and per-message stage/Snowpipe interpolation
+- New `snowflake_put` output: ports the [warpstreamlabs/bento Snowflake output](https://warpstreamlabs.github.io/bento/docs/components/outputs/snowflake_put/) into benthos-umh for writing batched messages to Snowflake stages with optional Snowpipe ingestion. Supports user/password and key-pair auth, all gosnowflake compression modes, and per-message stage/Snowpipe interpolation
 
 ## [0.12.5]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY ./topic_browser_plugin ./topic_browser_plugin
 COPY ./classic_to_core_plugin ./classic_to_core_plugin
 COPY ./sparkplug_plugin ./sparkplug_plugin
 COPY ./stream_processor_plugin ./stream_processor_plugin
+COPY ./snowflake_put_plugin ./snowflake_put_plugin
 
 ENV CGO_ENABLED=0
 RUN go build \

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GINKGO_CMD=go run github.com/onsi/ginkgo/v2/ginkgo
 GINKGO_FLAGS=-r --output-interceptor-mode=none -trace -p --randomize-all --cover --coverprofile=cover.profile
 GINKGO_SERIAL_FLAGS=$(GINKGO_FLAGS) --procs=1
 
-GOTESTSUM_FLAGS=--format pkgname -- -race -cover
+GOTESTSUM_FLAGS=--format pkgname -- -race -coverprofile=cover.profile
 
 BENTHOS_BIN := tmp/bin/benthos
 LOG_LEVEL ?= INFO

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ GINKGO_CMD=go run github.com/onsi/ginkgo/v2/ginkgo
 GINKGO_FLAGS=-r --output-interceptor-mode=none -trace -p --randomize-all --cover --coverprofile=cover.profile
 GINKGO_SERIAL_FLAGS=$(GINKGO_FLAGS) --procs=1
 
+GOTESTSUM_FLAGS=--format pkgname -- -race -cover
+
 BENTHOS_BIN := tmp/bin/benthos
 LOG_LEVEL ?= INFO
 CONFIG ?= ./config/opcua-hex-test.yaml
@@ -133,6 +135,10 @@ fuzz-stream-processor:
 test-tag-processor:
 	@TEST_TAG_PROCESSOR=true \
 		$(GINKGO_CMD) $(GINKGO_FLAGS) ./tag_processor_plugin/...
+
+.PHONY: test-snowflake-put
+test-snowflake-put: $(GOTESTSUM)
+	@$(GOTESTSUM) $(GOTESTSUM_FLAGS) ./snowflake_put_plugin/...
 
 .PHONY: test-sparkplug
 test-sparkplug:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -15,25 +15,27 @@
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
 
 
-LICENSE_EYE_VERSION = v0.7.0
-LINT_VERSION = v2.7.2
-NILAWAY_VERSION = v0.0.0-20251119034912-44f92224c998
+LICENSE_EYE_VERSION   = v0.7.0
+LINT_VERSION          = v2.7.2
+NILAWAY_VERSION       = v0.0.0-20251119034912-44f92224c998
 PROTOC_GEN_GO_VERSION = v1.36.10
-PROTOC_VERSION = cbbe65675855d0db6d94a43f565952c69ef7fc58081569837d44af3f044aa73d
-GRAPHVIZ_VERSION = 939f896cd783daeed8ab08c446f3e2b79213f5e5d87d73bada58667f3bcd8906
-GOFUMPT_VERSION = v0.7.0
-GCI_VERSION = v0.13.5
+PROTOC_VERSION        = cbbe65675855d0db6d94a43f565952c69ef7fc58081569837d44af3f044aa73d
+GRAPHVIZ_VERSION      = 939f896cd783daeed8ab08c446f3e2b79213f5e5d87d73bada58667f3bcd8906
+GOFUMPT_VERSION       = v0.7.0
+GCI_VERSION           = v0.13.5
+GOTESTSUM_VERSION     = v1.13.0
 
 # ---------------------------------------------------
 # Pinned URLs for go install
 # ---------------------------------------------------
 #  we might add some additional tools later e.g. golangci-lint/gofmt
-LICENSE_EYE_URL := github.com/apache/skywalking-eyes/cmd/license-eye@$(LICENSE_EYE_VERSION)
-LINT_URL := github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(LINT_VERSION)
-NILAWAY_URL := go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION)
+LICENSE_EYE_URL   := github.com/apache/skywalking-eyes/cmd/license-eye@$(LICENSE_EYE_VERSION)
+LINT_URL          := github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(LINT_VERSION)
+NILAWAY_URL       := go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION)
 PROTOC_GEN_GO_URL := google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)
-GOFUMPT_URL := mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
-GCI_URL := github.com/daixiang0/gci@$(GCI_VERSION)
+GOFUMPT_URL       := mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
+GCI_URL           := github.com/daixiang0/gci@$(GCI_VERSION)
+GOTESTSUM_URL     := gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 
 
 TOOLS_BIN_DIR    := $(SRC_ROOT)/.tools
@@ -43,12 +45,13 @@ TOOLS_BIN_DIR    := $(SRC_ROOT)/.tools
 # Tools references
 # ---------------------------------------------------
 LICENSE_EYE := $(TOOLS_BIN_DIR)/license-eye
-LINT := $(TOOLS_BIN_DIR)/golangci-lint
-NILAWAY := $(TOOLS_BIN_DIR)/nilaway
-PROTOC := docker run --rm -v $(PWD):$(PWD) -w $(PWD) rvolosatovs/protoc@sha256:$(PROTOC_VERSION)
-DOT := $(TOOLS_BIN_DIR)/graphviz/dot
-GOFUMPT := $(TOOLS_BIN_DIR)/gofumpt
-GCI := $(TOOLS_BIN_DIR)/gci
+LINT        := $(TOOLS_BIN_DIR)/golangci-lint
+NILAWAY     := $(TOOLS_BIN_DIR)/nilaway
+PROTOC      := docker run --rm -v $(PWD):$(PWD) -w $(PWD) rvolosatovs/protoc@sha256:$(PROTOC_VERSION)
+DOT         := $(TOOLS_BIN_DIR)/graphviz/dot
+GOFUMPT     := $(TOOLS_BIN_DIR)/gofumpt
+GCI         := $(TOOLS_BIN_DIR)/gci
+GOTESTSUM   := $(TOOLS_BIN_DIR)/gotestsum
 
 $(TOOLS_BIN_DIR):
 	@mkdir -p $@
@@ -74,11 +77,14 @@ $(GOFUMPT): $(TOOLS_BIN_DIR)
 $(GCI): $(TOOLS_BIN_DIR)
 	@GOBIN=$(TOOLS_BIN_DIR) go install $(GCI_URL)
 
+$(GOTESTSUM): $(TOOLS_BIN_DIR)
+	@GOBIN=$(TOOLS_BIN_DIR) go install $(GOTESTSUM_URL)
+
 .PHONY: install-license-eye
 install-license-eye: $(LICENSE_EYE)
 
 .PHONY: install-tools
-install-tools: $(LICENSE_EYE) $(LINT) $(NILAWAY) $(DOT) $(GOFUMPT) $(GCI)
+install-tools: $(LICENSE_EYE) $(LINT) $(NILAWAY) $(DOT) $(GOFUMPT) $(GCI) $(GOTESTSUM)
 
 .PHONY: help
 help:

--- a/NOTICE
+++ b/NOTICE
@@ -10,8 +10,8 @@ warpstreamlabs/bento project:
 
   https://github.com/warpstreamlabs/bento
 
-Original work Copyright (c) 2024-present Bento contributors, licensed under
-the MIT License:
+Original work Copyright (c) 2020-2024 Ashley Jeffs and
+Copyright (c) 2024-present Bento contributors, licensed under the MIT License:
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -2,3 +2,31 @@ benthos-umh
 Copyright 2023 UMH Systems GmbH
 
 This product is based on the https://github.com/makenew/benthos-plugin project (MIT license). Copyright (c) 2022 Evan Sosenko.
+
+------------------------------------------------------------------------------
+
+The snowflake_put_plugin/ package contains code derived from the
+warpstreamlabs/bento project:
+
+  https://github.com/warpstreamlabs/bento
+
+Original work Copyright (c) 2024-present Bento contributors, licensed under
+the MIT License:
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.

--- a/cmd/benthos/bundle/package.go
+++ b/cmd/benthos/bundle/package.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/united-manufacturing-hub/benthos-umh/opcua_plugin"
 	_ "github.com/united-manufacturing-hub/benthos-umh/s7comm_plugin"
 	_ "github.com/united-manufacturing-hub/benthos-umh/sensorconnect_plugin"
+	_ "github.com/united-manufacturing-hub/benthos-umh/snowflake_put_plugin"
 	_ "github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin"
 	_ "github.com/united-manufacturing-hub/benthos-umh/stream_processor_plugin"
 	_ "github.com/united-manufacturing-hub/benthos-umh/tag_processor_plugin"

--- a/docs/output/README.md
+++ b/docs/output/README.md
@@ -10,6 +10,8 @@ This section covers Benthos output plugins for writing data to various industria
 
 - **[Sparkplug B Output](sparkplug-b-output.md)** - Publishes batched messages to an MQTT Broker with the protocol Sparkplug B. 
 
+- **[Snowflake PUT Output](snowflake-put.md)** - Writes batched messages to a Snowflake stage and optionally triggers Snowpipe ingestion. Ported from warpstreamlabs/bento.
+
 - **[More Output Plugins](https://docs.redpanda.com/redpanda-connect/components/outputs/about/)** - Additional built-in output plugins available in Benthos/Redpanda Connect for various destinations.
 
 ## Choosing the Right Output Plugin

--- a/docs/output/snowflake-put.md
+++ b/docs/output/snowflake-put.md
@@ -10,7 +10,7 @@ Ported from the upstream [warpstreamlabs/bento](https://github.com/warpstreamlab
 
 For configuration, examples, and behavior, refer to the upstream bento documentation:
 
-- **[bento.dev — `snowflake_put` output](https://www.bento.dev/docs/components/outputs/snowflake_put)**
+- **[warpstreamlabs/bento — `snowflake_put` docs (source)](https://github.com/warpstreamlabs/bento/blob/main/website/docs/components/outputs/snowflake_put.md)**
 
 ## Quick example
 

--- a/docs/output/snowflake-put.md
+++ b/docs/output/snowflake-put.md
@@ -1,0 +1,43 @@
+# Snowflake PUT Output
+
+Writes batched messages to a Snowflake stage with optional Snowpipe ingestion.
+
+## Source
+
+Ported from the upstream [warpstreamlabs/bento](https://github.com/warpstreamlabs/bento) project (MIT license).
+
+## Documentation
+
+For configuration, examples, and behavior, refer to the upstream bento documentation:
+
+- **[bento.dev — `snowflake_put` output](https://www.bento.dev/docs/components/outputs/snowflake_put)**
+
+## Quick example
+
+```yaml
+output:
+  snowflake_put:
+    account: my_account
+    user: my_user
+    private_key_file: /path/to/rsa_key.pem
+    role: ACCOUNTADMIN
+    database: MY_DB
+    warehouse: COMPUTE_WH
+    schema: PUBLIC
+    stage: "@%MY_TBL"
+    path: ingest
+    compression: AUTO
+    snowpipe: MY_PIPE
+    batching:
+      count: 100
+      period: 5s
+      processors:
+        - archive:
+            format: concatenate
+```
+
+## Notes
+
+- Snowpipe requires key-pair authentication (`private_key_file`); user/password auth only supports PUT to stages, not Snowpipe.
+- Encrypted private keys must use PKCS#5 v2.0 (e.g. `openssl pkcs8 -topk8 -v2 des3`). PKCS#5 v1.5 is not supported.
+- The underlying [gosnowflake](https://github.com/snowflakedb/gosnowflake) driver needs write access to the OS temp directory.

--- a/docs/output/snowflake-put.md
+++ b/docs/output/snowflake-put.md
@@ -2,6 +2,10 @@
 
 Writes batched messages to a Snowflake stage with optional Snowpipe ingestion.
 
+## Why `snowflake_put` over `sql_insert`
+
+`sql_insert` issues row-by-row `INSERT`s that run on a Snowflake virtual warehouse, so all the ingestion cost lands on warehouse compute (billed per second). `snowflake_put` stages batched files and, when a Snowpipe is configured (key-pair auth plus a pre-created pipe), loads them through Snowpipe, Snowflake's serverless ingestion path billed per GB, so the warehouse no longer runs the ingestion (a warehouse must still be configured). For continuous, high-volume loads this is much cheaper. The benefit assumes files are batched to a reasonable size (Snowflake recommends ~100-250 MB); many tiny files add queue overhead that cancels out the saving. Without a Snowpipe configured, `snowflake_put` only stages files and a warehouse-run `COPY INTO` is still needed to load them. See Snowflake's [Snowpipe billing](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-billing) docs for current rates.
+
 ## Source
 
 Ported from the upstream [warpstreamlabs/bento](https://github.com/warpstreamlabs/bento) project (MIT license).

--- a/docs/output/snowflake-put.md
+++ b/docs/output/snowflake-put.md
@@ -10,7 +10,7 @@ Ported from the upstream [warpstreamlabs/bento](https://github.com/warpstreamlab
 
 For configuration, examples, and behavior, refer to the upstream bento documentation:
 
-- **[warpstreamlabs/bento — `snowflake_put` docs (source)](https://github.com/warpstreamlabs/bento/blob/main/website/docs/components/outputs/snowflake_put.md)**
+- **[warpstreamlabs/bento — `snowflake_put` docs](https://warpstreamlabs.github.io/bento/docs/components/outputs/snowflake_put/)**
 
 ## Quick example
 

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,8 @@ require (
 	github.com/danomagnum/gologix v0.27.2-beta
 	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c
 	github.com/eclipse/paho.mqtt.golang v1.5.1
+	github.com/gofrs/uuid/v5 v5.4.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gopcua/opcua v0.8.0
 	github.com/grid-x/modbus v0.0.0-20260325140807-cf9e1b9daae0
@@ -43,10 +45,13 @@ require (
 	github.com/redpanda-data/benthos/v4 v4.73.0
 	github.com/redpanda-data/connect/public/bundle/free/v4 v4.90.3
 	github.com/robinson/gos7 v0.0.0-20241205073040-7ea1d6fb9d20
+	github.com/snowflakedb/gosnowflake v1.19.0
+	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/redpanda v0.42.0
 	github.com/twmb/franz-go v1.21.1
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
+	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	golang.org/x/crypto v0.51.0
 	golang.org/x/sys v0.44.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
@@ -252,9 +257,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/gocql/gocql v1.7.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
-	github.com/gofrs/uuid/v5 v5.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -422,11 +425,9 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/smira/go-statsd v1.3.4 // indirect
-	github.com/snowflakedb/gosnowflake v1.19.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/theparanoids/crypki v1.21.0 // indirect
 	github.com/tilinna/z85 v1.0.0 // indirect
@@ -454,7 +455,6 @@ require (
 	github.com/xitongsys/parquet-go v1.6.2 // indirect
 	github.com/xitongsys/parquet-go-source v0.0.0-20241021075129-b732d2ac9c9b // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
-	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	gitlab.com/golang-commonmark/html v0.0.0-20191124015941-a22733972181 // indirect

--- a/snowflake_put_plugin/output_snowflake_put.go
+++ b/snowflake_put_plugin/output_snowflake_put.go
@@ -445,7 +445,7 @@ func getPrivateKey(f fs.FS, path string, passphrase string) (*rsa.PrivateKey, er
 
 	if privateKeyBlock.Type == "ENCRYPTED PRIVATE KEY" {
 		if passphrase == "" {
-			return nil, errors.New("private key requires a passphrase, but private_key_passphrase was not supplied")
+			return nil, errors.New("private key requires a passphrase, but private_key_pass was not supplied")
 		}
 
 		var privateKey *rsa.PrivateKey
@@ -617,7 +617,7 @@ func newSnowflakeWriterFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 	var uploadParallelThreads int
 	uploadParallelThreads, err = conf.FieldInt("upload_parallel_threads")
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse stage: %w", err)
+		return nil, fmt.Errorf("failed to parse upload_parallel_threads: %w", err)
 	}
 
 	compressionStr, err := conf.FieldString("compression")
@@ -851,7 +851,7 @@ func (s *snowflakeWriter) WriteBatch(ctx context.Context, batch service.MessageB
 			return fmt.Errorf("failed to get stage: %w", err)
 		}
 		if f.stage == "" {
-			return fmt.Errorf("stage cannot be empty: %w", err)
+			return errors.New("stage cannot be empty")
 		}
 
 		f.stagePath, err = s.path.TryString(msg)

--- a/snowflake_put_plugin/output_snowflake_put.go
+++ b/snowflake_put_plugin/output_snowflake_put.go
@@ -16,8 +16,9 @@
 // Portions of this file are derived from the warpstreamlabs/bento project:
 //   https://github.com/warpstreamlabs/bento/blob/main/internal/impl/snowflake/output_snowflake_put.go
 //
-// Original work Copyright (c) 2024-present Bento contributors, licensed under
-// the MIT License. A copy of the MIT License is reproduced in NOTICE.
+// Original work Copyright (c) 2020-2024 Ashley Jeffs and
+// Copyright (c) 2024-present Bento contributors, licensed under the MIT License.
+// A copy of the MIT License is reproduced in NOTICE.
 // -----------------------------------------------------------------------------
 
 package snowflake_put_plugin

--- a/snowflake_put_plugin/output_snowflake_put.go
+++ b/snowflake_put_plugin/output_snowflake_put.go
@@ -1,0 +1,937 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// Portions of this file are derived from the warpstreamlabs/bento project:
+//   https://github.com/warpstreamlabs/bento/blob/main/internal/impl/snowflake/output_snowflake_put.go
+//
+// Original work Copyright (c) 2024-present Bento contributors, licensed under
+// the MIT License. A copy of the MIT License is reproduced in NOTICE.
+// -----------------------------------------------------------------------------
+
+package snowflake_put_plugin
+
+import (
+	"bytes"
+	"context"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/snowflakedb/gosnowflake"
+	"github.com/youmark/pkcs8"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	defaultJWTTimeout = 60 * time.Second
+)
+
+// CompressionType represents the compression used for the payloads sent to Snowflake.
+type CompressionType string
+
+const (
+	// CompressionTypeNone No compression.
+	CompressionTypeNone CompressionType = "NONE"
+	// CompressionTypeAuto Automatic compression (gzip).
+	CompressionTypeAuto CompressionType = "AUTO"
+	// CompressionTypeGzip Gzip compression.
+	CompressionTypeGzip CompressionType = "GZIP"
+	// CompressionTypeDeflate Deflate compression using zlib algorithm (with zlib header, RFC1950).
+	CompressionTypeDeflate CompressionType = "DEFLATE"
+	// CompressionTypeRawDeflate Deflate compression using flate algorithm (without header, RFC1951).
+	CompressionTypeRawDeflate CompressionType = "RAW_DEFLATE"
+	// CompressionTypeZstandard compression using Zstandard algorithm.
+	CompressionTypeZstandard CompressionType = "ZSTD"
+)
+
+func snowflakePutOutputConfig() *service.ConfigSpec {
+	return service.NewConfigSpec().
+		Stable().
+		Categories("Services").
+		Summary("Sends messages to Snowflake stages and, optionally, calls Snowpipe to load this data into one or more tables.").
+		Description(`
+In order to use a different stage and / or Snowpipe for each message, you can use function interpolations as described
+[here](/docs/configuration/interpolation#bloblang-queries). When using batching, messages are grouped by the calculated
+stage and Snowpipe and are streamed to individual files in their corresponding stage and, optionally, a Snowpipe
+`+"`insertFiles`"+` REST API call will be made for each individual file.
+
+### Credentials
+
+Two authentication mechanisms are supported:
+- User/password
+- Key Pair Authentication
+
+#### User/password
+
+This is a basic authentication mechanism which allows you to PUT data into a stage. However, it is not compatible with
+Snowpipe.
+
+#### Key Pair Authentication
+
+This authentication mechanism allows Snowpipe functionality, but it does require configuring an SSH Private Key
+beforehand. Please consult the [documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication)
+for details on how to set it up and assign the Public Key to your user.
+
+Note that the Snowflake documentation [used to suggest](https://twitter.com/felipehoffa/status/1560811785606684672)
+using this command:
+
+`+"```shell"+`
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8
+`+"```"+`
+
+to generate an encrypted SSH private key. However, in this case, it uses an encryption algorithm called
+`+"`pbeWithMD5AndDES-CBC`"+`, which is part of the PKCS#5 v1.5 and is considered insecure. Due to this, Bento does not
+support it and, if you wish to use password-protected keys directly, you must use PKCS#5 v2.0 to encrypt them by using
+the following command (as the current Snowflake docs suggest):
+
+`+"```shell"+`
+openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 des3 -inform PEM -out rsa_key.p8
+`+"```"+`
+
+If you have an existing key encrypted with PKCS#5 v1.5, you can re-encrypt it with PKCS#5 v2.0 using this command:
+
+`+"```shell"+`
+openssl pkcs8 -in rsa_key_original.p8 -topk8 -v2 des3 -out rsa_key.p8
+`+"```"+`
+
+Please consult [this](https://linux.die.net/man/1/pkcs8) pkcs8 command documentation for details on PKCS#5 algorithms.
+
+### Batching
+
+It's common to want to upload messages to Snowflake as batched archives. The easiest way to do this is to batch your
+messages at the output level and join the batch of messages with an
+`+"[`archive`](/docs/components/processors/archive)"+` and/or `+"[`compress`](/docs/components/processors/compress)"+`
+processor.
+
+For the optimal batch size, please consult the Snowflake [documentation](https://docs.snowflake.com/en/user-guide/data-load-considerations-prepare.html).
+
+### Snowpipe
+
+Given a table called `+"`BENTO_TBL`"+` with one column of type `+"`variant`"+`:
+
+`+"```sql"+`
+CREATE OR REPLACE TABLE BENTO_DB.PUBLIC.BENTO_TBL(RECORD variant)
+`+"```"+`
+
+and the following `+"`BENTO_PIPE`"+` Snowpipe:
+
+`+"```sql"+`
+CREATE OR REPLACE PIPE BENTO_DB.PUBLIC.BENTO_PIPE AUTO_INGEST = FALSE AS COPY INTO BENTO_DB.PUBLIC.BENTO_TBL FROM (SELECT * FROM @%BENTO_TBL) FILE_FORMAT = (TYPE = JSON COMPRESSION = AUTO)
+`+"```"+`
+
+you can configure Bento to use the implicit table stage `+"`@%BENTO_TBL`"+` as the `+"`stage`"+` and
+`+"`BENTO_PIPE`"+` as the `+"`snowpipe`"+`. In this case, you must set `+"`compression`"+` to `+"`AUTO`"+` and, if
+using message batching, you'll need to configure an [`+"`archive`"+`](/docs/components/processors/archive) processor
+with the `+"`concatenate`"+` format. Since the `+"`compression`"+` is set to `+"`AUTO`"+`, the
+[gosnowflake](https://github.com/snowflakedb/gosnowflake) client library will compress the messages automatically so you
+don't need to add a `+"[`compress`](/docs/components/processors/compress)"+` processor for message batches.
+
+If you add `+"`STRIP_OUTER_ARRAY = TRUE`"+` in your Snowpipe `+"`FILE_FORMAT`"+`
+definition, then you must use `+"`json_array`"+` instead of `+"`concatenate`"+` as the archive processor format.
+
+Note: Only Snowpipes with `+"`FILE_FORMAT`"+` `+"`TYPE`"+` `+"`JSON`"+` are currently supported.
+
+### Snowpipe Troubleshooting
+
+Snowpipe [provides](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-rest-apis.html) the `+"`insertReport`"+`
+and `+"`loadHistoryScan`"+` REST API endpoints which can be used to get information about recent Snowpipe calls. In
+order to query them, you'll first need to generate a valid JWT token for your Snowflake account. There are two methods
+for doing so:
+- Using the `+"`snowsql`"+` [utility](https://docs.snowflake.com/en/user-guide/snowsql.html):
+
+`+"```shell"+`
+snowsql --private-key-path rsa_key.p8 --generate-jwt -a <account> -u <user>
+`+"```"+`
+
+- Using the Python `+"`sql-api-generate-jwt`"+` [utility](https://docs.snowflake.com/en/developer-guide/sql-api/authenticating.html#generating-a-jwt-in-python):
+
+`+"```shell"+`
+python3 sql-api-generate-jwt.py --private_key_file_path=rsa_key.p8 --account=<account> --user=<user>
+`+"```"+`
+
+Once you successfully generate a JWT token and store it into the `+"`JWT_TOKEN`"+` environment variable, then you can,
+for example, query the `+"`insertReport`"+` endpoint using `+"`curl`"+`:
+
+`+"```shell"+`
+curl -H "Authorization: Bearer ${JWT_TOKEN}" "https://<account>.snowflakecomputing.com/v1/data/pipes/<database>.<schema>.<snowpipe>/insertReport"
+`+"```"+`
+
+If you need to pass in a valid `+"`requestId`"+` to any of these Snowpipe REST API endpoints, you can set a
+[uuid_v4()](https://www.bento.dev/docs/guides/bloblang/functions#uuid_v4) string in a metadata field called
+`+"`request_id`"+`, log it via the [`+"`log`"+`](https://www.bento.dev/docs/components/processors/log) processor and
+then configure `+"`request_id: ${ @request_id }`"+` ). Alternatively, you can enable debug logging as described
+[here](/docs/components/logger/about) and Bento will print the Request IDs that it sends to Snowpipe.
+
+### General Troubleshooting
+
+The underlying [`+"`gosnowflake`"+` driver](https://github.com/snowflakedb/gosnowflake) requires write access to
+the default directory to use for temporary files. Please consult the [`+"`os.TempDir`"+`](https://pkg.go.dev/os#TempDir)
+docs for details on how to change this directory via environment variables.
+
+A silent failure can occur due to [this issue](https://github.com/snowflakedb/gosnowflake/issues/701), where the
+underlying [`+"`gosnowflake`"+` driver](https://github.com/snowflakedb/gosnowflake) doesn't return an error and doesn't
+log a failure if it can't figure out the current username. One way to trigger this behavior is by running Bento in a
+Docker container with a non-existent user ID (such as `+"`--user 1000:1000`"+`).
+`+service.OutputPerformanceDocs(true, true)).
+		Field(service.NewStringField("account").Description(`Account name, which is the same as the Account Identifier
+as described [here](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#where-are-account-identifiers-used).
+However, when using an [Account Locator](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#using-an-account-locator-as-an-identifier),
+the Account Identifier is formatted as `+"`<account_locator>.<region_id>.<cloud>`"+` and this field needs to be
+populated using the `+"`<account_locator>`"+` part.
+`)).
+		Field(service.NewStringField("region").Description(`Optional region field which needs to be populated when using
+an [Account Locator](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#using-an-account-locator-as-an-identifier)
+and it must be set to the `+"`<region_id>`"+` part of the Account Identifier
+(`+"`<account_locator>.<region_id>.<cloud>`"+`).
+`).Example("us-west-2").Optional()).
+		Field(service.NewStringField("cloud").Description(`Optional cloud platform field which needs to be populated
+when using an [Account Locator](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#using-an-account-locator-as-an-identifier)
+and it must be set to the `+"`<cloud>`"+` part of the Account Identifier
+(`+"`<account_locator>.<region_id>.<cloud>`"+`).
+`).Example("aws").Example("gcp").Example("azure").Optional()).
+		Field(service.NewStringField("user").Description("Username.")).
+		Field(service.NewStringField("password").Description("An optional password.").Optional().Secret()).
+		Field(service.NewStringField("private_key_file").Description("The path to a file containing the private SSH key.").Optional()).
+		Field(service.NewStringField("private_key_pass").Description("An optional private SSH key passphrase.").Optional().Secret()).
+		Field(service.NewStringField("role").Description("Role.")).
+		Field(service.NewStringField("database").Description("Database.")).
+		Field(service.NewStringField("warehouse").Description("Warehouse.")).
+		Field(service.NewStringField("schema").Description("Schema.")).
+		Field(service.NewInterpolatedStringField("stage").Description(`Stage name. Use either one of the
+[supported](https://docs.snowflake.com/en/user-guide/data-load-local-file-system-create-stage.html) stage types.`)).
+		Field(service.NewInterpolatedStringField("path").Description("Stage path.").Default("")).
+		Field(service.NewInterpolatedStringField("file_name").Description("Stage file name. Will be equal to the Request ID if not set or empty.").Optional().Default("").Version("v4.12.0")).
+		Field(service.NewInterpolatedStringField("file_extension").Description("Stage file extension. Will be derived from the configured `compression` if not set or empty.").Optional().Default("").Example("csv").Example("parquet").Version("v4.12.0")).
+		Field(service.NewIntField("upload_parallel_threads").Description("Specifies the number of threads to use for uploading files.").Advanced().Default(4).LintRule(`root = if this < 1 || this > 99 { [ "upload_parallel_threads must be between 1 and 99" ] }`)).
+		Field(service.NewStringAnnotatedEnumField("compression", map[string]string{
+			string(CompressionTypeNone):       "No compression is applied and messages must contain plain-text JSON. Default `file_extension`: `json`.",
+			string(CompressionTypeAuto):       "Compression (gzip) is applied automatically by the output and messages must contain plain-text JSON. Default `file_extension`: `gz`.",
+			string(CompressionTypeGzip):       "Messages must be pre-compressed using the gzip algorithm. Default `file_extension`: `gz`.",
+			string(CompressionTypeDeflate):    "Messages must be pre-compressed using the zlib algorithm (with zlib header, RFC1950). Default `file_extension`: `deflate`.",
+			string(CompressionTypeRawDeflate): "Messages must be pre-compressed using the flate algorithm (without header, RFC1951). Default `file_extension`: `raw_deflate`.",
+			string(CompressionTypeZstandard):  "Messages must be pre-compressed using the Zstandard algorithm. Default `file_extension`: `zst`.",
+		}).Description("Compression type.").Default(string(CompressionTypeAuto))).
+		Field(service.NewInterpolatedStringField("request_id").Description("Request ID. Will be assigned a random UUID (v4) string if not set or empty.").Optional().Default("").Version("v4.12.0")).
+		Field(service.NewInterpolatedStringField("snowpipe").Description(`An optional Snowpipe name. Use the `+"`<snowpipe>`"+` part from `+"`<database>.<schema>.<snowpipe>`"+`.`).Optional()).
+		Field(service.NewBoolField("client_session_keep_alive").Description("Enable Snowflake keepalive mechanism to prevent the client session from expiring after 4 hours (error 390114).").Advanced().Default(false)).
+		Field(service.NewBatchPolicyField("batching")).
+		Field(service.NewIntField("max_in_flight").Description("The maximum number of parallel message batches to have in flight at any given time.").Default(1)).
+		LintRule(`root = match {
+  this.exists("password") && this.password != "" && this.exists("private_key_file") && this.private_key_file != "" => [ "both `+"`password`"+` and `+"`private_key_file`"+` can't be set simultaneously" ],
+  this.exists("snowpipe") && this.snowpipe != "" && (!this.exists("private_key_file") || this.private_key_file == "") => [ "`+"`private_key_file`"+` is required when setting `+"`snowpipe`"+`" ],
+}`).
+		Example("Kafka / realtime brokers", "Upload message batches from realtime brokers such as Kafka persisting the batch partition and offsets in the stage path and filename similarly to the [Kafka Connector scheme](https://docs.snowflake.com/en/user-guide/kafka-connector-ts.html#step-1-view-the-copy-history-for-the-table) and call Snowpipe to load them into a table. When batching is configured at the input level, it is done per-partition.", `
+input:
+  kafka:
+    addresses:
+      - localhost:9092
+    topics:
+      - foo
+    consumer_group: bento
+    batching:
+      count: 10
+      period: 3s
+      processors:
+        - mapping: |
+            meta kafka_start_offset = metadata("kafka_offset").from(0).string()
+            meta kafka_end_offset = metadata("kafka_offset").from(-1).string()
+            meta batch_timestamp = if batch_index() == 0 { now() }
+        - mapping: |
+            meta batch_timestamp = if batch_index() != 0 { metadata("batch_timestamp").from(0).string() }
+
+output:
+  snowflake_put:
+    account: bento
+    user: test@bento.dev
+    private_key_file: path_to_ssh_key.pem
+    role: ACCOUNTADMIN
+    database: BENTO_DB
+    warehouse: COMPUTE_WH
+    schema: PUBLIC
+    stage: "@%BENTO_TBL"
+    path: bento/BENTO_TBL/${! @kafka_partition }
+    file_name: ${! @kafka_start_offset }_${! @kafka_end_offset }_${! metadata("batch_timestamp").string() }
+    upload_parallel_threads: 4
+    compression: NONE
+    snowpipe: BENTO_PIPE
+`).
+		Example("No compression", "Upload concatenated messages into a `.json` file to a table stage without calling Snowpipe.", `
+output:
+  snowflake_put:
+    account: bento
+    user: test@bento.dev
+    private_key_file: path_to_ssh_key.pem
+    role: ACCOUNTADMIN
+    database: BENTO_DB
+    warehouse: COMPUTE_WH
+    schema: PUBLIC
+    stage: "@%BENTO_TBL"
+    path: bento
+    upload_parallel_threads: 4
+    compression: NONE
+    batching:
+      count: 10
+      period: 3s
+      processors:
+        - archive:
+            format: concatenate
+`).
+		Example("Parquet format with snappy compression", "Upload concatenated messages into a `.parquet` file to a table stage without calling Snowpipe.", `
+output:
+  snowflake_put:
+    account: bento
+    user: test@bento.dev
+    private_key_file: path_to_ssh_key.pem
+    role: ACCOUNTADMIN
+    database: BENTO_DB
+    warehouse: COMPUTE_WH
+    schema: PUBLIC
+    stage: "@%BENTO_TBL"
+    path: bento
+    file_extension: parquet
+    upload_parallel_threads: 4
+    compression: NONE
+    batching:
+      count: 10
+      period: 3s
+      processors:
+        - parquet_encode:
+            schema:
+              - name: ID
+                type: INT64
+              - name: CONTENT
+                type: BYTE_ARRAY
+            default_compression: snappy
+`).
+		Example("Automatic compression", "Upload concatenated messages compressed automatically into a `.gz` archive file to a table stage without calling Snowpipe.", `
+output:
+  snowflake_put:
+    account: bento
+    user: test@bento.dev
+    private_key_file: path_to_ssh_key.pem
+    role: ACCOUNTADMIN
+    database: BENTO_DB
+    warehouse: COMPUTE_WH
+    schema: PUBLIC
+    stage: "@%BENTO_TBL"
+    path: bento
+    upload_parallel_threads: 4
+    compression: AUTO
+    batching:
+      count: 10
+      period: 3s
+      processors:
+        - archive:
+            format: concatenate
+`).
+		Example("DEFLATE compression", "Upload concatenated messages compressed into a `.deflate` archive file to a table stage and call Snowpipe to load them into a table.", `
+output:
+  snowflake_put:
+    account: bento
+    user: test@bento.dev
+    private_key_file: path_to_ssh_key.pem
+    role: ACCOUNTADMIN
+    database: BENTO_DB
+    warehouse: COMPUTE_WH
+    schema: PUBLIC
+    stage: "@%BENTO_TBL"
+    path: bento
+    upload_parallel_threads: 4
+    compression: DEFLATE
+    snowpipe: BENTO_PIPE
+    batching:
+      count: 10
+      period: 3s
+      processors:
+        - archive:
+            format: concatenate
+        - mapping: |
+            root = content().compress("zlib")
+`).
+		Example("RAW_DEFLATE compression", "Upload concatenated messages compressed into a `.raw_deflate` archive file to a table stage and call Snowpipe to load them into a table.", `
+output:
+  snowflake_put:
+    account: bento
+    user: test@bento.dev
+    private_key_file: path_to_ssh_key.pem
+    role: ACCOUNTADMIN
+    database: BENTO_DB
+    warehouse: COMPUTE_WH
+    schema: PUBLIC
+    stage: "@%BENTO_TBL"
+    path: bento
+    upload_parallel_threads: 4
+    compression: RAW_DEFLATE
+    snowpipe: BENTO_PIPE
+    batching:
+      count: 10
+      period: 3s
+      processors:
+        - archive:
+            format: concatenate
+        - mapping: |
+            root = content().compress("flate")
+`)
+}
+
+func init() {
+	err := service.RegisterBatchOutput("snowflake_put", snowflakePutOutputConfig(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchOutput, service.BatchPolicy, int, error) {
+			maxInFlight, err := conf.FieldInt("max_in_flight")
+			if err != nil {
+				return nil, service.BatchPolicy{}, 0, err
+			}
+			batchPolicy, err := conf.FieldBatchPolicy("batching")
+			if err != nil {
+				return nil, service.BatchPolicy{}, 0, err
+			}
+			output, err := newSnowflakeWriterFromConfig(conf, mgr)
+			if err != nil {
+				return nil, service.BatchPolicy{}, 0, err
+			}
+			return output, batchPolicy, maxInFlight, nil
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+//------------------------------------------------------------------------------
+
+// getPrivateKey reads and parses the private key
+// Inspired from https://github.com/chanzuckerberg/terraform-provider-snowflake/blob/c07d5820bea7ac3d8a5037b0486c405fdf58420e/pkg/provider/provider.go#L367
+func getPrivateKey(f fs.FS, path string, passphrase string) (*rsa.PrivateKey, error) {
+	privateKeyBytes, err := service.ReadFile(f, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read private key %s: %w", path, err)
+	}
+	if len(privateKeyBytes) == 0 {
+		return nil, errors.New("private key is empty")
+	}
+
+	privateKeyBlock, _ := pem.Decode(privateKeyBytes)
+	if privateKeyBlock == nil {
+		return nil, errors.New("could not parse private key, key is not in PEM format")
+	}
+
+	if privateKeyBlock.Type == "ENCRYPTED PRIVATE KEY" {
+		if passphrase == "" {
+			return nil, errors.New("private key requires a passphrase, but private_key_passphrase was not supplied")
+		}
+
+		var privateKey *rsa.PrivateKey
+		privateKey, err = pkcs8.ParsePKCS8PrivateKeyRSA(privateKeyBlock.Bytes, []byte(passphrase))
+		if err != nil {
+			return nil, fmt.Errorf("failed to decrypt encrypted private key (only ciphers aes-128-cbc, aes-128-gcm, aes-192-cbc, aes-192-gcm, aes-256-cbc, aes-256-gcm, and des-ede3-cbc are supported): %w", err)
+		}
+
+		return privateKey, nil
+	}
+
+	privateKey, err := ssh.ParseRawPrivateKey(privateKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse private key: %w", err)
+	}
+
+	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key must be of type RSA but got %T instead: ", privateKey)
+	}
+	return rsaPrivateKey, nil
+}
+
+// calculatePublicKeyFingerprint computes the value of the `RSA_PUBLIC_KEY_FP` for the current user based on the
+// configured private key
+// Inspired from https://stackoverflow.com/questions/63598044/snowpipe-rest-api-returning-always-invalid-jwt-token
+func calculatePublicKeyFingerprint(privateKey *rsa.PrivateKey) (string, error) {
+	pubKey := privateKey.Public()
+	pubDER, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal public key: %w", err)
+	}
+
+	hash := sha256.Sum256(pubDER)
+	return "SHA256:" + base64.StdEncoding.EncodeToString(hash[:]), nil
+}
+
+type dbI interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	Close() error
+}
+
+type uuidGenI interface {
+	NewV4() (uuid.UUID, error)
+}
+
+type httpClientI interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type snowflakeWriter struct {
+	logger *service.Logger
+
+	account       string
+	user          string
+	database      string
+	schema        string
+	stage         *service.InterpolatedString
+	path          *service.InterpolatedString
+	fileName      *service.InterpolatedString
+	fileExtension *service.InterpolatedString
+	requestID     *service.InterpolatedString
+	snowpipe      *service.InterpolatedString
+
+	accountIdentifier         string
+	putQueryFormat            string
+	defaultStageFileExtension string
+	privateKey                *rsa.PrivateKey
+	publicKeyFingerprint      string
+	dsn                       string
+
+	connMut       sync.Mutex
+	uuidGenerator uuidGenI
+	httpClient    httpClientI
+	nowFn         func() time.Time
+	db            dbI
+}
+
+func newSnowflakeWriterFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (*snowflakeWriter, error) {
+	s := snowflakeWriter{
+		logger:        mgr.Logger(),
+		uuidGenerator: uuid.NewGen(),
+		httpClient:    http.DefaultClient,
+		nowFn:         time.Now,
+	}
+
+	var err error
+
+	s.account, err = conf.FieldString("account")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse account: %w", err)
+	}
+
+	s.accountIdentifier = s.account
+
+	if conf.Contains("region") {
+		var region string
+		region, err = conf.FieldString("region")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse region: %w", err)
+		}
+		s.accountIdentifier += "." + region
+	}
+
+	if conf.Contains("cloud") {
+		var cloud string
+		cloud, err = conf.FieldString("cloud")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cloud: %w", err)
+		}
+		s.accountIdentifier += "." + cloud
+	}
+
+	s.user, err = conf.FieldString("user")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse user: %w", err)
+	}
+
+	var password string
+	if conf.Contains("password") {
+		password, err = conf.FieldString("password")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse password: %w", err)
+		}
+	}
+
+	var role string
+	role, err = conf.FieldString("role")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse role: %w", err)
+	}
+
+	s.database, err = conf.FieldString("database")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse database: %w", err)
+	}
+
+	var warehouse string
+	warehouse, err = conf.FieldString("warehouse")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse warehouse: %w", err)
+	}
+
+	s.schema, err = conf.FieldString("schema")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse schema: %w", err)
+	}
+
+	s.stage, err = conf.FieldInterpolatedString("stage")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse stage: %w", err)
+	}
+
+	s.path, err = conf.FieldInterpolatedString("path")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse path: %w", err)
+	}
+
+	s.fileName, err = conf.FieldInterpolatedString("file_name")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse file_name: %w", err)
+	}
+
+	s.fileExtension, err = conf.FieldInterpolatedString("file_extension")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse file_extension: %w", err)
+	}
+
+	var uploadParallelThreads int
+	uploadParallelThreads, err = conf.FieldInt("upload_parallel_threads")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse stage: %w", err)
+	}
+
+	compressionStr, err := conf.FieldString("compression")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse compression: %w", err)
+	}
+
+	compression := CompressionType(compressionStr)
+	var autoCompress, sourceCompression string
+	switch compression {
+	case CompressionTypeNone:
+		s.defaultStageFileExtension = "json"
+		autoCompress = "FALSE"
+		sourceCompression = "NONE"
+	case CompressionTypeAuto:
+		s.defaultStageFileExtension = "gz"
+		autoCompress = "TRUE"
+		sourceCompression = "AUTO_DETECT"
+	case CompressionTypeGzip:
+		s.defaultStageFileExtension = "gz"
+		autoCompress = "FALSE"
+		sourceCompression = "GZIP"
+	case CompressionTypeDeflate:
+		s.defaultStageFileExtension = "deflate"
+		autoCompress = "FALSE"
+		sourceCompression = string(compression)
+	case CompressionTypeRawDeflate:
+		s.defaultStageFileExtension = "raw_deflate"
+		autoCompress = "FALSE"
+		sourceCompression = string(compression)
+	case CompressionTypeZstandard:
+		s.defaultStageFileExtension = "zst"
+		autoCompress = "FALSE"
+		sourceCompression = string(compression)
+	default:
+		return nil, fmt.Errorf("unrecognized compression type: %s", compression)
+	}
+
+	s.putQueryFormat = fmt.Sprintf("PUT file://%%s %%s AUTO_COMPRESS = %s SOURCE_COMPRESSION = %s PARALLEL=%d", autoCompress, sourceCompression, uploadParallelThreads)
+
+	s.requestID, err = conf.FieldInterpolatedString("request_id")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse request_id: %w", err)
+	}
+
+	if conf.Contains("snowpipe") {
+		s.snowpipe, err = conf.FieldInterpolatedString("snowpipe")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse snowpipe: %w", err)
+		}
+	}
+
+	authenticator := gosnowflake.AuthTypeJwt
+	if password == "" {
+		var privateKeyFile string
+		privateKeyFile, err = conf.FieldString("private_key_file")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse private_key_file: %w", err)
+		}
+
+		var privateKeyPass string
+		if conf.Contains("private_key_pass") {
+			privateKeyPass, err = conf.FieldString("private_key_pass")
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse private_key_pass: %w", err)
+			}
+		}
+
+		s.privateKey, err = getPrivateKey(mgr.FS(), privateKeyFile, privateKeyPass)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read private key: %w", err)
+		}
+
+		s.publicKeyFingerprint, err = calculatePublicKeyFingerprint(s.privateKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate public key fingerprint: %w", err)
+		}
+	} else {
+		authenticator = gosnowflake.AuthTypeSnowflake
+	}
+
+	var params map[string]*string
+	clientSessionKeepAlive, err := conf.FieldBool("client_session_keep_alive")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse client_session_keep_alive: %w", err)
+	}
+	if clientSessionKeepAlive {
+		params = make(map[string]*string)
+		value := "true"
+		params["client_session_keep_alive"] = &value
+	}
+
+	s.dsn, err = gosnowflake.DSN(&gosnowflake.Config{
+		Account:       s.accountIdentifier,
+		Password:      password,
+		Authenticator: authenticator,
+		User:          s.user,
+		Role:          role,
+		Database:      s.database,
+		Warehouse:     warehouse,
+		Schema:        s.schema,
+		PrivateKey:    s.privateKey,
+		Params:        params,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct DSN: %w", err)
+	}
+
+	return &s, nil
+}
+
+//------------------------------------------------------------------------------
+
+func (s *snowflakeWriter) Connect(_ context.Context) error {
+	var err error
+	s.db, err = sql.Open("snowflake", s.dsn)
+	if err != nil {
+		return fmt.Errorf("failed to connect to snowflake: %w", err)
+	}
+
+	return nil
+}
+
+// createJWT creates a new Snowpipe JWT token
+// Inspired from https://stackoverflow.com/questions/63598044/snowpipe-rest-api-returning-always-invalid-jwt-token
+func (s *snowflakeWriter) createJWT() (string, error) {
+	qualifiedUsername := strings.ToUpper(s.account + "." + s.user)
+	now := s.nowFn().UTC()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": qualifiedUsername + "." + s.publicKeyFingerprint,
+		"sub": qualifiedUsername,
+		"iat": now.Unix(),
+		"exp": now.Add(defaultJWTTimeout).Unix(),
+	})
+
+	return token.SignedString(s.privateKey)
+}
+
+func (s *snowflakeWriter) getSnowpipeInsertURL(snowpipe string, requestID string) string {
+	query := url.Values{"requestId": []string{requestID}}
+	u := url.URL{
+		Scheme:   "https",
+		Host:     s.accountIdentifier + ".snowflakecomputing.com",
+		Path:     path.Join("/v1/data/pipes", fmt.Sprintf("%s.%s.%s", s.database, s.schema, snowpipe), "insertFiles"),
+		RawQuery: query.Encode(),
+	}
+	return u.String()
+}
+
+func (s *snowflakeWriter) callSnowpipe(ctx context.Context, snowpipe string, requestID string, filePath string) error {
+	jwtToken, err := s.createJWT()
+	if err != nil {
+		return fmt.Errorf("failed to create Snowpipe JWT token: %w", err)
+	}
+
+	type File struct {
+		Path string `json:"path"`
+	}
+	reqPayload := struct {
+		Files []File `json:"files"`
+	}{
+		Files: []File{
+			{
+				Path: filePath,
+			},
+		},
+	}
+
+	buf := bytes.Buffer{}
+	err = json.NewEncoder(&buf).Encode(reqPayload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body JSON: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.getSnowpipeInsertURL(snowpipe, requestID), &buf)
+	if err != nil {
+		return fmt.Errorf("failed to create Snowpipe HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute Snowpipe HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("received unexpected Snowpipe response status: %d", resp.StatusCode)
+	}
+
+	var respPayload struct {
+		ResponseCode string
+	}
+	err = json.NewDecoder(resp.Body).Decode(&respPayload)
+	if err != nil {
+		return fmt.Errorf("failed to decode Snowpipe HTTP response: %w", err)
+	}
+	if respPayload.ResponseCode != "SUCCESS" {
+		return fmt.Errorf("received unexpected Snowpipe response code: %s", respPayload.ResponseCode)
+	}
+
+	return nil
+}
+
+func (s *snowflakeWriter) WriteBatch(ctx context.Context, batch service.MessageBatch) error {
+	s.connMut.Lock()
+	defer s.connMut.Unlock()
+	if s.db == nil {
+		return service.ErrNotConnected
+	}
+
+	type file struct {
+		stage         string
+		stagePath     string
+		fileName      string
+		fileExtension string
+		requestID     string
+		snowpipe      string
+	}
+
+	files := map[file][]byte{}
+	for _, msg := range batch {
+		var (
+			f   file
+			err error
+		)
+
+		f.stage, err = s.stage.TryString(msg)
+		if err != nil {
+			return fmt.Errorf("failed to get stage: %w", err)
+		}
+		if f.stage == "" {
+			return fmt.Errorf("stage cannot be empty: %w", err)
+		}
+
+		f.stagePath, err = s.path.TryString(msg)
+		if err != nil {
+			return fmt.Errorf("failed to get stage path: %w", err)
+		}
+
+		f.requestID, err = s.requestID.TryString(msg)
+		if err != nil {
+			return fmt.Errorf("failed to get request ID: %w", err)
+		}
+
+		f.fileName, err = s.fileName.TryString(msg)
+		if err != nil {
+			return fmt.Errorf("failed to get file: %w", err)
+		}
+
+		f.fileExtension, err = s.fileExtension.TryString(msg)
+		if err != nil {
+			return fmt.Errorf("failed to get file extension: %w", err)
+		}
+		if f.fileExtension == "" {
+			f.fileExtension = s.defaultStageFileExtension
+		}
+
+		if s.snowpipe != nil {
+			f.snowpipe, err = s.snowpipe.TryString(msg)
+			if err != nil {
+				return fmt.Errorf("failed to get snowpipe: %w", err)
+			}
+		}
+
+		msgBytes, err := msg.AsBytes()
+		if err != nil {
+			return fmt.Errorf("failed to get message bytes: %w", err)
+		}
+
+		files[f] = append(files[f], msgBytes...)
+	}
+
+	for f, fBytes := range files {
+		requestID := f.requestID
+		if requestID == "" {
+			uuid, err := s.uuidGenerator.NewV4()
+			if err != nil {
+				return fmt.Errorf("failed to generate requestID: %w", err)
+			}
+
+			requestID = uuid.String()
+		}
+
+		fileName := f.fileName
+		if fileName == "" {
+			fileName = requestID
+		}
+
+		filePath := path.Join(f.stagePath, fileName+"."+f.fileExtension)
+
+		_, err := s.db.ExecContext(gosnowflake.WithFileStream(
+			gosnowflake.WithFileTransferOptions(ctx, &gosnowflake.SnowflakeFileTransferOptions{RaisePutGetError: true}),
+			bytes.NewReader(fBytes)), fmt.Sprintf(s.putQueryFormat, filePath, path.Join(f.stage, f.stagePath)))
+		if err != nil {
+			return fmt.Errorf("failed to run query: %w", err)
+		}
+
+		if f.snowpipe != "" {
+			s.logger.Debugf("Calling Snowpipe with requestId=%s", requestID)
+
+			err = s.callSnowpipe(ctx, f.snowpipe, requestID, filePath)
+			if err != nil {
+				return fmt.Errorf("failed to call Snowpipe: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *snowflakeWriter) Close(_ context.Context) error {
+	s.connMut.Lock()
+	defer s.connMut.Unlock()
+
+	return s.db.Close()
+}

--- a/snowflake_put_plugin/output_snowflake_put_test.go
+++ b/snowflake_put_plugin/output_snowflake_put_test.go
@@ -273,7 +273,7 @@ snowpipe: '` + tc.snowpipe + `'
 			keyKind:           keyEncrypted,
 			stage:             "@test_stage",
 			compression:       "NONE",
-			errConfigContains: "failed to read private key: private key requires a passphrase, but private_key_passphrase was not supplied",
+			errConfigContains: "failed to read private key: private key requires a passphrase, but private_key_pass was not supplied",
 		},
 		{
 			name:         "executes snowflake query without compression",

--- a/snowflake_put_plugin/output_snowflake_put_test.go
+++ b/snowflake_put_plugin/output_snowflake_put_test.go
@@ -1,0 +1,473 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// Portions of this file are derived from the warpstreamlabs/bento project:
+//   https://github.com/warpstreamlabs/bento/blob/main/internal/impl/snowflake/output_snowflake_put_test.go
+//
+// Original work Copyright (c) 2024-present Bento contributors, licensed under
+// the MIT License. A copy of the MIT License is reproduced in NOTICE.
+// -----------------------------------------------------------------------------
+
+package snowflake_put_plugin
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"database/sql"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/youmark/pkcs8"
+)
+
+const (
+	dummyUUID         = "12345678-90ab-cdef-1234-567890abcdef"
+	testKeyPassphrase = "test123"
+)
+
+// keyKind selects which generated private key a test case uses.
+type keyKind int
+
+const (
+	keyNone keyKind = iota
+	keyPlaintext
+	keyEncrypted
+	keyMissing
+)
+
+// Generated once in TestMain so no private keys are committed to the repo.
+var (
+	testPrivateKey       *rsa.PrivateKey
+	testPlaintextKeyPath string
+	testEncryptedKeyPath string
+	testMissingKeyPath   string
+)
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "snowflake_keys")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	testPrivateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	plainDER, err := x509.MarshalPKCS8PrivateKey(testPrivateKey)
+	if err != nil {
+		panic(err)
+	}
+	testPlaintextKeyPath = filepath.Join(dir, "rsa_key.pem")
+	writePEM(testPlaintextKeyPath, "PRIVATE KEY", plainDER)
+
+	encDER, err := pkcs8.MarshalPrivateKey(testPrivateKey, []byte(testKeyPassphrase), nil)
+	if err != nil {
+		panic(err)
+	}
+	testEncryptedKeyPath = filepath.Join(dir, "rsa_key.p8")
+	writePEM(testEncryptedKeyPath, "ENCRYPTED PRIVATE KEY", encDER)
+
+	testMissingKeyPath = filepath.Join(dir, "missing_key.pem")
+
+	os.Exit(m.Run())
+}
+
+func writePEM(path string, blockType string, der []byte) {
+	f, err := os.Create(path)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	err = pem.Encode(f, &pem.Block{Type: blockType, Bytes: der})
+	if err != nil {
+		panic(err)
+	}
+}
+
+type MockDB struct {
+	Queries      []string
+	QueriesCount int
+}
+
+func (db *MockDB) ExecContext(_ context.Context, query string, _ ...any) (sql.Result, error) {
+	db.Queries = append(db.Queries, query)
+	db.QueriesCount++
+
+	return nil, nil
+}
+
+func (db *MockDB) Close() error { return nil }
+
+func (db *MockDB) hasQuery(query string) bool {
+	return slices.Contains(db.Queries, query)
+}
+
+type MockUUIDGenerator struct{}
+
+func (MockUUIDGenerator) NewV4() (uuid.UUID, error) {
+	return uuid.Must(uuid.FromString(dummyUUID)), nil
+}
+
+type MockHTTPClient struct {
+	SnowpipeHost string
+	Queries      []string
+	QueriesCount int
+	Payloads     []string
+	JWTs         []string
+}
+
+func (c *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	req.URL.Host = c.SnowpipeHost
+	req.URL.Scheme = "http"
+
+	query := req.URL.Path
+	query += "?" + req.URL.RawQuery
+	c.Queries = append(c.Queries, query)
+	c.QueriesCount++
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	c.Payloads = append(c.Payloads, strings.TrimSpace(string(bodyBytes)))
+
+	c.JWTs = append(c.JWTs, req.Header.Get("Authorization"))
+
+	return http.DefaultClient.Do(req)
+}
+
+func (c *MockHTTPClient) hasQuery(query string) bool {
+	return slices.Contains(c.Queries, query)
+}
+
+func (c *MockHTTPClient) hasPayload(payload string) bool {
+	return slices.Contains(c.Payloads, payload)
+}
+
+func TestSnowflakeOutput(t *testing.T) {
+	type testCase struct {
+		name                      string
+		keyKind                   keyKind
+		privateKeyPassphrase      string
+		stage                     string
+		fileName                  string
+		fileExtension             string
+		requestID                 string
+		snowpipe                  string
+		compression               string
+		snowflakeHTTPResponseCode int
+		snowflakeResponseCode     string
+		wantPUTQuery              string
+		wantPUTQueriesCount       int
+		wantSnowpipeQuery         string
+		wantSnowpipeQueriesCount  int
+		wantSnowpipePayload       string
+		errConfigContains         string
+		errContains               string
+	}
+
+	keyPath := func(tc testCase) string {
+		switch tc.keyKind {
+		case keyPlaintext:
+			return testPlaintextKeyPath
+		case keyEncrypted:
+			return testEncryptedKeyPath
+		case keyMissing:
+			return testMissingKeyPath
+		default:
+			return ""
+		}
+	}
+
+	getSnowflakeWriter := func(t *testing.T, tc testCase) (*snowflakeWriter, error) {
+		t.Helper()
+
+		outputConfig := `
+account: bento
+region: east-us-2
+cloud: azure
+user: foobar
+private_key_file: ` + keyPath(tc) + `
+private_key_pass: ` + tc.privateKeyPassphrase + `
+role: test_role
+database: test_db
+warehouse: test_warehouse
+schema: test_schema
+path: foo/bar/baz
+stage: '` + tc.stage + `'
+file_name: '` + tc.fileName + `'
+file_extension: '` + tc.fileExtension + `'
+upload_parallel_threads: 42
+compression: ` + tc.compression + `
+request_id: '` + tc.requestID + `'
+snowpipe: '` + tc.snowpipe + `'
+`
+
+		spec := snowflakePutOutputConfig()
+		env := service.NewEnvironment()
+		conf, err := spec.ParseYAML(outputConfig, env)
+		require.NoError(t, err)
+
+		return newSnowflakeWriterFromConfig(conf, service.MockResources())
+	}
+
+	tests := []testCase{
+		{
+			name:         "executes snowflake query with plaintext SSH key",
+			keyKind:      keyPlaintext,
+			stage:        "@test_stage",
+			compression:  "NONE",
+			wantPUTQuery: "PUT file://foo/bar/baz/" + dummyUUID + ".json @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = NONE PARALLEL=42",
+		},
+		{
+			name:                 "executes snowflake query with encrypted SSH key",
+			keyKind:              keyEncrypted,
+			privateKeyPassphrase: testKeyPassphrase,
+			stage:                "@test_stage",
+			compression:          "NONE",
+			wantPUTQuery:         "PUT file://foo/bar/baz/" + dummyUUID + ".json @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = NONE PARALLEL=42",
+		},
+		{
+			name:              "fails to read missing SSH key",
+			keyKind:           keyMissing,
+			stage:             "@test_stage",
+			compression:       "NONE",
+			errConfigContains: "no such file or directory",
+		},
+		{
+			name:              "fails to read encrypted SSH key without passphrase",
+			keyKind:           keyEncrypted,
+			stage:             "@test_stage",
+			compression:       "NONE",
+			errConfigContains: "failed to read private key: private key requires a passphrase, but private_key_passphrase was not supplied",
+		},
+		{
+			name:         "executes snowflake query without compression",
+			keyKind:      keyPlaintext,
+			stage:        "@test_stage",
+			compression:  "NONE",
+			wantPUTQuery: "PUT file://foo/bar/baz/" + dummyUUID + ".json @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = NONE PARALLEL=42",
+		},
+		{
+			name:         "executes snowflake query with automatic compression",
+			keyKind:      keyPlaintext,
+			stage:        "@test_stage",
+			compression:  "AUTO",
+			wantPUTQuery: "PUT file://foo/bar/baz/" + dummyUUID + ".gz @test_stage/foo/bar/baz AUTO_COMPRESS = TRUE SOURCE_COMPRESSION = AUTO_DETECT PARALLEL=42",
+		},
+		{
+			name:         "executes snowflake query with gzip compression",
+			keyKind:      keyPlaintext,
+			stage:        "@test_stage",
+			compression:  "GZIP",
+			wantPUTQuery: "PUT file://foo/bar/baz/" + dummyUUID + ".gz @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = GZIP PARALLEL=42",
+		},
+		{
+			name:         "executes snowflake query with DEFLATE compression",
+			keyKind:      keyPlaintext,
+			stage:        "@test_stage",
+			compression:  "DEFLATE",
+			wantPUTQuery: "PUT file://foo/bar/baz/" + dummyUUID + ".deflate @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = DEFLATE PARALLEL=42",
+		},
+		{
+			name:         "executes snowflake query with RAW_DEFLATE compression",
+			keyKind:      keyPlaintext,
+			stage:        "@test_stage",
+			compression:  "RAW_DEFLATE",
+			wantPUTQuery: "PUT file://foo/bar/baz/" + dummyUUID + ".raw_deflate @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = RAW_DEFLATE PARALLEL=42",
+		},
+		{
+			name:          "handles file name and file extension interpolation",
+			keyKind:       keyPlaintext,
+			stage:         "@test_stage",
+			fileName:      `${! "deadbeef" }`,
+			fileExtension: `${! "parquet" }`,
+			compression:   "NONE",
+			wantPUTQuery:  "PUT file://foo/bar/baz/deadbeef.parquet @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = NONE PARALLEL=42",
+		},
+		{
+			name:                      "executes snowflake query and calls Snowpipe",
+			keyKind:                   keyPlaintext,
+			stage:                     "@test_stage",
+			snowpipe:                  "test_pipe",
+			compression:               "NONE",
+			snowflakeHTTPResponseCode: http.StatusOK,
+			snowflakeResponseCode:     "SUCCESS",
+			wantPUTQuery:              "PUT file://foo/bar/baz/" + dummyUUID + ".json @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = NONE PARALLEL=42",
+			wantPUTQueriesCount:       1,
+			wantSnowpipeQuery:         "/v1/data/pipes/test_db.test_schema.test_pipe/insertFiles?requestId=" + dummyUUID,
+			wantSnowpipeQueriesCount:  1,
+			wantSnowpipePayload:       `{"files":[{"path":"foo/bar/baz/` + dummyUUID + `.json"}]}`,
+		},
+		{
+			name:                      "gets error code from Snowpipe",
+			keyKind:                   keyPlaintext,
+			stage:                     "@test_stage",
+			snowpipe:                  "test_pipe",
+			compression:               "NONE",
+			snowflakeHTTPResponseCode: http.StatusOK,
+			snowflakeResponseCode:     "FAILURE",
+			errContains:               "received unexpected Snowpipe response code: FAILURE",
+		},
+		{
+			name:                      "gets http error from Snowpipe",
+			keyKind:                   keyPlaintext,
+			stage:                     "@test_stage",
+			snowpipe:                  "test_pipe",
+			compression:               "NONE",
+			snowflakeHTTPResponseCode: http.StatusTeapot,
+			errContains:               "received unexpected Snowpipe response status: 418",
+		},
+		{
+			name:                "handles stage interpolation and runs a query for each sub-batch",
+			keyKind:             keyPlaintext,
+			stage:               `@test_stage_${! json("id") }`,
+			compression:         "NONE",
+			wantPUTQueriesCount: 2,
+			wantPUTQuery:        "PUT file://foo/bar/baz/" + dummyUUID + ".json @test_stage_bar/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = NONE PARALLEL=42",
+		},
+		{
+			name:                      "handles Snowpipe interpolation and runs a query for each sub-batch",
+			keyKind:                   keyPlaintext,
+			stage:                     "@test_stage",
+			snowpipe:                  `test_pipe_${! json("id") }`,
+			compression:               "NONE",
+			snowflakeHTTPResponseCode: http.StatusOK,
+			snowflakeResponseCode:     "SUCCESS",
+			wantPUTQuery:              "PUT file://foo/bar/baz/" + dummyUUID + ".json @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = NONE PARALLEL=42",
+			wantPUTQueriesCount:       2,
+			wantSnowpipeQuery:         "/v1/data/pipes/test_db.test_schema.test_pipe_bar/insertFiles?requestId=" + dummyUUID,
+			wantSnowpipeQueriesCount:  2,
+			wantSnowpipePayload:       `{"files":[{"path":"foo/bar/baz/` + dummyUUID + `.json"}]}`,
+		},
+		{
+			name:                      "handles request_id interpolation and runs a query and makes a single Snowpipe call for the entire batch",
+			keyKind:                   keyPlaintext,
+			stage:                     `@test_stage`,
+			snowpipe:                  `test_pipe`,
+			requestID:                 `${! "deadbeef" }`,
+			compression:               "NONE",
+			snowflakeHTTPResponseCode: http.StatusOK,
+			snowflakeResponseCode:     "SUCCESS",
+			wantPUTQuery:              "PUT file://foo/bar/baz/deadbeef.json @test_stage/foo/bar/baz AUTO_COMPRESS = FALSE SOURCE_COMPRESSION = NONE PARALLEL=42",
+			wantPUTQueriesCount:       1,
+			wantSnowpipeQuery:         "/v1/data/pipes/test_db.test_schema.test_pipe/insertFiles?requestId=deadbeef",
+			wantSnowpipeQueriesCount:  1,
+			wantSnowpipePayload:       `{"files":[{"path":"foo/bar/baz/deadbeef.json"}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s, err := getSnowflakeWriter(t, test)
+			if test.errConfigContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.errConfigContains)
+				return
+			}
+			require.NoError(t, err)
+
+			s.uuidGenerator = MockUUIDGenerator{}
+
+			snowpipeTestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.snowflakeHTTPResponseCode)
+				_, _ = w.Write([]byte(`{"ResponseCode": "` + test.snowflakeResponseCode + `"}`))
+			}))
+			t.Cleanup(snowpipeTestServer.Close)
+
+			mockHTTPClient := MockHTTPClient{
+				SnowpipeHost: snowpipeTestServer.Listener.Addr().String(),
+			}
+			s.httpClient = &mockHTTPClient
+
+			mockDB := MockDB{}
+			s.db = &mockDB
+
+			err = s.WriteBatch(context.Background(), service.MessageBatch{
+				service.NewMessage([]byte(`{"id":"foo","content":"foo stuff"}`)),
+				service.NewMessage([]byte(`{"id":"bar","content":"bar stuff"}`)),
+			})
+			if test.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.errContains)
+				return
+			}
+			require.NoError(t, err)
+
+			if test.wantPUTQueriesCount > 0 {
+				assert.Equal(t, test.wantPUTQueriesCount, mockDB.QueriesCount)
+			}
+			if test.wantPUTQuery != "" {
+				assert.True(t, mockDB.hasQuery(test.wantPUTQuery))
+			}
+			if test.wantSnowpipeQueriesCount > 0 {
+				assert.Equal(t, test.wantSnowpipeQueriesCount, mockHTTPClient.QueriesCount)
+				assert.Len(t, mockHTTPClient.JWTs, test.wantSnowpipeQueriesCount)
+				// JWTs are signed with the ephemeral key generated in TestMain, so verify
+				// them structurally rather than against a hardcoded token.
+				for _, raw := range mockHTTPClient.JWTs {
+					assertValidSnowpipeJWT(t, raw)
+				}
+			}
+			if test.wantSnowpipeQuery != "" {
+				assert.True(t, mockHTTPClient.hasQuery(test.wantSnowpipeQuery))
+			}
+			if test.wantSnowpipePayload != "" {
+				assert.True(t, mockHTTPClient.hasPayload(test.wantSnowpipePayload))
+			}
+		})
+	}
+}
+
+// assertValidSnowpipeJWT verifies the bearer token is signed by the generated
+// key and carries the expected issuer/subject claims.
+func assertValidSnowpipeJWT(t *testing.T, authHeader string) {
+	t.Helper()
+
+	tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+	claims := jwt.MapClaims{}
+	token, err := jwt.ParseWithClaims(tokenStr, claims, func(_ *jwt.Token) (any, error) {
+		return &testPrivateKey.PublicKey, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, token.Valid)
+
+	// account="bento", user="foobar" -> uppercased "BENTO.FOOBAR".
+	sub, _ := claims["sub"].(string)
+	iss, _ := claims["iss"].(string)
+	assert.Equal(t, "BENTO.FOOBAR", sub)
+	assert.True(t, strings.HasPrefix(iss, "BENTO.FOOBAR.SHA256:"))
+}

--- a/snowflake_put_plugin/output_snowflake_put_test.go
+++ b/snowflake_put_plugin/output_snowflake_put_test.go
@@ -16,8 +16,9 @@
 // Portions of this file are derived from the warpstreamlabs/bento project:
 //   https://github.com/warpstreamlabs/bento/blob/main/internal/impl/snowflake/output_snowflake_put_test.go
 //
-// Original work Copyright (c) 2024-present Bento contributors, licensed under
-// the MIT License. A copy of the MIT License is reproduced in NOTICE.
+// Original work Copyright (c) 2020-2024 Ashley Jeffs and
+// Copyright (c) 2024-present Bento contributors, licensed under the MIT License.
+// A copy of the MIT License is reproduced in NOTICE.
 // -----------------------------------------------------------------------------
 
 package snowflake_put_plugin

--- a/snowflake_put_plugin/snowflake_put_suite_test.go
+++ b/snowflake_put_plugin/snowflake_put_suite_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snowflake_put_plugin_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// TestSnowflakePut registers a Ginkgo suite so `make test` (`ginkgo -r`) discovers
+// this package alongside the vendored stdlib `testing.T` cases in
+// output_snowflake_put_test.go. Do not migrate the ported tests to Ginkgo —
+// keeping them stdlib preserves the faithful upstream-bento port.
+func TestSnowflakePut(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SnowflakePut Suite")
+}


### PR DESCRIPTION
# Description

This PR introduces the `snowflake_put` plugin, which is taken from [bento-repository](https://github.com/warpstreamlabs/bento). Credits for this can be found in the `NOTICE` as well as in the `README.md`. 

It is kindly adjusted due to our linting restrictions and uses included tests as well as the key-generation. This is only used for functional testing and we want to exclude them from our repository. As they don't have any infrastructural access or sth like this we decide to simply generate ephemeral keys here for testing purpose. Could change at a later stage whenever we might introduce snowflake-testing.


On top of that it needed adjustments to work with the original benthos-cli, where we wrap around with our custom plugins. That's the reason we couldn't directly import it from there and just use it as a reference from the bento-repository.


### Outlook

At a certain time we could potentially set up a testing pipeline using a full snowflake integration for CI, but currently not needed as the impact / request is not that high.


### Follow-Up

As a follow-up we need to

- [ ] add a template to ManagementConsole 
- [ ] test functinality within a full-fletched snowflake setup
- [ ] get feedback from VE regarding the usage of the plugin vs. `sql_insert`

Part of ENG-4903 (rollout)
Fixes ENG-5061