### PR TITLE
ENG-5087: fix Sparkplug B output dropping tag_processor messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Sparkplug B output: a standard `tag_processor → sparkplug_b` flow now publishes its tags. Previously the output looked for the value under a payload field named after the tag, found nothing in the UMH-Core `{value, …}` payload, and dropped every message — leaving only an empty `NBIRTH` on the broker (ENG-5087)
 - Sparkplug B output: `virtual_path` is now optional. When it is not set the metric name is just `tag_name`, instead of the message being dropped (ENG-5087)
+- Sparkplug B output: a tag that matches a configured `metrics` entry by name but whose `value_from` field is missing is now dropped, instead of being silently republished under a different auto-derived metric name and alias — a broken `value_from` no longer masquerades as a working dynamic metric (ENG-5087)
 
 ## [0.12.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Sparkplug B output: a standard `tag_processor → sparkplug_b` flow now publishes its tags. Previously the output looked for the value under a payload field named after the tag, found nothing in the UMH-Core `{value, …}` payload, and dropped every message — leaving only an empty `NBIRTH` on the broker (ENG-5087)
 - Sparkplug B output: `virtual_path` is now optional. When it is not set the metric name is just `tag_name`, instead of the message being dropped (ENG-5087)
-- Sparkplug B output: a tag that matches a configured `metrics` entry by name but whose `value_from` field is missing is now dropped, instead of being silently republished under a different auto-derived metric name and alias — a broken `value_from` no longer masquerades as a working dynamic metric (ENG-5087)
+- Sparkplug B output: a tag that matches a configured `metrics` entry by name but whose `value_from` field is missing is now dropped with a warn-level log, instead of being silently republished under a different auto-derived metric name and alias — a broken `value_from` no longer masquerades as a working dynamic metric (ENG-5087)
+- Sparkplug B output: a `tag_processor` message no longer fans out across other configured `metrics`. Previously a single tag whose payload field (e.g. `value`) matched several metrics' `value_from` published all of them with the same value; a tag-scoped message now emits only its own metric (ENG-5087)
 
 ## [0.12.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,7 @@
 
 ### Fixes
 
-- Sparkplug B output: a standard `tag_processor → sparkplug_b` flow now publishes its tags. Previously the output looked for the value under a payload field named after the tag, found nothing in the UMH-Core `{value, …}` payload, and dropped every message — leaving only an empty `NBIRTH` on the broker (ENG-5087)
-- Sparkplug B output: `virtual_path` is now optional. When it is not set the metric name is just `tag_name`, instead of the message being dropped (ENG-5087)
-- Sparkplug B output: a tag that matches a configured `metrics` entry by name but whose `value_from` field is missing is now dropped with a warn-level log, instead of being silently republished under a different auto-derived metric name and alias — a broken `value_from` no longer masquerades as a working dynamic metric (ENG-5087)
-- Sparkplug B output: a `tag_processor` message no longer fans out across other configured `metrics`. Previously a single tag whose payload field (e.g. `value`) matched several metrics' `value_from` published all of them with the same value; a tag-scoped message now emits only its own metric (ENG-5087)
+- Sparkplug B output: a standard `tag_processor → sparkplug_b` flow now publishes its tags. The output read the value from a payload field named after the tag, but `tag_processor` emits it under `value`, so every message was silently dropped — leaving only an empty `NBIRTH` on the broker. The output now extracts the value the same way the Sparkplug B input does (`value`/`val`/`data`/`measurement`), makes `virtual_path` optional, and warns instead of dropping silently when a payload can't be turned into a metric (ENG-5087)
 
 ## [0.12.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Sparkplug B output: a standard `tag_processor → sparkplug_b` flow now publishes its tags. Previously the output looked for the value under a payload field named after the tag, found nothing in the UMH-Core `{value, …}` payload, and dropped every message — leaving only an empty `NBIRTH` on the broker (ENG-5087)
+- Sparkplug B output: `virtual_path` is now optional. When it is not set the metric name is just `tag_name`, instead of the message being dropped (ENG-5087)
+
 ## [0.12.6]
 
 ### Fixes

