### PR TITLE
fix: make string types directly use json.Marshal conv (eng-5011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Sparkplug B output: a standard `tag_processor → sparkplug_b` flow now publishes its tags. The output read the value from a payload field named after the tag, but `tag_processor` emits it under `value`, so every message was silently dropped — leaving only an empty `NBIRTH` on the broker. The output now extracts the value the same way the Sparkplug B input does (`value`/`val`/`data`/`measurement`), makes `virtual_path` optional, and warns instead of dropping silently when a payload can't be turned into a metric (ENG-5087)
 - Sparkplug B input: metric datatypes now survive from BIRTH to DATA. Per spec, `NDATA`/`DDATA` carries only alias + value while the BIRTH certificate defines name and datatype — but the input cached only the name, so DATA messages lost their `spb_datatype` metadata and signed integers decoded as their unsigned two's-complement wire value (an `Int32` of `-12` surfaced as `4294967284`). The alias cache now restores the datatype alongside the name, and `Int8`/`Int16`/`Int32`/`Int64` wire values are reinterpreted as signed (ENG-5126)
+- OPC-UA input now preserves string values exactly. Previously, a string tag whose value looked like a large number, such as a long marking or serial code like `83275631010238526`, was emitted as a number and rounded to something like `8.33e+16` (ENG-5011)
 
 ## [0.12.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Sparkplug B output: a standard `tag_processor → sparkplug_b` flow now publishes its tags. The output read the value from a payload field named after the tag, but `tag_processor` emits it under `value`, so every message was silently dropped — leaving only an empty `NBIRTH` on the broker. The output now extracts the value the same way the Sparkplug B input does (`value`/`val`/`data`/`measurement`), makes `virtual_path` optional, and warns instead of dropping silently when a payload can't be turned into a metric (ENG-5087)
 - Sparkplug B input: metric datatypes now survive from BIRTH to DATA. Per spec, `NDATA`/`DDATA` carries only alias + value while the BIRTH certificate defines name and datatype — but the input cached only the name, so DATA messages lost their `spb_datatype` metadata and signed integers decoded as their unsigned two's-complement wire value (an `Int32` of `-12` surfaced as `4294967284`). The alias cache now restores the datatype alongside the name, and `Int8`/`Int16`/`Int32`/`Int64` wire values are reinterpreted as signed (ENG-5126)
-- OPC-UA input now preserves string values exactly. Previously, a string tag whose value looked like a large number, such as a long marking or serial code like `83275631010238526`, was emitted as a number and rounded to something like `8.33e+16` (ENG-5011)
+- OPC-UA input now preserves string values exactly; previously, numeric-looking strings like serial codes were emitted as numbers and lost precision. For tags processed by `tag_processor`, also set `msg.meta.datatype = "string"` so auto-detection does not convert them back (ENG-5011)
 
 ## [0.12.6]
 

--- a/docs/input/opc-ua-input.md
+++ b/docs/input/opc-ua-input.md
@@ -75,6 +75,8 @@ The plugin provides metadata for each message, that can be used to create a topi
 | `opcua_attr_datatype`    | The DataType attribute of the Node as a string                                                                                                       |
 | `opcua_attr_statuscode`  | The OPC UA quality/status code for the data value (e.g., "Good", "BadNodeIdUnknown"). Indicates the reliability of the value.                       |
 
+**Note:** String values are delivered exactly as the server sends them. However, `tag_processor` auto-detection converts numeric-looking strings (e.g., serial codes) back to lossy numbers. To keep them as strings, set `msg.meta.datatype = "string"` for those tags in the processing section.
+
 Taking as example the following OPC-UA structure:
 
 ```

--- a/docs/processing/tag-processor.md
+++ b/docs/processing/tag-processor.md
@@ -269,6 +269,7 @@ The processor uses the following metadata fields:
 **Optional Fields:**
 
 - `virtual_path`: Logical, non-physical grouping path in dot notation (e.g., "axis.x.position")
+- `datatype`: Forces the output value type (`"string"`, `"number"`, or `"bool"`) instead of auto-detection. Set to `"string"` to keep numeric-looking strings (e.g., serial codes) from being converted to lossy numbers
 
 **Generated Fields:**
 

--- a/opcua_plugin/core_read.go
+++ b/opcua_plugin/core_read.go
@@ -69,9 +69,6 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 	case float64:
 		b = append(b, []byte(strconv.FormatFloat(v, 'f', -1, 64))...)
 		tagType = "number"
-	case string:
-		b = append(b, []byte(v)...)
-		tagType = "string"
 	case bool:
 		b = append(b, []byte(strconv.FormatBool(v))...)
 		tagType = "bool"
@@ -106,7 +103,7 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 		b = append(b, []byte(strconv.FormatUint(v, 10))...)
 		tagType = "number"
 	default:
-		// Convert unknown types to JSON
+		// Convert unknown and string types to JSON
 		jsonBytes, err := json.Marshal(v)
 		if err != nil {
 			g.Log.Errorf("Error marshaling to JSON: %v", err)

--- a/opcua_plugin/core_read.go
+++ b/opcua_plugin/core_read.go
@@ -103,7 +103,8 @@ func (g *OPCUAConnection) getBytesFromValue(dataValue *ua.DataValue, nodeDef Nod
 		b = append(b, []byte(strconv.FormatUint(v, 10))...)
 		tagType = "number"
 	default:
-		// Convert unknown and string types to JSON
+		// Strings must be JSON-quoted too: downstream parses the body as JSON, and raw
+		// bytes would turn numeric-looking strings into lossy numbers.
 		jsonBytes, err := json.Marshal(v)
 		if err != nil {
 			g.Log.Errorf("Error marshaling to JSON: %v", err)

--- a/opcua_plugin/core_read_test.go
+++ b/opcua_plugin/core_read_test.go
@@ -17,10 +17,9 @@ package opcua_plugin
 import (
 	"encoding/json"
 
+	"github.com/gopcua/opcua/ua"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/gopcua/opcua/ua"
 )
 
 // ENG-5011: an OPC UA String value must be emitted as a valid JSON string so it

--- a/opcua_plugin/core_read_test.go
+++ b/opcua_plugin/core_read_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opcua_plugin
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gopcua/opcua/ua"
+)
+
+// ENG-5011: an OPC UA String value must be emitted as a valid JSON string so it
+// round-trips as a string downstream. A numeric-looking string ("83280661010132726")
+// must not be re-parsed as a (lossy) number by the downstream json.Unmarshal.
+var _ = Describe("getBytesFromValue string encoding", func() {
+	DescribeTable("emits a valid JSON string that round-trips losslessly",
+		func(value string, expectedBytes string) {
+			g := &OPCUAConnection{}
+			dv := &ua.DataValue{Value: ua.MustVariant(value), Status: ua.StatusOK}
+
+			b, tagType := g.getBytesFromValue(dv, NodeDef{})
+
+			Expect(string(b)).To(Equal(expectedBytes))
+			Expect(tagType).To(Equal("string"))
+
+			// Downstream contract: unmarshalling the body yields the original string.
+			var decoded any
+			Expect(json.Unmarshal(b, &decoded)).To(Succeed())
+			Expect(decoded).To(Equal(value))
+		},
+		Entry("numeric-looking string from the bug report", "83280661010132726", `"83280661010132726"`),
+		Entry("plain string", "hello", `"hello"`),
+		Entry("string with a quote", `he"llo`, `"he\"llo"`),
+		Entry("string with a newline", "line1\nline2", `"line1\nline2"`),
+	)
+})

--- a/opcua_plugin/core_read_test.go
+++ b/opcua_plugin/core_read_test.go
@@ -15,11 +15,16 @@
 package opcua_plugin
 
 import (
+	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/gopcua/opcua/ua"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	_ "github.com/united-manufacturing-hub/benthos-umh/tag_processor_plugin"
 )
 
 // ENG-5011: an OPC UA String value must be emitted as a valid JSON string so it
@@ -46,4 +51,64 @@ var _ = Describe("getBytesFromValue string encoding", func() {
 		Entry("string with a quote", `he"llo`, `"he\"llo"`),
 		Entry("string with a newline", "line1\nline2", `"line1\nline2"`),
 	)
+
+	// Full-chain regression for ENG-5011: the message built by createMessageFromValue
+	// must survive tag_processor unchanged when datatype is wired from opcua_tag_type,
+	// mirroring a real bridge pipeline.
+	It("preserves a numeric-looking string through tag_processor", func() {
+		input := &OPCUAInput{OPCUAConnection: &OPCUAConnection{}}
+		value := "83280661010132726"
+		dv := &ua.DataValue{Value: ua.MustVariant(value), Status: ua.StatusOK}
+		nodeDef := NodeDef{NodeID: ua.NewNumericNodeID(0, 1234)}
+
+		inputMsg := input.createMessageFromValue(dv, nodeDef)
+		Expect(inputMsg).NotTo(BeNil())
+
+		builder := service.NewStreamBuilder()
+
+		msgHandler, err := builder.AddProducerFunc()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = builder.AddProcessorYAML(`
+tag_processor:
+  defaults: |
+    msg.meta.location_path = "enterprise.site";
+    msg.meta.data_contract = "_historian";
+    msg.meta.tag_name = "lastMarkingCode";
+    msg.meta.datatype = msg.meta.opcua_tag_type;
+    return msg;
+`)
+		Expect(err).NotTo(HaveOccurred())
+
+		var messages []*service.Message
+		err = builder.AddConsumerFunc(func(_ context.Context, msg *service.Message) error {
+			messages = append(messages, msg)
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		stream, err := builder.Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		go func() {
+			_ = stream.Run(ctx)
+		}()
+
+		err = msgHandler(ctx, inputMsg)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() int {
+			return len(messages)
+		}).Should(Equal(1))
+
+		structured, err := messages[0].AsStructured()
+		Expect(err).NotTo(HaveOccurred())
+
+		payload, ok := structured.(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(payload["value"]).To(Equal(value))
+	})
 })


### PR DESCRIPTION
# Description

In `opcua_plugin` when reading from strings it could happen that you get the edge-case of reading large numeric strings, which will then be not correctly converted due to "raw" data extraction.

We now use direct `json.Marshal` for this to work around any edge-cases that could happen e.g. with large numeric strings, `"` in strings or special characters in strings.

Fixes ENG-5011