### PR TITLE
fix: make string types directly use json.Marshal conv (eng-5005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- OPC-UA input now preserves string values exactly. Previously, a string tag whose value looked like a large number, such as a long marking or serial code like `83275631010238526`, was emitted as a number and rounded to something like `8.33e+16` (ENG-5011)
+
 ## [0.12.6]
 
 ### Fixes

--- a/opcua_plugin/core_read.go
+++ b/opcua_plugin/core_read.go
@@ -69,9 +69,6 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 	case float64:
 		b = append(b, []byte(strconv.FormatFloat(v, 'f', -1, 64))...)
 		tagType = "number"
-	case string:
-		b = append(b, []byte(v)...)
-		tagType = "string"
 	case bool:
 		b = append(b, []byte(strconv.FormatBool(v))...)
 		tagType = "bool"
@@ -106,7 +103,7 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 		b = append(b, []byte(strconv.FormatUint(v, 10))...)
 		tagType = "number"
 	default:
-		// Convert unknown types to JSON
+		// Convert unknown and string types to JSON
 		jsonBytes, err := json.Marshal(v)
 		if err != nil {
 			g.Log.Errorf("Error marshaling to JSON: %v", err)

--- a/opcua_plugin/core_read_test.go
+++ b/opcua_plugin/core_read_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opcua_plugin
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gopcua/opcua/ua"
+)
+
+// ENG-5011: an OPC UA String value must be emitted as a valid JSON string so it
+// round-trips as a string downstream. A numeric-looking string ("83280661010132726")
+// must not be re-parsed as a (lossy) number by the downstream json.Unmarshal.
+var _ = Describe("getBytesFromValue string encoding", func() {
+	DescribeTable("emits a valid JSON string that round-trips losslessly",
+		func(value string, expectedBytes string) {
+			g := &OPCUAConnection{}
+			dv := &ua.DataValue{Value: ua.MustVariant(value), Status: ua.StatusOK}
+
+			b, tagType := g.getBytesFromValue(dv, NodeDef{})
+
+			Expect(string(b)).To(Equal(expectedBytes))
+			Expect(tagType).To(Equal("string"))
+
+			// Downstream contract: unmarshalling the body yields the original string.
+			var decoded any
+			Expect(json.Unmarshal(b, &decoded)).To(Succeed())
+			Expect(decoded).To(Equal(value))
+		},
+		Entry("numeric-looking string from the bug report", "83280661010132726", `"83280661010132726"`),
+		Entry("plain string", "hello", `"hello"`),
+		Entry("string with a quote", `he"llo`, `"he\"llo"`),
+		Entry("string with a newline", "line1\nline2", `"line1\nline2"`),
+	)
+})


### PR DESCRIPTION
# Description

In `opcua_plugin` when reading from strings it could happen that you get the edge-case of reading large numeric strings, which will then be not correctly converted due to "raw" data extraction.

We now use direct `json.Marshal` for this to work around any edge-cases that could happen e.g. with large numeric strings, `"` in strings or special characters in strings.