--- a/sparkplug_plugin/sparkplug_b_output.go
+++ b/sparkplug_plugin/sparkplug_b_output.go
@@ -1251,8 +1251,15 @@ func (s *sparkplugOutput) extractMessageData(msg *service.Message) (map[string]i
 		"autoExtractTagName: %t, configured metrics: %d, structured payload: %+v",
 		s.autoExtractTagName, len(s.metrics), structured)
 
+	// A tag-scoped message (tag_processor flow: tag_name in metadata) represents
+	// exactly one tag; its metric identity comes from the metadata. Once it is
+	// handled here, the static-metric sweep below must be skipped so the single
+	// value does not fan out across every configured metric sharing its value_from.
+	handledViaTagName := false
+
 	if s.autoExtractTagName {
 		if tagName, exists := msg.MetaGet("tag_name"); exists {
+			handledViaTagName = true
 			s.logger.Debugf("extractMessageData: Found tag_name metadata: %s", tagName)
 
 			// Try to match with configured metrics first
@@ -1263,8 +1270,13 @@ func (s *sparkplugOutput) extractMessageData(msg *service.Message) (map[string]i
 					s.logger.Debugf("extractMessageData: Matched tag_name %s with configured metric, extracting from path: %s", tagName, metricConfig.ValueFrom)
 					value, err := s.extractValueFromPath(structured, metricConfig.ValueFrom)
 					if err != nil {
-						s.logger.Debugf("Failed to extract value for metric %s: %v", tagName, err)
-						continue
+						// Matched a configured metric by name but value_from is absent
+						// from the payload. The message is dropped (we do NOT fall
+						// through to auto-derive, which would republish it under a
+						// different name); warn so the misconfiguration is observable,
+						// consistent with the other drop paths below.
+						s.logger.Warnf("sparkplug_b: dropping message for tag_name %q: configured metric value_from %q not found in payload: %v", tagName, metricConfig.ValueFrom, err)
+						break
 					}
 					data[tagName] = value
 					break
@@ -1305,20 +1317,24 @@ func (s *sparkplugOutput) extractMessageData(msg *service.Message) (map[string]i
 		}
 	}
 
-	// Process only static configured metrics (from config file)
-	// Dynamic metrics are handled above via tag_name metadata extraction
-	for _, metricConfig := range s.metrics {
-		if _, exists := data[metricConfig.Name]; exists {
-			continue // Already extracted via tag_name metadata
-		}
+	// Process static configured metrics (from config file) only for messages that
+	// were NOT tag-scoped. A tag-scoped message carries a single tag and was fully
+	// handled above; sweeping the configured metrics here would publish unrelated
+	// metrics from the same payload (e.g. every metric whose value_from is "value").
+	if !handledViaTagName {
+		for _, metricConfig := range s.metrics {
+			if _, exists := data[metricConfig.Name]; exists {
+				continue // Already extracted via tag_name metadata
+			}
 
-		s.logger.Debugf("extractMessageData: Processing static configured metric %s with value_from: %s", metricConfig.Name, metricConfig.ValueFrom)
-		value, err := s.extractValueFromPath(structured, metricConfig.ValueFrom)
-		if err != nil {
-			s.logger.Debugf("Failed to extract value for static metric %s: %v", metricConfig.Name, err)
-			continue
+			s.logger.Debugf("extractMessageData: Processing static configured metric %s with value_from: %s", metricConfig.Name, metricConfig.ValueFrom)
+			value, err := s.extractValueFromPath(structured, metricConfig.ValueFrom)
+			if err != nil {
+				s.logger.Debugf("Failed to extract value for static metric %s: %v", metricConfig.Name, err)
+				continue
+			}
+			data[metricConfig.Name] = value
 		}
-		data[metricConfig.Name] = value
 	}
 
 	s.logger.Debugf("extractMessageData: Extraction complete - extracted %d metrics: %+v", len(data), data)

--- a/sparkplug_plugin/sparkplug_b_output.go
+++ b/sparkplug_plugin/sparkplug_b_output.go
@@ -51,11 +51,10 @@ import (
 	"github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin/sparkplugb"
 )
 
-func sparkplugOutputConfigSpec() *service.ConfigSpec {
-	return service.NewConfigSpec().
-		Version("1.0.0").
-		Summary("Sparkplug B MQTT output acting as Edge Node").
-		Description(`The Sparkplug B output acts as an Edge Node, publishing data to Sparkplug MQTT topics
+var SparkplugConfigSpec = service.NewConfigSpec().
+	Version("1.0.0").
+	Summary("Sparkplug B MQTT output acting as Edge Node").
+	Description(`The Sparkplug B output acts as an Edge Node, publishing data to Sparkplug MQTT topics
 with complete session lifecycle management. It handles BIRTH/DEATH certificates, maintains sequence
 numbers, manages alias mappings, and ensures full Sparkplug B compliance.
 
@@ -72,86 +71,83 @@ Key features:
 
 The output connects to an MQTT broker, publishes BIRTH certificates to announce available metrics,
 and then publishes DATA messages as Benthos messages flow through the pipeline.`).
-		// MQTT Transport Configuration
-		Field(service.NewObjectField("mqtt",
-			service.NewStringListField("urls").
-				Description("List of MQTT broker URLs to connect to").
-				Example([]string{"tcp://localhost:1883", "ssl://broker.hivemq.com:8883"}).
-				Default([]string{"tcp://localhost:1883"}),
-			service.NewStringField("client_id").
-				Description("MQTT client ID for this edge node").
-				Default("benthos-sparkplug-output"),
-			service.NewObjectField("credentials",
-				service.NewStringField("username").
-					Description("MQTT username for authentication").
-					Default("").
-					Optional(),
-				service.NewStringField("password").
-					Description("MQTT password for authentication").
-					Default("").
-					Secret().
-					Optional()).
-				Description("MQTT authentication credentials").
-				Optional(),
-			service.NewIntField("qos").
-				Description("QoS level for MQTT publishing (0, 1, or 2)").
-				Default(1),
-			service.NewDurationField("keep_alive").
-				Description("MQTT keep alive interval").
-				Default("60s"),
-			service.NewDurationField("connect_timeout").
-				Description("MQTT connection timeout").
-				Default("30s"),
-			service.NewBoolField("clean_session").
-				Description("MQTT clean session flag").
-				Default(true)).
-			Description("MQTT transport configuration")).
-		// Sparkplug Identity Configuration
-		Field(service.NewObjectField("identity",
-			service.NewStringField("group_id").
-				Description("Sparkplug Group ID (e.g., 'FactoryA')").
-				Example("FactoryA"),
-			service.NewStringField("edge_node_id").
-				Description("Edge Node ID within the group (e.g., 'Line3'). If empty, auto-generated from location_path metadata using Parris Method").
-				Example("Line3"),
-			service.NewStringField("device_id").
-				Description("Device ID under the edge node (optional, if not specified acts as node-level)").
+	// MQTT Transport Configuration
+	Field(service.NewObjectField("mqtt",
+		service.NewStringListField("urls").
+			Description("List of MQTT broker URLs to connect to").
+			Example([]string{"tcp://localhost:1883", "ssl://broker.hivemq.com:8883"}).
+			Default([]string{"tcp://localhost:1883"}),
+		service.NewStringField("client_id").
+			Description("MQTT client ID for this edge node").
+			Default("benthos-sparkplug-output"),
+		service.NewObjectField("credentials",
+			service.NewStringField("username").
+				Description("MQTT username for authentication").
 				Default("").
+				Optional(),
+			service.NewStringField("password").
+				Description("MQTT password for authentication").
+				Default("").
+				Secret().
 				Optional()).
-			Description("Sparkplug identity configuration")).
-
-		// Output-specific Configuration
-		Field(service.NewObjectListField("metrics",
-			service.NewStringField("name").
-				Description("Metric name as it will appear in BIRTH messages"),
-			service.NewIntField("alias").
-				Description("Numeric alias for this metric (1-65535)"),
-			service.NewStringField("type").
-				Description("Data type: int8, int16, int32, int64, uint8, uint16, uint32, uint64, float, double, boolean, string").
-				Default("double"),
-			service.NewStringField("value_from").
-				Description("JSONPath or field name in the message to extract value from").
-				Default("value")).
-			Description("Metric definitions for BIRTH messages and alias mapping").
+			Description("MQTT authentication credentials").
+			Optional(),
+		service.NewIntField("qos").
+			Description("QoS level for MQTT publishing (0, 1, or 2)").
+			Default(1),
+		service.NewDurationField("keep_alive").
+			Description("MQTT keep alive interval").
+			Default("60s"),
+		service.NewDurationField("connect_timeout").
+			Description("MQTT connection timeout").
+			Default("30s"),
+		service.NewBoolField("clean_session").
+			Description("MQTT clean session flag").
+			Default(true)).
+		Description("MQTT transport configuration")).
+	// Sparkplug Identity Configuration
+	Field(service.NewObjectField("identity",
+		service.NewStringField("group_id").
+			Description("Sparkplug Group ID (e.g., 'FactoryA')").
+			Example("FactoryA"),
+		service.NewStringField("edge_node_id").
+			Description("Edge Node ID within the group (e.g., 'Line3'). If empty, auto-generated from location_path metadata using Parris Method").
+			Example("Line3"),
+		service.NewStringField("device_id").
+			Description("Device ID under the edge node (optional, if not specified acts as node-level)").
+			Default("").
 			Optional()).
-		// Behavior Configuration
-		Field(service.NewObjectField("behavior",
-			service.NewBoolField("auto_extract_tag_name").
-				Description("Whether to automatically extract tag_name from message metadata").
-				Default(true),
-			service.NewBoolField("retain_last_values").
-				Description("Whether to retain last known values for BIRTH messages after reconnection").
-				Default(true)).
-			Description("Processing behavior configuration").
-			Optional())
-}
+		Description("Sparkplug identity configuration")).
+
+	// Output-specific Configuration
+	Field(service.NewObjectListField("metrics",
+		service.NewStringField("name").
+			Description("Metric name as it will appear in BIRTH messages"),
+		service.NewIntField("alias").
+			Description("Numeric alias for this metric (1-65535)"),
+		service.NewStringField("type").
+			Description("Data type: int8, int16, int32, int64, uint8, uint16, uint32, uint64, float, double, boolean, string").
+			Default("double"),
+		service.NewStringField("value_from").
+			Description("JSONPath or field name in the message to extract value from").
+			Default("value")).
+		Description("Metric definitions for BIRTH messages and alias mapping").
+		Optional()).
+	// Behavior Configuration
+	Field(service.NewObjectField("behavior",
+		service.NewBoolField("auto_extract_tag_name").
+			Description("Whether to automatically extract tag_name from message metadata").
+			Default(true),
+		service.NewBoolField("retain_last_values").
+			Description("Whether to retain last known values for BIRTH messages after reconnection").
+			Default(true)).
+		Description("Processing behavior configuration").
+		Optional())
 
 func init() {
-	outputSpec := sparkplugOutputConfigSpec()
-
 	err := service.RegisterOutput(
 		"sparkplug_b",
-		outputSpec,
+		SparkplugConfigSpec,
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Output, int, error) {
 			output, err := newSparkplugOutput(conf, mgr)
 			if err != nil {

--- a/sparkplug_plugin/sparkplug_b_output.go
+++ b/sparkplug_plugin/sparkplug_b_output.go
@@ -129,7 +129,7 @@ and then publishes DATA messages as Benthos messages flow through the pipeline.`
 			Description("Data type: int8, int16, int32, int64, uint8, uint16, uint32, uint64, float, double, boolean, string").
 			Default("double"),
 		service.NewStringField("value_from").
-			Description("JSONPath or field name in the message to extract value from").
+			Description("Top-level field name in the message to extract value from").
 			Default("value")).
 		Description("Metric definitions for BIRTH messages and alias mapping").
 		Optional()).
@@ -1256,8 +1256,10 @@ func (s *sparkplugOutput) extractMessageData(msg *service.Message) (map[string]i
 			s.logger.Debugf("extractMessageData: Found tag_name metadata: %s", tagName)
 
 			// Try to match with configured metrics first
+			matchedConfiguredMetric := false
 			for _, metricConfig := range s.metrics {
 				if metricConfig.Name == tagName {
+					matchedConfiguredMetric = true
 					s.logger.Debugf("extractMessageData: Matched tag_name %s with configured metric, extracting from path: %s", tagName, metricConfig.ValueFrom)
 					value, err := s.extractValueFromPath(structured, metricConfig.ValueFrom)
 					if err != nil {
@@ -1269,14 +1271,20 @@ func (s *sparkplugOutput) extractMessageData(msg *service.Message) (map[string]i
 				}
 			}
 
-			// If no configured metric matched, derive the metric the same way the
-			// input plugin does, via the shared FormatConverter: the value comes from
-			// the UMH-Core payload ("value"/"val"/"data"/"measurement") and the metric
-			// name is virtual_path:tag_name (or just tag_name when virtual_path is empty).
+			// Only auto-derive when no configured metric matched by name. A metric
+			// that matched but failed value_from extraction must NOT fall through to
+			// the dynamic UMH path: that would republish it under a different metric
+			// name/alias, masking the misconfiguration and breaking the configured
+			// Sparkplug contract.
+			//
+			// Derive the metric the same way the input plugin does, via the shared
+			// FormatConverter: the value comes from the UMH-Core payload
+			// ("value"/"val"/"data"/"measurement") and the metric name is
+			// virtual_path:tag_name (or just tag_name when virtual_path is empty).
 			// parseUMHMessage requires location_path and a UMH-valid tag_name; when it
 			// cannot, the message yields no metric and is dropped downstream, so log the
 			// drop at warn (not debug) to keep a misconfigured pipeline observable.
-			if len(data) == 0 {
+			if !matchedConfiguredMetric && len(data) == 0 {
 				umh, err := s.formatConverter.parseUMHMessage(msg)
 				switch {
 				case err != nil:

--- a/sparkplug_plugin/sparkplug_b_output.go
+++ b/sparkplug_plugin/sparkplug_b_output.go
@@ -51,8 +51,8 @@ import (
 	"github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin/sparkplugb"
 )
 
-func init() {
-	outputSpec := service.NewConfigSpec().
+func sparkplugOutputConfigSpec() *service.ConfigSpec {
+	return service.NewConfigSpec().
 		Version("1.0.0").
 		Summary("Sparkplug B MQTT output acting as Edge Node").
 		Description(`The Sparkplug B output acts as an Edge Node, publishing data to Sparkplug MQTT topics
@@ -144,6 +144,10 @@ and then publishes DATA messages as Benthos messages flow through the pipeline.`
 				Default(true)).
 			Description("Processing behavior configuration").
 			Optional())
+}
+
+func init() {
+	outputSpec := sparkplugOutputConfigSpec()
 
 	err := service.RegisterOutput(
 		"sparkplug_b",
@@ -227,6 +231,9 @@ type sparkplugOutput struct {
 
 	// Added for type inference
 	typeConverter *TypeConverter
+
+	// Shared UMH-Core <-> Sparkplug conversion (same logic the input plugin uses)
+	formatConverter *FormatConverter
 }
 
 func newSparkplugOutput(conf *service.ParsedConfig, mgr *service.Resources) (*sparkplugOutput, error) {
@@ -418,6 +425,7 @@ func newSparkplugOutput(conf *service.ParsedConfig, mgr *service.Resources) (*sp
 		sequenceWraps:     mgr.Metrics().NewCounter("sequence_wraps"),
 		publishErrors:     mgr.Metrics().NewCounter("publish_errors"),
 		typeConverter:     NewTypeConverter(),
+		formatConverter:   NewFormatConverter(),
 	}, nil
 }
 
@@ -1265,24 +1273,27 @@ func (s *sparkplugOutput) extractMessageData(msg *service.Message) (map[string]i
 				}
 			}
 
-			// If no configured metrics matched, try to generate metric name from virtual_path:tag_name
+			// If no configured metric matched, derive the metric the same way the
+			// input plugin does, via the shared FormatConverter: the value comes from
+			// the UMH-Core payload ("value"/"val"/"data"/"measurement") and the metric
+			// name is virtual_path:tag_name (or just tag_name when virtual_path is empty).
+			// parseUMHMessage requires location_path and a UMH-valid tag_name; when it
+			// cannot, the message yields no metric and is dropped downstream, so log the
+			// drop at warn (not debug) to keep a misconfigured pipeline observable.
 			if len(data) == 0 {
-				if virtualPath, hasVirtualPath := msg.MetaGet("virtual_path"); hasVirtualPath {
-					// convert virtual_path "." to ":"
-					virtualPath = strings.ReplaceAll(virtualPath, ".", ":")
-					// Generate metric name using virtual_path:tag_name format
-					metricName := virtualPath + ":" + tagName
-					s.logger.Debugf("extractMessageData: No matching configured metrics, generating metric name: %s", metricName)
-
-					// Extract value from the tag_name field in the payload
-					if value, err := s.extractValueFromPath(structured, tagName); err == nil {
-						data[metricName] = value
-						s.logger.Debugf("extractMessageData: Successfully extracted value for generated metric %s: %v", metricName, value)
-					} else {
-						s.logger.Debugf("extractMessageData: Failed to extract value for generated metric %s from path %s: %v", metricName, tagName, err)
-					}
-				} else {
-					s.logger.Debugf("extractMessageData: tag_name %s found but no virtual_path metadata for metric generation", tagName)
+				umh, err := s.formatConverter.parseUMHMessage(msg)
+				switch {
+				case err != nil:
+					s.logger.Warnf("sparkplug_b: dropping message for tag_name %q: cannot derive a metric (needs a valid location_path and tag_name): %v", tagName, err)
+				case !isScalarValue(umh.Value):
+					// parseUMHMessage falls back to the whole payload when no recognized
+					// value field is present; publishing that map/slice as a string metric
+					// would be garbage, so drop it instead.
+					s.logger.Warnf("sparkplug_b: dropping message for tag_name %q: payload has no scalar value field (value/val/data/measurement)", tagName)
+				default:
+					metricName := s.formatConverter.constructSparkplugMetricName(umh.TopicInfo)
+					data[metricName] = umh.Value
+					s.logger.Debugf("extractMessageData: generated metric %s = %v", metricName, umh.Value)
 				}
 			}
 		} else {
@@ -1308,6 +1319,18 @@ func (s *sparkplugOutput) extractMessageData(msg *service.Message) (map[string]i
 
 	s.logger.Debugf("extractMessageData: Extraction complete - extracted %d metrics: %+v", len(data), data)
 	return data, nil
+}
+
+// isScalarValue reports whether v is a primitive value that can be published as a
+// single Sparkplug metric. parseUMHMessage falls back to the entire payload (a map)
+// when no recognized value field exists; such a value must not be published.
+func isScalarValue(v interface{}) bool {
+	switch v.(type) {
+	case nil, map[string]interface{}, []interface{}:
+		return false
+	default:
+		return true
+	}
 }
 
 func (s *sparkplugOutput) extractValueFromPath(structured interface{}, path string) (interface{}, error) {

--- a/sparkplug_plugin/sparkplug_b_output_test.go
+++ b/sparkplug_plugin/sparkplug_b_output_test.go
@@ -118,6 +118,27 @@ var _ = Describe("Sparkplug B output extractMessageData (auto-extract path)", fu
 		Expect(data).To(BeEmpty())
 	})
 
+	It("does not fan a tag-scoped message out across other configured metrics", func() {
+		// ENG-5087 follow-up: a tag_processor message carries a single tag, and its
+		// identity comes from meta.tag_name. The static-metric sweep must not also
+		// publish other configured metrics that happen to share the same value_from
+		// (here both default to "value"), or one tag would emit several metrics.
+		out.metrics = []MetricConfig{
+			{Name: "temperature", Alias: 1, ValueFrom: "value"},
+			{Name: "pressure", Alias: 2, ValueFrom: "value"},
+		}
+
+		data, err := out.extractMessageData(newMsg(`{"value": 42}`, map[string]string{
+			"location_path": "enterprise.site.area.line",
+			"tag_name":      "temperature",
+		}))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(1))
+		Expect(data["temperature"]).To(Equal(json.Number("42")))
+		Expect(data).NotTo(HaveKey("pressure"))
+	})
+
 	It("drops a payload with no scalar value field instead of publishing the whole map", func() {
 		// No value/val/data/measurement field and no field named after the tag ->
 		// parseUMHMessage falls back to the whole payload map; the output must NOT

--- a/sparkplug_plugin/sparkplug_b_output_test.go
+++ b/sparkplug_plugin/sparkplug_b_output_test.go
@@ -97,6 +97,27 @@ var _ = Describe("Sparkplug B output extractMessageData (auto-extract path)", fu
 		Expect(data["temperature"]).To(Equal(json.Number("7")))
 	})
 
+	It("does not auto-derive when a configured metric matched by name but value_from failed", func() {
+		// ENG-5087 follow-up: a configured metric whose name matches tag_name but
+		// whose value_from cannot be extracted must NOT fall through to the dynamic
+		// UMH path. Doing so would republish the message under a derived metric name
+		// (here "modbus:temperature"), masking the value_from misconfiguration and
+		// breaking the configured Sparkplug name/alias contract.
+		out.metrics = []MetricConfig{
+			{Name: "temperature", Alias: 5, ValueFrom: "raw"}, // "raw" is absent from the payload
+		}
+
+		data, err := out.extractMessageData(newMsg(`{"value": 42}`, map[string]string{
+			"location_path": "enterprise.site.area.line",
+			"tag_name":      "temperature",
+			"virtual_path":  "modbus",
+		}))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).NotTo(HaveKey("modbus:temperature")) // would be the masked, auto-derived name
+		Expect(data).To(BeEmpty())
+	})
+
 	It("drops a payload with no scalar value field instead of publishing the whole map", func() {
 		// No value/val/data/measurement field and no field named after the tag ->
 		// parseUMHMessage falls back to the whole payload map; the output must NOT

--- a/sparkplug_plugin/sparkplug_b_output_test.go
+++ b/sparkplug_plugin/sparkplug_b_output_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Sparkplug B output extractMessageData (auto-extract path)", fu
 // constructor here.
 var _ = Describe("Sparkplug B output construction", func() {
 	It("wires up the FormatConverter and extracts via the constructed instance", func() {
-		parsed, err := sparkplugOutputConfigSpec().ParseYAML(`
+		parsed, err := SparkplugConfigSpec.ParseYAML(`
 mqtt:
   urls: ["tcp://localhost:1883"]
 identity:

--- a/sparkplug_plugin/sparkplug_b_output_test.go
+++ b/sparkplug_plugin/sparkplug_b_output_test.go
@@ -1,0 +1,152 @@
+//go:build !integration
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sparkplug_plugin
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// These tests cover the auto-extract (no configured metrics:) path of the
+// Sparkplug B output, which is what a standard `tag_processor -> sparkplug_b`
+// pipeline exercises. Regression for ENG-5087: the value must be read from the
+// UMH-Core payload ("value"), and a metric must be produced from
+// virtual_path + tag_name (or just tag_name when virtual_path is absent),
+// rather than being silently dropped.
+var _ = Describe("Sparkplug B output extractMessageData (auto-extract path)", func() {
+	var out *sparkplugOutput
+
+	BeforeEach(func() {
+		out = &sparkplugOutput{
+			autoExtractTagName: true, // no configured metrics -> dynamic path
+			logger:             service.MockResources().Logger(),
+			formatConverter:    NewFormatConverter(),
+		}
+	})
+
+	// newMsg builds a UMH-Core message with the given payload JSON and metadata.
+	newMsg := func(payload string, meta map[string]string) *service.Message {
+		msg := service.NewMessage([]byte(payload))
+		for k, v := range meta {
+			msg.MetaSet(k, v)
+		}
+		return msg
+	}
+	umhCore := `{"value": 42, "timestamp_ms": 1640995200000}`
+
+	It("extracts the value and builds virtual_path:tag_name (the ENG-5087 bug case)", func() {
+		data, err := out.extractMessageData(newMsg(umhCore, map[string]string{
+			"location_path": "enterprise.site.area.line",
+			"tag_name":      "FirstFlagOfDiscreteInput",
+			"virtual_path":  "modbus",
+		}))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(1))
+		// Assert the typed value, not its string rendering: the extracted value's
+		// Go type drives the Sparkplug wire datatype, which is what ENG-5087 is about.
+		Expect(data["modbus:FirstFlagOfDiscreteInput"]).To(Equal(json.Number("42")))
+	})
+
+	It("makes virtual_path optional: metric name is just tag_name", func() {
+		data, err := out.extractMessageData(newMsg(umhCore, map[string]string{
+			"location_path": "enterprise.site.area.line",
+			"tag_name":      "FirstFlagOfDiscreteInput",
+		}))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(1))
+		Expect(data["FirstFlagOfDiscreteInput"]).To(Equal(json.Number("42")))
+	})
+
+	It("joins a dotted virtual_path with colons", func() {
+		data, err := out.extractMessageData(newMsg(umhCore, map[string]string{
+			"location_path": "enterprise.site.area.line",
+			"tag_name":      "temperature",
+			"virtual_path":  "motor.diagnostics",
+		}))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKey("motor:diagnostics:temperature"))
+	})
+
+	It("reads alternate UMH-Core value field names (val/data/measurement)", func() {
+		data, err := out.extractMessageData(newMsg(`{"val": 7}`, map[string]string{
+			"location_path": "enterprise.site.area.line",
+			"tag_name":      "temperature",
+		}))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data["temperature"]).To(Equal(json.Number("7")))
+	})
+
+	It("drops a payload with no scalar value field instead of publishing the whole map", func() {
+		// No value/val/data/measurement field and no field named after the tag ->
+		// parseUMHMessage falls back to the whole payload map; the output must NOT
+		// publish that as a stringified-map metric.
+		data, err := out.extractMessageData(newMsg(`{"foo": 1, "bar": 2}`, map[string]string{
+			"location_path": "enterprise.site.area.line",
+			"tag_name":      "temperature",
+		}))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(BeEmpty())
+	})
+
+	It("produces no metric when location_path is missing (message would be dropped)", func() {
+		data, err := out.extractMessageData(newMsg(umhCore, map[string]string{
+			"tag_name":     "temperature",
+			"virtual_path": "motor",
+		}))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(BeEmpty())
+	})
+})
+
+// Guards the construction seam: the auto-extract path dereferences
+// s.formatConverter, which newSparkplugOutput must wire up. A struct-literal test
+// can't catch a regression that drops that initialization, so build via the real
+// constructor here.
+var _ = Describe("Sparkplug B output construction", func() {
+	It("wires up the FormatConverter and extracts via the constructed instance", func() {
+		parsed, err := sparkplugOutputConfigSpec().ParseYAML(`
+mqtt:
+  urls: ["tcp://localhost:1883"]
+identity:
+  group_id: FactoryA
+  edge_node_id: benthos-fix
+`, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		out, err := newSparkplugOutput(parsed, service.MockResources())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out.formatConverter).NotTo(BeNil())
+
+		msg := service.NewMessage([]byte(`{"value": 42, "timestamp_ms": 1640995200000}`))
+		msg.MetaSet("location_path", "enterprise.site.area.line")
+		msg.MetaSet("tag_name", "temperature")
+		msg.MetaSet("virtual_path", "modbus")
+
+		data, err := out.extractMessageData(msg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveKey("modbus:temperature"))
+	})
+})


### PR DESCRIPTION
## What

A standard `tag_processor → sparkplug_b` flow silently dropped every message — the broker only ever saw an empty `NBIRTH`, never `DBIRTH`/`DDATA`.

## Why

The output read the metric value from a payload field named after the tag, but `tag_processor` emits the value under `value`. Nothing matched, so every message was acked and dropped with no error.

## Fix

- Extract the value and metric name via the same converter the Sparkplug B **input** already uses — value from `value`/`val`/`data`/`measurement`, metric name `virtual_path:tag_name` (or just `tag_name` when `virtual_path` is empty).
- Make `virtual_path` optional.
- Drop non-scalar payloads instead of publishing a stringified map, and warn on dropped messages so a misconfigured pipeline is observable.

## Testing

- New unit tests for the auto-extract path and the construction seam; full sparkplug suite (261 specs) passes; `go vet` and `golangci-lint` clean.
- End-to-end: ran the built binary against a real Modbus device with the original config (no `nodered_js` workaround) — publishes `DBIRTH` + `DDATA` with the correct tag values.

Closes ENG-5087

🤖 Generated with [Claude Code](https://claude.com/claude-code)