### PR TITLE
ci: add Beckhoff ADS test workflow (2/5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       opcua: ${{ steps.filter.outputs.opcua }}
       modbus: ${{ steps.filter.outputs.modbus }}
       s7: ${{ steps.filter.outputs.s7 }}
+      ads: ${{ steps.filter.outputs.ads }}
       sparkplug: ${{ steps.filter.outputs.sparkplug }}
       eip: ${{ steps.filter.outputs.eip }}
       sensorconnect: ${{ steps.filter.outputs.sensorconnect }}
@@ -68,6 +69,9 @@ jobs:
             s7:
               - 's7comm_plugin/**'
               - '!s7comm_plugin/**/*.md'
+            ads:
+              - 'beckhoff_ads_plugin/**'
+              - '!beckhoff_ads_plugin/**/*.md'
             sparkplug:
               - 'sparkplug_plugin/**'
               - '!sparkplug_plugin/**/*.md'
@@ -196,6 +200,17 @@ jobs:
       test_plc: ${{ needs.detect-changes.outputs.test_plc == 'true' }}
     secrets: inherit
 
+  test-ads:
+    needs: [detect-changes, lint]
+    if: |
+      always() &&
+      needs.lint.result == 'success' &&
+      (needs.detect-changes.outputs.ads == 'true' ||
+       needs.detect-changes.outputs.gomod == 'true' ||
+       needs.detect-changes.outputs.cmd == 'true')
+    uses: ./.github/workflows/test-ads.yml
+    secrets: inherit
+
   test-sparkplug:
     needs: [detect-changes, lint]
     if: |
@@ -322,6 +337,7 @@ jobs:
       - test-opcua
       - test-modbus
       - test-s7
+      - test-ads
       - test-sparkplug
       - test-eip
       - test-sensorconnect

--- a/.github/workflows/test-ads.yml
+++ b/.github/workflows/test-ads.yml
@@ -1,0 +1,144 @@
+# Copyright 2026 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Test ADS
+
+on:
+  workflow_call:
+
+# TODO: Add the following GitHub secrets before enabling PLC tests:
+#   TEST_ADS_TC3_TARGET_IP      - IP address of the TwinCAT 3 PLC (e.g. 192.168.1.100)
+#   TEST_ADS_TC3_TARGET_AMS     - AMS Net ID of the TwinCAT 3 PLC (e.g. 192.168.1.100.1.1)
+#   TEST_ADS_TC3_ROUTE_USERNAME - PLC admin username for automatic route registration
+#   TEST_ADS_TC3_ROUTE_PASSWORD - PLC admin password for automatic route registration
+#   TEST_ADS_TC2_TARGET_IP      - IP address of the TwinCAT 2 PLC (optional, for TC2 tests)
+#   TEST_ADS_TC2_TARGET_AMS     - AMS Net ID of the TwinCAT 2 PLC (optional, for TC2 tests)
+#   TEST_ADS_TC2_ROUTE_USERNAME - PLC admin username for TC2 route registration (optional)
+#   TEST_ADS_TC2_ROUTE_PASSWORD - PLC admin password for TC2 route registration (optional)
+
+jobs:
+  test:
+    name: ADS Unittest
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Install Ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Test
+        env:
+          TEST_ADS_UNITTEST: true
+        run: make test-ads
+
+  test-plc-tc3:
+    name: ADS TwinCAT 3 PLC
+    needs: [test]
+    concurrency:
+      group: ads-tc3-plc
+      cancel-in-progress: false
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Install Ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Install Tcping
+        run: go install github.com/cloverstd/tcping@v0.1.1
+
+      - name: Check ADS TC3 port availability
+        id: check_ads_tc3
+        run: |
+          set +x
+          TARGET_IP="${{ secrets.TEST_ADS_TC3_TARGET_IP }}"
+          if [ -z "$TARGET_IP" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "TEST_ADS_TC3_TARGET_IP secret not configured"
+            exit 0
+          fi
+          if tcping -c 4 -T 1s "$TARGET_IP" 48898 | grep -qi "Connected"; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "ADS TC3 PLC reachable at $TARGET_IP:48898"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "ADS TC3 PLC not reachable at $TARGET_IP:48898"
+          fi
+
+      - name: Test
+        if: ${{ steps.check_ads_tc3.outputs.available == 'true' }}
+        env:
+          TEST_ADS_UNITTEST: true
+          TEST_ADS_TC3_TARGET_IP: ${{ secrets.TEST_ADS_TC3_TARGET_IP }}
+          TEST_ADS_TC3_TARGET_AMS: ${{ secrets.TEST_ADS_TC3_TARGET_AMS }}
+          TEST_ADS_TC3_RUNTIME_PORT: 851
+        run: make test-ads
+
+      - name: Skip notice
+        if: ${{ steps.check_ads_tc3.outputs.available != 'true' }}
+        run: echo "Skipping ADS TC3 PLC tests - device not available"
+
+  test-plc-tc2:
+    name: ADS TwinCAT 2 PLC
+    needs: [test]
+    concurrency:
+      group: ads-tc2-plc
+      cancel-in-progress: false
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Install Ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
+      - name: Install Tcping
+        run: go install github.com/cloverstd/tcping@v0.1.1
+
+      - name: Check ADS TC2 port availability
+        id: check_ads_tc2
+        run: |
+          set +x
+          TARGET_IP="${{ secrets.TEST_ADS_TC2_TARGET_IP }}"
+          if [ -z "$TARGET_IP" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "TEST_ADS_TC2_TARGET_IP secret not configured"
+            exit 0
+          fi
+          if tcping -c 4 -T 1s "$TARGET_IP" 48898 | grep -qi "Connected"; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "ADS TC2 PLC reachable at $TARGET_IP:48898"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "ADS TC2 PLC not reachable at $TARGET_IP:48898"
+          fi
+
+      - name: Test
+        if: ${{ steps.check_ads_tc2.outputs.available == 'true' }}
+        env:
+          TEST_ADS_UNITTEST: true
+          TEST_ADS_TC2_TARGET_IP: ${{ secrets.TEST_ADS_TC2_TARGET_IP }}
+          TEST_ADS_TC2_TARGET_AMS: ${{ secrets.TEST_ADS_TC2_TARGET_AMS }}
+          TEST_ADS_TC2_RUNTIME_PORT: 801
+        run: make test-ads
+
+      - name: Skip notice
+        if: ${{ steps.check_ads_tc2.outputs.available != 'true' }}
+        run: echo "Skipping ADS TC2 PLC tests - device not available"

--- a/.github/workflows/test-ads.yml
+++ b/.github/workflows/test-ads.yml
@@ -35,11 +35,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.3
       - name: Test
         env:
           TEST_ADS_UNITTEST: true
@@ -55,19 +55,20 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.3
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
 
       - name: Check ADS TC3 port availability
         id: check_ads_tc3
+        env:
+          TARGET_IP: ${{ secrets.TEST_ADS_TC3_TARGET_IP }}
         run: |
           set +x
-          TARGET_IP="${{ secrets.TEST_ADS_TC3_TARGET_IP }}"
           if [ -z "$TARGET_IP" ]; then
             echo "available=false" >> "$GITHUB_OUTPUT"
             echo "TEST_ADS_TC3_TARGET_IP secret not configured"
@@ -104,19 +105,20 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.3
       - name: Install Tcping
         run: go install github.com/cloverstd/tcping@v0.1.1
 
       - name: Check ADS TC2 port availability
         id: check_ads_tc2
+        env:
+          TARGET_IP: ${{ secrets.TEST_ADS_TC2_TARGET_IP }}
         run: |
           set +x
-          TARGET_IP="${{ secrets.TEST_ADS_TC2_TARGET_IP }}"
           if [ -z "$TARGET_IP" ]; then
             echo "available=false" >> "$GITHUB_OUTPUT"
             echo "TEST_ADS_TC2_TARGET_IP secret not configured"

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,10 @@ test-uns-redpanda:
 test-s7comm:
 	@$(GINKGO_CMD) $(GINKGO_FLAGS) ./s7comm_plugin/...
 
+.PHONY: test-ads
+test-ads:
+	@$(GINKGO_CMD) $(GINKGO_SERIAL_FLAGS) ./beckhoff_ads_plugin/...
+
 .PHONY: test-sensorconnect
 test-sensorconnect:
 	@$(GINKGO_CMD) $(GINKGO_SERIAL_FLAGS) ./sensorconnect_plugin/...

--- a/beckhoff_ads_plugin/ads_input.go
+++ b/beckhoff_ads_plugin/ads_input.go
@@ -1,0 +1,660 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beckhoff_ads_plugin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	adsLib "github.com/RuneRoven/go-ads/v2"
+)
+
+// benthosLogHandler is a slog.Handler that forwards log records to a Benthos service.Logger.
+// This bridges go-ads v2's slog-based logging into Benthos's logging infrastructure.
+type benthosLogHandler struct {
+	logger *service.Logger
+	level  slog.Level
+	attrs  []slog.Attr
+}
+
+func (h *benthosLogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *benthosLogHandler) Handle(_ context.Context, r slog.Record) error {
+	var kvs []any
+	for _, a := range h.attrs {
+		kvs = append(kvs, a.Key, a.Value.Any())
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		kvs = append(kvs, a.Key, a.Value.Any())
+		return true
+	})
+
+	l := h.logger
+	if len(kvs) > 0 {
+		l = l.With(kvs...)
+	}
+
+	switch {
+	case r.Level >= slog.LevelError:
+		l.Errorf("%s", r.Message)
+	case r.Level >= slog.LevelWarn:
+		l.Warnf("%s", r.Message)
+	case r.Level >= slog.LevelInfo:
+		l.Infof("%s", r.Message)
+	default:
+		l.Debugf("%s", r.Message)
+	}
+	return nil
+}
+
+func (h *benthosLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &benthosLogHandler{
+		logger: h.logger,
+		level:  h.level,
+		attrs:  append(h.attrs, attrs...),
+	}
+}
+
+func (h *benthosLogHandler) WithGroup(_ string) slog.Handler {
+	return h
+}
+
+// slogLevelFromString maps the plugin's logLevel config string to a slog.Level.
+// The go-ads v2 library accepts a *slog.Logger via WithLogger, so we create
+// a level-filtered logger per connection instead of mutating global state.
+func slogLevelFromString(level string) slog.Level {
+	switch level {
+	case "trace":
+		return adsLib.LevelTrace
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		// "disabled", "panic", "fatal", and unknown values → suppress all logging
+		// slog has no "off" level; use a level higher than any real log line
+		return slog.Level(100)
+	}
+}
+
+// PlcSymbol holds the configuration for a single PLC symbol to read.
+type PlcSymbol struct {
+	Name      string
+	MaxDelay  time.Duration
+	CycleTime time.Duration
+}
+
+// isLikelyContainerIP checks if an IP address looks like a Docker/container-internal
+// address that is probably not routable from an external PLC network.
+// Docker bridge networks typically use 172.17.0.0/16, 172.18-31.0.0/16, or 10.0.0.0/8.
+// Kubernetes pod networks commonly use 10.x.x.x or 100.64-127.x.x (CGNAT range).
+func isLikelyContainerIP(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	p := parsed.To4()
+	if p == nil {
+		return false
+	}
+	// Docker default bridge: 172.17.0.0/16
+	if p[0] == 172 && p[1] >= 17 && p[1] <= 31 {
+		return true
+	}
+	// Common container overlay/pod networks: 10.0.0.0/8
+	if p[0] == 10 {
+		return true
+	}
+	// CGNAT range used by some Kubernetes CNIs: 100.64.0.0/10
+	if p[0] == 100 && p[1] >= 64 && p[1] <= 127 {
+		return true
+	}
+	return false
+}
+
+// validateIP checks that s is a valid IPv4 address (4 dot-separated octets, each 0–255).
+func validateIP(s string) error {
+	parts := strings.Split(s, ".")
+	if len(parts) != 4 {
+		return fmt.Errorf("%q must have 4 dot-separated octets", s)
+	}
+	for _, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil || v < 0 || v > 255 {
+			return fmt.Errorf("%q contains invalid octet %q (must be 0–255)", s, p)
+		}
+	}
+	return nil
+}
+
+// validateAMSNetID checks that s is a valid AMS NetID (6 dot-separated octets, each 0–255).
+func validateAMSNetID(s string) error {
+	parts := strings.Split(s, ".")
+	if len(parts) != 6 {
+		return fmt.Errorf("%q must have 6 dot-separated octets (e.g. 192.168.1.100.1.1)", s)
+	}
+	for _, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil || v < 0 || v > 255 {
+			return fmt.Errorf("%q contains invalid octet %q (must be 0–255)", s, p)
+		}
+	}
+	return nil
+}
+
+// CreateSymbolList parses a list of symbol strings into PlcSymbol structs.
+//
+// Format: "name[:opt1[:opt2...]]"
+//
+// Each option is either positional (plain integer) or keyed ("key=value").
+// Positional options fill maxDelay then cycleTime in order; keyed options
+// override by name regardless of position. Both forms can be mixed.
+//
+//	"MAIN.var"                           — all defaults
+//	"MAIN.var:50:100"                    — maxDelay=50, cycleTime=100 (positional)
+//	"MAIN.var:50"                        — maxDelay=50, cycleTime=default
+//	"MAIN.var:cycleTime=100"             — maxDelay=default, cycleTime=100
+//	"MAIN.var:50:cycleTime=100"          — maxDelay=50 (positional), cycleTime=100 (key)
+//	"MAIN.var:maxDelay=50:cycleTime=100" — both keyed, any order
+func CreateSymbolList(s []string, defaultCycleTime time.Duration, defaultMaxDelay time.Duration) []PlcSymbol {
+	var result []PlcSymbol
+	for _, symbol := range s {
+		parts := strings.SplitN(symbol, ":", 2)
+		plcSym := PlcSymbol{
+			Name:      parts[0],
+			MaxDelay:  defaultMaxDelay,
+			CycleTime: defaultCycleTime,
+		}
+
+		if len(parts) == 2 {
+			positionalIdx := 0 // 0=maxDelay, 1=cycleTime
+			for _, opt := range strings.Split(parts[1], ":") {
+				if kv := strings.SplitN(opt, "=", 2); len(kv) == 2 {
+					// Keyed option — overrides by name, does not consume positional slot
+					if v, err := strconv.Atoi(kv[1]); err == nil {
+						switch kv[0] {
+						case "maxDelay":
+							plcSym.MaxDelay = time.Duration(v) * time.Millisecond
+						case "cycleTime":
+							plcSym.CycleTime = time.Duration(v) * time.Millisecond
+						}
+					}
+				} else {
+					// Positional option — always advances slot index.
+					// Empty string reserves the slot (keeps default), non-empty sets value.
+					if opt != "" {
+						if v, err := strconv.Atoi(opt); err == nil {
+							switch positionalIdx {
+							case 0:
+								plcSym.MaxDelay = time.Duration(v) * time.Millisecond
+							case 1:
+								plcSym.CycleTime = time.Duration(v) * time.Millisecond
+							}
+						}
+					}
+					positionalIdx++
+				}
+			}
+		}
+
+		result = append(result, plcSym)
+	}
+	return result
+}
+
+// AdsCommInput defines the structure for the Beckhoff ADS Benthos input plugin.
+// It holds the configuration necessary to establish a connection with a Beckhoff PLC,
+// along with the read requests to fetch data from the PLC.
+type AdsCommInput struct {
+	TargetIP         string              // IP address of the PLC.
+	TargetAMS        string              // Target AMS net ID.
+	TargetPort       int                 // Target port
+	RuntimePort      int                 // Target runtime port. Default 801(Twincat 2)
+	HostAMS          string              // The host AMS net ID, auto (default) automatically derives AMS from host IP. Enter manually if auto not working
+	HostPort         int                 // AMS source port (0 = random per session, recommended)
+	ReadType         string              // Read type, interval or notification
+	CycleTime        time.Duration       // Cycle time for notification handler or interval read
+	MaxDelay         time.Duration       // Max delay after value change before PLC sends notification
+	IntervalTime     time.Duration       // Time duration before a connection attempt or read request times out.
+	RequestTimeout   time.Duration       // Timeout for individual ADS requests.
+	Handler          *adsLib.Session     // TCP handler to manage the connection.
+	Log              *service.Logger     // Logger for logging plugin activity.
+	Symbols          []PlcSymbol         // List of items to read from the PLC
+	dataTypes        map[string]string   // configured symbol name → PLC data type (symbolic, e.g. "E_MachineState"), populated on connect
+	baseTypes        map[string]string   // configured symbol name → resolved primitive (e.g. "DINT" for an INT-aliased enum)
+	dataSizes        map[string]uint32   // configured symbol name → PLC reported byte length (STRING=Nbytes, primitives=2/4/8 etc)
+	symbolNames      map[string]string   // strings.ToLower(configured name) → configured name (TC2 returns uppercase)
+	NotificationChan chan *adsLib.Update // notification channel for PLC data
+	TransmissionMode adsLib.TransMode // Notification transmission mode
+
+	// Shutdown signal - closed to signal goroutines to stop.
+	// Used instead of closing NotificationChan to avoid send-on-closed-channel panics
+	// from the go-ads library's notification goroutines.
+	done chan struct{}
+
+	// Route registration settings
+	Username string // PLC route registration username; route registered when both Username and Password are set
+	Password string
+	HostIP   string // IP address the PLC uses to reach this client (auto-detected if empty)
+
+	// adsLogger is the slog.Logger passed to go-ads via WithLogger option.
+	adsLogger *slog.Logger
+}
+
+var adsConf = service.NewConfigSpec().
+	Summary("Creates an input that reads data from Beckhoff PLCs using ADS protocol.").
+	Description("This input plugin enables Benthos to read data directly from Beckhoff PLCs using the ADS protocol. " +
+		"Configure the plugin by specifying the PLC's IP address, runtime port, target AMS net ID, and symbols to read.").
+	// ---- Target connection (required) ----
+	Field(service.NewStringField("targetIP").Description("IP address of the Beckhoff PLC.")).
+	Field(service.NewStringField("targetAMS").Description("AMS net ID of the target PLC runtime (e.g. '192.168.1.100.1.1').")).
+	Field(service.NewIntField("runtimePort").Description("ADS runtime port. TwinCAT 3: 851, TwinCAT 2: 801.").Default(851).Advanced().Examples(851, 801)).
+	Field(service.NewIntField("targetPort").Description("TCP port of the PLC ADS gateway.").Default(48898).Advanced().Examples(48898)).
+	// ---- Local AMS identity ----
+	Field(service.NewStringField("hostAMS").Description("Local AMS net ID sent in ADS requests. 'auto' derives it from the outbound TCP source IP (or hostIP when set).").Default("auto").Advanced().Examples("auto")).
+	Field(service.NewIntField("hostPort").Description("AMS source port in protocol headers. 0 uses a random port per session (recommended). Set fixed only in firewalled environments.").Default(0).Advanced().Examples(0, 10500)).
+	Field(service.NewStringField("hostIP").Description("IP address the PLC uses to reach this client. Required in Docker bridge networking. When hostAMS is auto, derives NetID as hostIP+.1.1.").Default("").Advanced().Examples("192.168.1.50")).
+	// ---- Route registration ----
+	Field(service.NewStringField("username").Description("PLC username for automatic route registration. Both username and password must be set to activate. Requires UDP 48899.").Default("").Advanced().Examples("Administrator")).
+	Field(service.NewStringField("password").Description("PLC password for automatic route registration.").Default("").Advanced().Examples("1")).
+	// ---- Read mode ----
+	Field(service.NewStringEnumField("readType", "notification", "interval").Description("Read type. notification = PLC pushes on change; interval = plugin polls at intervalTime.").Default("notification").Advanced()).
+	Field(service.NewStringEnumField("transmissionMode", "serverOnChange", "serverCycle", "serverOnChange2", "serverCycle2").Description("Notification transmission mode (notification readType only). serverOnChange2/serverCycle2 auto-fall back on older PLCs.").Default("serverOnChange").Advanced()).
+	Field(service.NewDurationField("cycleTime").Description("How often the PLC checks the symbol for changes and delivers notifications. Lower = more responsive but more PLC CPU.").Default("100ms").Advanced().Examples("100ms", "10ms", "500ms", "1s")).
+	Field(service.NewDurationField("maxDelay").Description("Maximum time the PLC batches notifications before sending. All changes are delivered; this controls delivery latency vs network efficiency.").Default("100ms").Advanced().Examples("100ms", "0s", "500ms")).
+	Field(service.NewDurationField("intervalTime").Description("Poll interval for readType interval.").Default("1s").Advanced().Examples("1s", "500ms")).
+	// ---- Advanced ----
+	Field(service.NewDurationField("requestTimeout").Description("Timeout for individual ADS requests.").Default("5s").Advanced().Examples("5s", "10s")).
+	Field(service.NewStringEnumField("logLevel", "disabled", "error", "warn", "info", "debug", "trace").Description("go-ads library log level. error (default) surfaces transport and ADS errors. debug/trace add verbose ADS wire details.").Default("error").Advanced()).
+	// ---- Symbols (list — placed last for readability in YAML) ----
+	Field(service.NewStringListField("symbols").Description("Symbols to read. Format: 'name', 'name:maxDelayMs:cycleTimeMs', or 'name:maxDelay=100ms:cycleTime=100ms'. " +
+		"Examples: 'GVL.counter', 'GVL.trigger:0s:10ms', '.globalVar:maxDelay=0s:cycleTime=50ms'"))
+
+// NewAdsCommInput creates a new ADS input plugin from parsed Benthos configuration.
+func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
+
+	logLevel, err := conf.FieldString("logLevel")
+	if err != nil {
+		return nil, err
+	}
+	adsLogger := slog.New(&benthosLogHandler{
+		logger: mgr.Logger(),
+		level:  slogLevelFromString(logLevel),
+	})
+
+	targetIP, err := conf.FieldString("targetIP")
+	if err != nil {
+		return nil, err
+	}
+
+	targetAMS, err := conf.FieldString("targetAMS")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateIP(targetIP); err != nil {
+		return nil, fmt.Errorf("targetIP: %w", err)
+	}
+	if err := validateAMSNetID(targetAMS); err != nil {
+		return nil, fmt.Errorf("targetAMS: %w", err)
+	}
+
+	targetPort, err := conf.FieldInt("targetPort")
+	if err != nil {
+		return nil, err
+	}
+
+	runtimePort, err := conf.FieldInt("runtimePort")
+	if err != nil {
+		return nil, err
+	}
+
+	hostAMS, err := conf.FieldString("hostAMS")
+	if err != nil {
+		return nil, err
+	}
+
+	if hostAMS != "auto" && hostAMS != "" {
+		if err := validateAMSNetID(hostAMS); err != nil {
+			return nil, fmt.Errorf("hostAMS: %w", err)
+		}
+	}
+
+	hostPort, err := conf.FieldInt("hostPort")
+	if err != nil {
+		return nil, err
+	}
+
+	readType, err := conf.FieldString("readType")
+	if err != nil {
+		return nil, err
+	}
+
+	maxDelay, err := conf.FieldDuration("maxDelay")
+	if err != nil {
+		return nil, err
+	}
+
+	cycleTime, err := conf.FieldDuration("cycleTime")
+	if err != nil {
+		return nil, err
+	}
+
+	symbols, err := conf.FieldStringList("symbols")
+	if err != nil {
+		return nil, err
+	}
+
+	intervalTime, err := conf.FieldDuration("intervalTime")
+	if err != nil {
+		return nil, err
+	}
+	requestTimeout, err := conf.FieldDuration("requestTimeout")
+	if err != nil {
+		return nil, err
+	}
+
+	transmissionModeStr, err := conf.FieldString("transmissionMode")
+	if err != nil {
+		return nil, err
+	}
+	var transmissionMode adsLib.TransMode
+	switch transmissionModeStr {
+	case "serverOnChange":
+		transmissionMode = adsLib.TransModeServerOnChange
+	case "serverCycle":
+		transmissionMode = adsLib.TransModeServerCycle
+	case "serverOnChange2":
+		transmissionMode = adsLib.TransModeServerOnChange2
+	case "serverCycle2":
+		transmissionMode = adsLib.TransModeServerCycle2
+	default:
+		transmissionMode = adsLib.TransModeServerOnChange
+	}
+
+	username, err := conf.FieldString("username")
+	if err != nil {
+		return nil, err
+	}
+
+	password, err := conf.FieldString("password")
+	if err != nil {
+		return nil, err
+	}
+
+	hostIP, err := conf.FieldString("hostIP")
+	if err != nil {
+		return nil, err
+	}
+
+	// Derive hostAMS from hostIP when set to "auto"
+	if hostAMS == "auto" && hostIP != "" {
+		hostAMS = hostIP + ".1.1"
+	}
+
+	symbolList := CreateSymbolList(symbols, cycleTime, maxDelay)
+	m := &AdsCommInput{
+		TargetIP:         targetIP,
+		TargetAMS:        targetAMS,
+		TargetPort:       targetPort,
+		RuntimePort:      runtimePort,
+		HostAMS:          hostAMS,
+		HostPort:         hostPort,
+		ReadType:         readType,
+		MaxDelay:         maxDelay,
+		CycleTime:        cycleTime,
+		Symbols:          symbolList,
+		Log:              mgr.Logger(),
+		IntervalTime:     intervalTime,
+		RequestTimeout:   requestTimeout,
+		NotificationChan: make(chan *adsLib.Update, 256),
+		done:             make(chan struct{}),
+		TransmissionMode: transmissionMode,
+		Username:         username,
+		Password:         password,
+		HostIP:           hostIP,
+		adsLogger:        adsLogger,
+	}
+
+	return service.AutoRetryNacksBatched(m), nil
+
+}
+
+func init() {
+	err := service.RegisterBatchInput(
+		"ads", adsConf,
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
+			return NewAdsCommInput(conf, mgr)
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (g *AdsCommInput) Connect(ctx context.Context) error {
+	if g.Handler != nil {
+		return nil
+	}
+
+	// Ensure done channel is initialized (may be nil if constructed directly in tests)
+	if g.done == nil {
+		g.done = make(chan struct{})
+	}
+
+	// Build session options — route registration is handled automatically by Session.Connect
+	// when WithRoute is set; no manual AddRemoteRoute call needed.
+	g.Log.Infof("Creating new connection")
+	var err error
+	var connOpts []adsLib.SessionOption
+	if g.adsLogger != nil {
+		connOpts = append(connOpts, adsLib.WithLogger(g.adsLogger))
+		adsLib.SetDefaultLogger(g.adsLogger)
+	}
+	if g.Username != "" && g.Password != "" {
+		hostAddr := g.HostIP
+		if hostAddr == "" {
+			// Auto-detect via TCP connect to ADS port — guarantees same source IP
+			// as the actual ADS connection. On multi-homed machines, UDP routing
+			// can pick a different interface, causing the route to be registered
+			// with the wrong IP and accumulating stale routes on the PLC.
+			tcpConn, dialErr := net.DialTimeout("tcp4", net.JoinHostPort(g.TargetIP, "48898"), 3*time.Second)
+			if dialErr != nil {
+				// PLC unreachable; fall back to UDP routing lookup (no packet sent)
+				udpConn, udpErr := net.Dial("udp4", net.JoinHostPort(g.TargetIP, "48899"))
+				if udpErr != nil {
+					g.Log.Errorf("Failed to auto-detect local address: %v", dialErr)
+					return dialErr
+				}
+				hostAddr = udpConn.LocalAddr().(*net.UDPAddr).IP.String()
+				udpConn.Close()
+			} else {
+				hostAddr = tcpConn.LocalAddr().(*net.TCPAddr).IP.String()
+				tcpConn.Close()
+			}
+		}
+		if isLikelyContainerIP(hostAddr) {
+			g.Log.Warnf("Auto-detected IP %s looks like a container IP. Set hostIP to the Docker host's IP for route registration to work.", hostAddr)
+		}
+		routeName := fmt.Sprintf("benthosADS-%s", hostAddr)
+		g.Log.Infof("Route will be registered on PLC %s: name=%s, clientIP=%s", g.TargetIP, routeName, hostAddr)
+		connOpts = append(connOpts, adsLib.WithRoute(routeName, g.Username, g.Password))
+		connOpts = append(connOpts, adsLib.WithHostIP(hostAddr))
+	}
+
+	targetAMS, err := adsLib.NewAMSAddress(g.TargetAMS, uint16(g.RuntimePort))
+	if err != nil {
+		g.Log.Errorf("Invalid target AMS %q: %v", g.TargetAMS, err)
+		return err
+	}
+	// "auto" (default) means go-ads derives local AMS from the TCP connection.
+	if g.HostAMS != "" && g.HostAMS != "auto" {
+		localAMS, lerr := adsLib.NewAMSAddress(g.HostAMS, uint16(g.HostPort))
+		if lerr != nil {
+			g.Log.Errorf("Invalid local AMS %q: %v", g.HostAMS, lerr)
+			return lerr
+		}
+		connOpts = append(connOpts, adsLib.WithLocalAMS(localAMS))
+	}
+	if g.RequestTimeout > 0 {
+		connOpts = append(connOpts, adsLib.WithRequestTimeout(g.RequestTimeout))
+	}
+
+	// NewSession ctx is the session-lifetime ctx (cancel → session shutdown).
+	// Benthos passes a per-call ctx to Connect; using it here would tear the
+	// session down as soon as Connect returns. Use Background; teardown is
+	// driven by AdsCommInput.Close → g.Handler.Close().
+	g.Handler, err = adsLib.NewSession(context.Background(), adsLib.AMSEndpoint{
+		IP:   g.TargetIP,
+		Port: g.TargetPort,
+		AMS:  targetAMS,
+	}, connOpts...)
+	if err != nil {
+		g.Log.Errorf("Failed to create connection: %v", err)
+		return err
+	}
+
+	success := false
+	defer func() {
+		if !success && g.Handler != nil {
+			_ = g.Handler.Close()
+			g.Handler = nil
+		}
+	}()
+
+	// Connect; Session handles route registration internally when WithRoute is set
+	g.Log.Infof("Connecting to plc")
+	err = g.Handler.Connect(ctx)
+	if err != nil {
+		g.Log.Errorf("Failed to connect to PLC at %s: %v", g.TargetIP, err)
+		return err
+	}
+
+	// Build symbolNames map (lower-cased key → configured casing).
+	// TC2 returns all symbol names uppercase; this map normalises back to
+	// the casing the user configured.
+	g.symbolNames = make(map[string]string, len(g.Symbols))
+	g.dataTypes = make(map[string]string, len(g.Symbols))
+	g.baseTypes = make(map[string]string, len(g.Symbols))
+	g.dataSizes = make(map[string]uint32, len(g.Symbols))
+	for _, sym := range g.Symbols {
+		g.symbolNames[strings.ToLower(sym.Name)] = sym.Name
+	}
+
+
+	if g.ReadType == "notification" {
+		// Build notification configs for batch add
+		configs := make([]adsLib.NotificationConfig, len(g.Symbols))
+		for i, symbol := range g.Symbols {
+			configs[i] = adsLib.NotificationConfig{
+				SymbolName:       symbol.Name,
+				MaxDelay:         symbol.MaxDelay,
+				CycleTime:        symbol.CycleTime,
+				TransmissionMode: g.TransmissionMode,
+			}
+		}
+
+		// Connect() already ensures session is stable; no retry needed here.
+		// If this fails, return error and let Benthos retry Connect().
+		results, err := g.Handler.AddSymbolNotifications(ctx, configs, g.NotificationChan)
+		if err != nil {
+			g.Log.Errorf("Batch add notifications failed: %v", err)
+			return err
+		}
+
+		// AddSymbolNotifications returns nil error even when all symbols fail to
+		// resolve (e.g. PLC ADS not yet ready after route registration reconnect).
+		// Detect this case and return an error so Benthos retries Connect().
+		registered := 0
+		for i, r := range results {
+			switch {
+			case r.Skipped == nil && r.Error == adsLib.ReturnCodeNoErrors:
+				registered++
+			case r.Skipped != nil:
+				g.Log.Errorf("Notification symbol %q skipped (check symbol name): %v", configs[i].SymbolName, r.Skipped)
+			default:
+				g.Log.Errorf("Notification symbol %q rejected by PLC: ADS error 0x%X", configs[i].SymbolName, uint32(r.Error))
+			}
+		}
+		if registered == 0 && len(configs) > 0 {
+			return fmt.Errorf("no symbols registered for notifications (%d symbols all failed to resolve)", len(configs))
+		}
+		g.Log.Infof("Registered %d/%d notification symbols", registered, len(configs))
+
+		// Wait for initial sample from each registered symbol. TwinCAT sends an
+		// immediate sample on subscribe for all modes except NoTransmission, so
+		// this completes quickly. Guarantees the first ReadBatch returns a full
+		// batch rather than a partial one.
+		needed := make(map[string]bool, registered)
+		for i, r := range results {
+			if r.Skipped == nil && r.Error == adsLib.ReturnCodeNoErrors {
+				needed[strings.ToLower(configs[i].SymbolName)] = true
+			}
+		}
+		initialCtx, initialCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer initialCancel()
+		for len(needed) > 0 {
+			select {
+			case update := <-g.NotificationChan:
+				if update != nil {
+					delete(needed, strings.ToLower(update.Variable))
+				}
+			case <-initialCtx.Done():
+				g.Log.Warnf("Timed out waiting for initial samples; %d symbols not yet received: %v", len(needed), needed)
+				goto doneWaiting
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	doneWaiting:
+	}
+	success = true
+	return nil
+}
+
+// ReadBatch satisfies the service.BatchInput interface.
+// Full implementation (ReadBatchPull, ReadBatchNotification) is in a follow-up PR.
+func (g *AdsCommInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	return nil, nil, service.ErrNotConnected
+}
+func (g *AdsCommInput) Close(ctx context.Context) error {
+	g.Log.Infof("Close called")
+	// Signal shutdown to ReadBatchNotification before closing the handler,
+	// so it stops waiting for notifications.
+	if g.done != nil {
+		close(g.done)
+	}
+	if g.Handler != nil {
+		g.Log.Infof("Closing down, cleaning up PLC handles")
+		if cerr := g.Handler.Close(); cerr != nil {
+			g.Log.Warnf("Handler close error: %v", cerr)
+		}
+		g.Handler = nil
+	}
+
+	return nil
+}

--- a/beckhoff_ads_plugin/ads_input.go
+++ b/beckhoff_ads_plugin/ads_input.go
@@ -266,6 +266,8 @@ type AdsCommInput struct {
 	// from the go-ads library's notification goroutines.
 	done chan struct{}
 
+	LoadSymbols bool // download full symbol+datatype table on connect; required for struct/array symbols
+
 	// Route registration settings
 	Username string // PLC route registration username; route registered when both Username and Password are set
 	Password string
@@ -300,6 +302,7 @@ var adsConf = service.NewConfigSpec().
 	// ---- Advanced ----
 	Field(service.NewDurationField("requestTimeout").Description("Timeout for individual ADS requests.").Default("5s").Advanced().Examples("5s", "10s")).
 	Field(service.NewStringEnumField("logLevel", "disabled", "error", "warn", "info", "debug", "trace").Description("go-ads library log level. error (default) surfaces transport and ADS errors. debug/trace add verbose ADS wire details.").Default("error").Advanced().Examples("disabled", "error", "warn", "info", "debug", "trace")).
+	Field(service.NewBoolField("loadSymbols").Description("Download the full symbol and datatype table from the PLC on connect. Required for struct and array symbols. May cause brief real-time jitter on the PLC during initial connection; use with care on large programs.").Default(false).Advanced()).
 	// ---- Symbols (list — placed last for readability in YAML) ----
 	Field(service.NewStringListField("symbols").Description("Symbols to read. Format: 'name', 'name:maxDelayMs:cycleTimeMs', or 'name:maxDelay=100ms:cycleTime=100ms'. " +
 		"Examples: 'GVL.counter', 'GVL.trigger:0s:10ms', '.globalVar:maxDelay=0s:cycleTime=50ms'"))
@@ -426,6 +429,11 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 		return nil, err
 	}
 
+	loadSymbols, err := conf.FieldBool("loadSymbols")
+	if err != nil {
+		return nil, err
+	}
+
 	// Derive hostAMS from hostIP when set to "auto"
 	if hostAMS == "auto" && hostIP != "" {
 		hostAMS = hostIP + ".1.1"
@@ -449,6 +457,7 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 		NotificationChan: make(chan *adsLib.Update, 256),
 		done:             make(chan struct{}),
 		TransmissionMode: transmissionMode,
+		LoadSymbols:      loadSymbols,
 		Username:         username,
 		Password:         password,
 		HostIP:           hostIP,
@@ -578,6 +587,15 @@ func (g *AdsCommInput) Connect(ctx context.Context) error {
 		g.symbolNames[strings.ToLower(sym.Name)] = sym.Name
 	}
 
+	if g.LoadSymbols {
+		g.Log.Infof("Loading symbol and datatype table from PLC (loadSymbols=true)")
+		if err = g.Handler.LoadSymbols(ctx); err != nil {
+			g.Log.Errorf("LoadSymbols failed: %v", err)
+			return err
+		}
+		g.Log.Infof("Symbol table loaded")
+	}
+
 	if g.ReadType == "notification" {
 		// Build notification configs for batch add
 		configs := make([]adsLib.NotificationConfig, len(g.Symbols))
@@ -616,6 +634,19 @@ func (g *AdsCommInput) Connect(ctx context.Context) error {
 			return fmt.Errorf("no symbols registered for notifications (%d symbols all failed to resolve)", len(configs))
 		}
 		g.Log.Infof("Registered %d/%d notification symbols", registered, len(configs))
+
+		// Populate metadata cache from go-ads symbol cache (no extra round-trips).
+		// Without this, makeNotificationMessage reads from empty maps → null metadata.
+		for _, sym := range g.Symbols {
+			key := strings.ToLower(sym.Name)
+			if view, viewErr := g.Handler.GetSymbol(ctx, sym.Name); viewErr == nil {
+				g.dataTypes[key] = view.DataType
+				g.dataSizes[key] = view.Length
+				if bt := view.BaseTypeName(); bt != "" {
+					g.baseTypes[key] = bt
+				}
+			}
+		}
 
 		// Wait for initial sample from each registered symbol. TwinCAT sends an
 		// immediate sample on subscribe for all modes except NoTransmission, so

--- a/beckhoff_ads_plugin/ads_input.go
+++ b/beckhoff_ads_plugin/ads_input.go
@@ -152,6 +152,15 @@ func validateIP(s string) error {
 	return nil
 }
 
+// parseSymbolDuration parses a per-symbol timing override.
+// Bare integers are treated as milliseconds for backward compatibility; otherwise time.ParseDuration is used.
+func parseSymbolDuration(raw string) (time.Duration, error) {
+	if v, err := strconv.Atoi(raw); err == nil {
+		return time.Duration(v) * time.Millisecond, nil
+	}
+	return time.ParseDuration(raw)
+}
+
 // validateAMSNetID checks that s is a valid AMS NetID (6 dot-separated octets, each 0–255).
 func validateAMSNetID(s string) error {
 	parts := strings.Split(s, ".")
@@ -196,24 +205,24 @@ func CreateSymbolList(s []string, defaultCycleTime time.Duration, defaultMaxDela
 			for _, opt := range strings.Split(parts[1], ":") {
 				if kv := strings.SplitN(opt, "=", 2); len(kv) == 2 {
 					// Keyed option — overrides by name, does not consume positional slot
-					if v, err := strconv.Atoi(kv[1]); err == nil {
+					if d, err := parseSymbolDuration(kv[1]); err == nil {
 						switch kv[0] {
 						case "maxDelay":
-							plcSym.MaxDelay = time.Duration(v) * time.Millisecond
+							plcSym.MaxDelay = d
 						case "cycleTime":
-							plcSym.CycleTime = time.Duration(v) * time.Millisecond
+							plcSym.CycleTime = d
 						}
 					}
 				} else {
 					// Positional option — always advances slot index.
 					// Empty string reserves the slot (keeps default), non-empty sets value.
 					if opt != "" {
-						if v, err := strconv.Atoi(opt); err == nil {
+						if d, err := parseSymbolDuration(opt); err == nil {
 							switch positionalIdx {
 							case 0:
-								plcSym.MaxDelay = time.Duration(v) * time.Millisecond
+								plcSym.MaxDelay = d
 							case 1:
-								plcSym.CycleTime = time.Duration(v) * time.Millisecond
+								plcSym.CycleTime = d
 							}
 						}
 					}
@@ -250,7 +259,7 @@ type AdsCommInput struct {
 	dataSizes        map[string]uint32   // configured symbol name → PLC reported byte length (STRING=Nbytes, primitives=2/4/8 etc)
 	symbolNames      map[string]string   // strings.ToLower(configured name) → configured name (TC2 returns uppercase)
 	NotificationChan chan *adsLib.Update // notification channel for PLC data
-	TransmissionMode adsLib.TransMode // Notification transmission mode
+	TransmissionMode adsLib.TransMode    // Notification transmission mode
 
 	// Shutdown signal - closed to signal goroutines to stop.
 	// Used instead of closing NotificationChan to avoid send-on-closed-channel panics
@@ -283,21 +292,20 @@ var adsConf = service.NewConfigSpec().
 	Field(service.NewStringField("username").Description("PLC username for automatic route registration. Both username and password must be set to activate. Requires UDP 48899.").Default("").Advanced().Examples("Administrator")).
 	Field(service.NewStringField("password").Description("PLC password for automatic route registration.").Default("").Advanced().Examples("1")).
 	// ---- Read mode ----
-	Field(service.NewStringEnumField("readType", "notification", "interval").Description("Read type. notification = PLC pushes on change; interval = plugin polls at intervalTime.").Default("notification").Advanced()).
-	Field(service.NewStringEnumField("transmissionMode", "serverOnChange", "serverCycle", "serverOnChange2", "serverCycle2").Description("Notification transmission mode (notification readType only). serverOnChange2/serverCycle2 auto-fall back on older PLCs.").Default("serverOnChange").Advanced()).
+	Field(service.NewStringEnumField("readType", "notification", "interval").Description("Read type. notification = PLC pushes on change; interval = plugin polls at intervalTime.").Default("notification").Advanced().Examples("notification", "interval")).
+	Field(service.NewStringEnumField("transmissionMode", "serverOnChange", "serverCycle", "serverOnChange2", "serverCycle2").Description("Notification transmission mode (notification readType only). serverOnChange2/serverCycle2 auto-fall back on older PLCs.").Default("serverOnChange").Advanced().Examples("serverOnChange", "serverCycle", "serverOnChange2", "serverCycle2")).
 	Field(service.NewDurationField("cycleTime").Description("How often the PLC checks the symbol for changes and delivers notifications. Lower = more responsive but more PLC CPU.").Default("100ms").Advanced().Examples("100ms", "10ms", "500ms", "1s")).
 	Field(service.NewDurationField("maxDelay").Description("Maximum time the PLC batches notifications before sending. All changes are delivered; this controls delivery latency vs network efficiency.").Default("100ms").Advanced().Examples("100ms", "0s", "500ms")).
 	Field(service.NewDurationField("intervalTime").Description("Poll interval for readType interval.").Default("1s").Advanced().Examples("1s", "500ms")).
 	// ---- Advanced ----
 	Field(service.NewDurationField("requestTimeout").Description("Timeout for individual ADS requests.").Default("5s").Advanced().Examples("5s", "10s")).
-	Field(service.NewStringEnumField("logLevel", "disabled", "error", "warn", "info", "debug", "trace").Description("go-ads library log level. error (default) surfaces transport and ADS errors. debug/trace add verbose ADS wire details.").Default("error").Advanced()).
+	Field(service.NewStringEnumField("logLevel", "disabled", "error", "warn", "info", "debug", "trace").Description("go-ads library log level. error (default) surfaces transport and ADS errors. debug/trace add verbose ADS wire details.").Default("error").Advanced().Examples("disabled", "error", "warn", "info", "debug", "trace")).
 	// ---- Symbols (list — placed last for readability in YAML) ----
 	Field(service.NewStringListField("symbols").Description("Symbols to read. Format: 'name', 'name:maxDelayMs:cycleTimeMs', or 'name:maxDelay=100ms:cycleTime=100ms'. " +
 		"Examples: 'GVL.counter', 'GVL.trigger:0s:10ms', '.globalVar:maxDelay=0s:cycleTime=50ms'"))
 
 // NewAdsCommInput creates a new ADS input plugin from parsed Benthos configuration.
 func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
-
 	logLevel, err := conf.FieldString("logLevel")
 	if err != nil {
 		return nil, err
@@ -317,10 +325,10 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 		return nil, err
 	}
 
-	if err := validateIP(targetIP); err != nil {
+	if err = validateIP(targetIP); err != nil {
 		return nil, fmt.Errorf("targetIP: %w", err)
 	}
-	if err := validateAMSNetID(targetAMS); err != nil {
+	if err = validateAMSNetID(targetAMS); err != nil {
 		return nil, fmt.Errorf("targetAMS: %w", err)
 	}
 
@@ -333,6 +341,9 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 	if err != nil {
 		return nil, err
 	}
+	if runtimePort < 0 || runtimePort > 65535 {
+		return nil, fmt.Errorf("runtimePort %d out of range 0–65535", runtimePort)
+	}
 
 	hostAMS, err := conf.FieldString("hostAMS")
 	if err != nil {
@@ -340,7 +351,7 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 	}
 
 	if hostAMS != "auto" && hostAMS != "" {
-		if err := validateAMSNetID(hostAMS); err != nil {
+		if err = validateAMSNetID(hostAMS); err != nil {
 			return nil, fmt.Errorf("hostAMS: %w", err)
 		}
 	}
@@ -348,6 +359,9 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 	hostPort, err := conf.FieldInt("hostPort")
 	if err != nil {
 		return nil, err
+	}
+	if hostPort < 0 || hostPort > 65535 {
+		return nil, fmt.Errorf("hostPort %d out of range 0–65535", hostPort)
 	}
 
 	readType, err := conf.FieldString("readType")
@@ -442,7 +456,6 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 	}
 
 	return service.AutoRetryNacksBatched(m), nil
-
 }
 
 func init() {
@@ -565,7 +578,6 @@ func (g *AdsCommInput) Connect(ctx context.Context) error {
 		g.symbolNames[strings.ToLower(sym.Name)] = sym.Name
 	}
 
-
 	if g.ReadType == "notification" {
 		// Build notification configs for batch add
 		configs := make([]adsLib.NotificationConfig, len(g.Symbols))
@@ -639,14 +651,25 @@ func (g *AdsCommInput) Connect(ctx context.Context) error {
 // ReadBatch satisfies the service.BatchInput interface.
 // Full implementation (ReadBatchPull, ReadBatchNotification) is in a follow-up PR.
 func (g *AdsCommInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
-	return nil, nil, service.ErrNotConnected
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	default:
+		return nil, nil, service.ErrNotConnected
+	}
 }
+
+// Close shuts down the ADS connection. ctx is required by the service.BatchInput interface;
+// go-ads does not support context cancellation on close, so it is not forwarded.
+//
+//nolint:revive
 func (g *AdsCommInput) Close(ctx context.Context) error {
 	g.Log.Infof("Close called")
 	// Signal shutdown to ReadBatchNotification before closing the handler,
 	// so it stops waiting for notifications.
 	if g.done != nil {
 		close(g.done)
+		g.done = nil
 	}
 	if g.Handler != nil {
 		g.Log.Infof("Closing down, cleaning up PLC handles")

--- a/cmd/benthos/bundle/package.go
+++ b/cmd/benthos/bundle/package.go
@@ -15,7 +15,7 @@
 package bundle
 
 import (
-	_ "github.com/RuneRoven/benthosADS"
+	_ "github.com/united-manufacturing-hub/benthos-umh/beckhoff_ads_plugin"
 	_ "github.com/RuneRoven/benthosAlarm"
 	_ "github.com/RuneRoven/benthosSMTP"
 	// Fix for ENG-752

--- a/cmd/benthos/bundle/package.go
+++ b/cmd/benthos/bundle/package.go
@@ -15,7 +15,7 @@
 package bundle
 
 import (
-	_ "github.com/united-manufacturing-hub/benthos-umh/beckhoff_ads_plugin"
+	_ "github.com/RuneRoven/benthosADS"
 	_ "github.com/RuneRoven/benthosAlarm"
 	_ "github.com/RuneRoven/benthosSMTP"
 	// Fix for ENG-752

--- a/go.mod
+++ b/go.mod
@@ -27,9 +27,9 @@ require (
 )
 
 require (
-	github.com/RuneRoven/benthosADS v1.0.9
 	github.com/RuneRoven/benthosAlarm v1.0.0
 	github.com/RuneRoven/benthosSMTP v0.0.1
+	github.com/RuneRoven/go-ads/v2 v2.2.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/danomagnum/gologix v0.27.2-beta
 	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c

--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.15.0 // indirect
+	github.com/RuneRoven/benthosADS v1.0.7 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/apache/arrow-go/v18 v18.5.2 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect

--- a/go.sum
+++ b/go.sum
@@ -292,12 +292,12 @@ github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/RoaringBitmap/roaring/v2 v2.15.0 h1:gCbixa3UiG7g6WUZNVOfEEg2HTc1vR4OVdMkX8t1ZFc=
 github.com/RoaringBitmap/roaring/v2 v2.15.0/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
-github.com/RuneRoven/benthosADS v1.0.9 h1:1F1XO81X7SrtVTuBeB6UXXe8FkH5UYNt4UfeOt3ZSQQ=
-github.com/RuneRoven/benthosADS v1.0.9/go.mod h1:HFya/coDTwRy8GXqAzdYlYSFkKntXx94xddu/49tKCs=
 github.com/RuneRoven/benthosAlarm v1.0.0 h1:jI1RUjgta0FsNGtGPM7yIc1ox3zSbP/ZZVc518GhVs0=
 github.com/RuneRoven/benthosAlarm v1.0.0/go.mod h1:8081JBViQHAJAWDy+T/IYEB/UCICAJCb0M61EmI89DI=
 github.com/RuneRoven/benthosSMTP v0.0.1 h1:pgFBqcYvFXPT07YuoYPbpXhAD0CRD8dEC7SuC82VFAs=
 github.com/RuneRoven/benthosSMTP v0.0.1/go.mod h1:TXVZVWdtKUdHkPWJ/WWDWSEulsToHXNlOgx+zX5THH8=
+github.com/RuneRoven/go-ads/v2 v2.2.0 h1:jOPUxxSvu5MzP+ajEUkH00bXBoXAkilmleaET467xSw=
+github.com/RuneRoven/go-ads/v2 v2.2.0/go.mod h1:Er2Jijkt7rqQn61po2IngZYIzYokLagzNmgRewsAcM8=
 github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26 h1:3YVZUqkoev4mL+aCwVOSWV4M7pN+NURHL38Z2zq5JKA=
 github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26/go.mod h1:ymXt5bw5uSNu4jveerFxE0vNYxF8ncqbptntMaFMg3k=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/RoaringBitmap/roaring/v2 v2.15.0 h1:gCbixa3UiG7g6WUZNVOfEEg2HTc1vR4OVdMkX8t1ZFc=
 github.com/RoaringBitmap/roaring/v2 v2.15.0/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
+github.com/RuneRoven/benthosADS v1.0.7 h1:2A86WuJ/rX/OY2NZrK4cEVek3yVmWYd/EqCfRDC22/Q=
+github.com/RuneRoven/benthosADS v1.0.7/go.mod h1:TrMmERXkjxlbErsi2PNA+zsdu1GM14QanAdZgP3Lc5I=
 github.com/RuneRoven/benthosAlarm v1.0.0 h1:jI1RUjgta0FsNGtGPM7yIc1ox3zSbP/ZZVc518GhVs0=
 github.com/RuneRoven/benthosAlarm v1.0.0/go.mod h1:8081JBViQHAJAWDy+T/IYEB/UCICAJCb0M61EmI89DI=
 github.com/RuneRoven/benthosSMTP v0.0.1 h1:pgFBqcYvFXPT07YuoYPbpXhAD0CRD8dEC7SuC82VFAs=


### PR DESCRIPTION
## Summary

Adds CI support for the Beckhoff ADS plugin.

- `test-ads.yml`: hardware integration test workflow (runs on self-hosted runner with PLC access)
- `ci.yml`: adds `ads` path filter, `test-ads` job, and `test-ads` to the all-tests-passed gate

## Part of series
- 1/5 — init, config, connect
- **2/5 — CI workflow** ← this PR
- 3/5 — docs
- 4/5 — ReadBatch implementation
- 5/5 — tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)