### PR TITLE
ENG-5126: Sparkplug B input — persist metric datatype from BIRTH, decode signed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Sparkplug B output: a standard `tag_processor → sparkplug_b` flow now publishes its tags. The output read the value from a payload field named after the tag, but `tag_processor` emits it under `value`, so every message was silently dropped — leaving only an empty `NBIRTH` on the broker. The output now extracts the value the same way the Sparkplug B input does (`value`/`val`/`data`/`measurement`), makes `virtual_path` optional, and warns instead of dropping silently when a payload can't be turned into a metric (ENG-5087)
+- Sparkplug B input: metric datatypes now survive from BIRTH to DATA. Per spec, `NDATA`/`DDATA` carries only alias + value while the BIRTH certificate defines name and datatype — but the input cached only the name, so DATA messages lost their `spb_datatype` metadata and signed integers decoded as their unsigned two's-complement wire value (an `Int32` of `-12` surfaced as `4294967284`). The alias cache now restores the datatype alongside the name, and `Int8`/`Int16`/`Int32`/`Int64` wire values are reinterpreted as signed (ENG-5126)
 
 ## [0.12.6]
 

--- a/sparkplug_plugin/sparkplug_b_core.go
+++ b/sparkplug_plugin/sparkplug_b_core.go
@@ -179,16 +179,25 @@ func (mt MessageType) IsState() bool {
 	return mt == MessageTypeSTATE
 }
 
-// AliasCache manages metric name to alias mappings for Sparkplug B optimization.
+// aliasEntry is the per-alias metric definition remembered from a BIRTH
+// certificate. DATA messages carry only the alias; name and datatype must be
+// restored from here (ENG-5126: datatype is required to decode signed integer
+// wire values, which Sparkplug packs as two's-complement into unsigned fields).
+type aliasEntry struct {
+	name     string
+	datatype *uint32 // nil when the BIRTH metric omitted the datatype
+}
+
+// AliasCache manages metric alias → definition mappings for Sparkplug B optimization.
 type AliasCache struct {
-	cache map[string]map[uint64]string // deviceKey -> (alias -> metric name)
+	cache map[string]map[uint64]aliasEntry // deviceKey -> (alias -> metric definition)
 	mu    sync.RWMutex
 }
 
 // NewAliasCache creates a new thread-safe alias cache.
 func NewAliasCache() *AliasCache {
 	return &AliasCache{
-		cache: make(map[string]map[uint64]string),
+		cache: make(map[string]map[uint64]aliasEntry),
 	}
 }
 
@@ -208,7 +217,7 @@ func (ac *AliasCache) CacheAliases(deviceKey string, metrics []*sparkplugb.Paylo
 
 	aliasMap, exists := ac.cache[deviceKey]
 	if !exists {
-		aliasMap = make(map[uint64]string)
+		aliasMap = make(map[uint64]aliasEntry)
 		ac.cache[deviceKey] = aliasMap
 	}
 
@@ -219,7 +228,12 @@ func (ac *AliasCache) CacheAliases(deviceKey string, metrics []*sparkplugb.Paylo
 		}
 		// Store alias mapping if both alias and name are present
 		if metric.Alias != nil && *metric.Alias != 0 && metric.Name != nil && *metric.Name != "" {
-			aliasMap[*metric.Alias] = *metric.Name
+			entry := aliasEntry{name: *metric.Name}
+			if metric.Datatype != nil {
+				dt := *metric.Datatype
+				entry.datatype = &dt
+			}
+			aliasMap[*metric.Alias] = entry
 			count++
 		}
 	}
@@ -247,7 +261,7 @@ func (ac *AliasCache) ResolveAliases(deviceKey string, metrics []*sparkplugb.Pay
 	}
 
 	// Create a copy of the alias map to avoid holding the lock during metric updates
-	aliasMapCopy := make(map[uint64]string, len(aliasMap))
+	aliasMapCopy := make(map[uint64]aliasEntry, len(aliasMap))
 	for k, v := range aliasMap {
 		aliasMapCopy[k] = v
 	}
@@ -260,8 +274,15 @@ func (ac *AliasCache) ResolveAliases(deviceKey string, metrics []*sparkplugb.Pay
 		}
 		// If metric has an alias but no name, try to resolve it
 		if metric.Alias != nil && *metric.Alias != 0 && (metric.Name == nil || *metric.Name == "") {
-			if name, found := aliasMapCopy[*metric.Alias]; found {
+			if entry, found := aliasMapCopy[*metric.Alias]; found {
+				name := entry.name
 				metric.Name = &name
+				// Restore the datatype from the BIRTH certificate unless the
+				// DATA metric carries its own (publisher-sent wins).
+				if metric.Datatype == nil && entry.datatype != nil {
+					dt := *entry.datatype
+					metric.Datatype = &dt
+				}
 				count++
 			}
 		}
@@ -274,7 +295,7 @@ func (ac *AliasCache) ResolveAliases(deviceKey string, metrics []*sparkplugb.Pay
 func (ac *AliasCache) Clear() {
 	ac.mu.Lock()
 	defer ac.mu.Unlock()
-	ac.cache = make(map[string]map[uint64]string)
+	ac.cache = make(map[string]map[uint64]aliasEntry)
 }
 
 // SpbDeviceKey creates a unified device key for Sparkplug B

--- a/sparkplug_plugin/sparkplug_b_datatype_test.go
+++ b/sparkplug_plugin/sparkplug_b_datatype_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ENG-5126: Sparkplug B metric datatype must survive from BIRTH to DATA.
+// Sparkplug B metric datatype must survive from BIRTH to DATA.
 //
 // Per the Sparkplug B spec, NBIRTH/DBIRTH carries alias + name + datatype while
 // NDATA/DDATA carries only alias + value; the host is required to remember the
@@ -36,7 +36,7 @@ import (
 	"github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin/sparkplugb"
 )
 
-var _ = Describe("Datatype persistence across BIRTH and DATA (ENG-5126)", func() {
+var _ = Describe("Datatype persistence across BIRTH and DATA", func() {
 	Describe("AliasCache", func() {
 		var cache *sparkplugplugin.AliasCache
 

--- a/sparkplug_plugin/sparkplug_b_datatype_test.go
+++ b/sparkplug_plugin/sparkplug_b_datatype_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 var _ = Describe("Datatype persistence across BIRTH and DATA (ENG-5126)", func() {
-
 	Describe("AliasCache", func() {
 		var cache *sparkplugplugin.AliasCache
 
@@ -191,7 +190,8 @@ var _ = Describe("Datatype persistence across BIRTH and DATA (ENG-5126)", func()
 			}
 		}
 
-		DescribeTable("decodes signed integer wire values using the BIRTH datatype",
+		DescribeTable(
+			"decodes signed integer wire values using the BIRTH datatype",
 			func(datatype uint32, wire interface{}, expected float64) {
 				birthMetric := &sparkplugb.Payload_Metric{
 					Name:     stringPtr("temp"),

--- a/sparkplug_plugin/sparkplug_b_datatype_test.go
+++ b/sparkplug_plugin/sparkplug_b_datatype_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Datatype persistence across BIRTH and DATA", func() {
 		// runNDATA pushes an NBIRTH (full defs) then an NDATA (alias-only) through
 		// the same processing path processSparkplugMessage uses and returns the
 		// split messages produced for the NDATA.
-		runNDATA := func(birthMetric *sparkplugb.Payload_Metric, dataMetric *sparkplugb.Payload_Metric) (string, map[string]interface{}) {
+		runNDATA := func(birthMetric *sparkplugb.Payload_Metric, dataMetric *sparkplugb.Payload_Metric) (string, map[string]any) {
 			birthPayload := birth(birthMetric)
 			wrapper.ProcessBirthMessage(sparkplugplugin.MessageTypeNBIRTH, birthPayload, topicInfo)
 
@@ -146,7 +146,7 @@ var _ = Describe("Datatype persistence across BIRTH and DATA", func() {
 
 			raw, err := msg.AsBytes()
 			Expect(err).NotTo(HaveOccurred())
-			var body map[string]interface{}
+			var body map[string]any
 			Expect(json.Unmarshal(raw, &body)).To(Succeed())
 
 			return datatypeMeta, body
@@ -178,8 +178,8 @@ var _ = Describe("Datatype persistence across BIRTH and DATA", func() {
 
 		// setWireValue assigns an int_value/long_value oneof to a metric. The oneof
 		// interface type is unexported in the generated code, so entries pass the
-		// exported wrapper structs as interface{}.
-		setWireValue := func(m *sparkplugb.Payload_Metric, wire interface{}) {
+		// exported wrapper structs as any.
+		setWireValue := func(m *sparkplugb.Payload_Metric, wire any) {
 			switch v := wire.(type) {
 			case *sparkplugb.Payload_Metric_IntValue:
 				m.Value = v
@@ -192,7 +192,7 @@ var _ = Describe("Datatype persistence across BIRTH and DATA", func() {
 
 		DescribeTable(
 			"decodes signed integer wire values using the BIRTH datatype",
-			func(datatype uint32, wire interface{}, expected float64) {
+			func(datatype uint32, wire any, expected float64) {
 				birthMetric := &sparkplugb.Payload_Metric{
 					Name:     stringPtr("temp"),
 					Alias:    uint64Ptr(1),
@@ -238,7 +238,7 @@ var _ = Describe("Datatype persistence across BIRTH and DATA", func() {
 
 			raw, err := batch[0].AsBytes()
 			Expect(err).NotTo(HaveOccurred())
-			var body map[string]interface{}
+			var body map[string]any
 			Expect(json.Unmarshal(raw, &body)).To(Succeed())
 
 			Expect(body["value"]).To(BeNumerically("==", float64(-7)))
@@ -260,6 +260,42 @@ var _ = Describe("Datatype persistence across BIRTH and DATA", func() {
 
 			Expect(datatypeMeta).To(Equal("Float"))
 			Expect(body["value"]).To(BeNumerically("==", 3.5))
+		})
+
+		// DDATA shares processDataMessage/resolveAliases/extractMetricValue with
+		// NDATA, so the BIRTH-datatype fix applies to device metrics too; this
+		// spec locks that in through the device-level path (aliases are cached
+		// per device from DBIRTH).
+		It("sets spb_datatype and decodes signed values on DDATA from the DBIRTH definition", func() {
+			deviceTopicInfo := &sparkplugplugin.TopicInfo{Group: "Factory", EdgeNode: "Line1", Device: "Device1"}
+
+			birthPayload := birth(&sparkplugb.Payload_Metric{
+				Name:     stringPtr("temp"),
+				Alias:    uint64Ptr(1),
+				Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt32),
+				Value:    &sparkplugb.Payload_Metric_IntValue{IntValue: wireInt32(-7)},
+			})
+			wrapper.ProcessBirthMessage(sparkplugplugin.MessageTypeDBIRTH, birthPayload, deviceTopicInfo)
+
+			dataPayload := data(1, &sparkplugb.Payload_Metric{
+				Alias: uint64Ptr(1),
+				Value: &sparkplugb.Payload_Metric_IntValue{IntValue: wireInt32(-12)},
+			})
+			wrapper.ProcessDataMessage(sparkplugplugin.MessageTypeDDATA, dataPayload, deviceTopicInfo)
+			batch := wrapper.CreateSplitMessages(dataPayload, sparkplugplugin.MessageTypeDDATA, deviceTopicInfo, "spBv1.0/Factory/DDATA/Line1/Device1")
+			Expect(batch).To(HaveLen(1))
+
+			msg := batch[0]
+			datatypeMeta, _ := msg.MetaGet("spb_datatype")
+			Expect(datatypeMeta).To(Equal("Int32"),
+				"spb_datatype must be present on DDATA, sourced from the DBIRTH certificate")
+
+			raw, err := msg.AsBytes()
+			Expect(err).NotTo(HaveOccurred())
+			var body map[string]any
+			Expect(json.Unmarshal(raw, &body)).To(Succeed())
+			Expect(body["name"]).To(Equal("temp"))
+			Expect(body["value"]).To(BeNumerically("==", float64(-12)))
 		})
 	})
 })

--- a/sparkplug_plugin/sparkplug_b_datatype_test.go
+++ b/sparkplug_plugin/sparkplug_b_datatype_test.go
@@ -1,0 +1,265 @@
+//go:build !integration
+
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ENG-5126: Sparkplug B metric datatype must survive from BIRTH to DATA.
+//
+// Per the Sparkplug B spec, NBIRTH/DBIRTH carries alias + name + datatype while
+// NDATA/DDATA carries only alias + value; the host is required to remember the
+// BIRTH definitions. These tests pin two behaviors:
+//  1. AliasCache restores Datatype (not just Name) when resolving DATA aliases.
+//  2. Signed integer wire values (two's-complement packed into the unsigned
+//     int_value/long_value protobuf fields) are reinterpreted using the datatype,
+//     so Int32(-12) surfaces as -12, not 4294967284.
+
+package sparkplug_plugin_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sparkplugplugin "github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin"
+	"github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin/sparkplugb"
+)
+
+var _ = Describe("Datatype persistence across BIRTH and DATA (ENG-5126)", func() {
+
+	Describe("AliasCache", func() {
+		var cache *sparkplugplugin.AliasCache
+
+		BeforeEach(func() {
+			cache = sparkplugplugin.NewAliasCache()
+		})
+
+		It("restores the cached datatype when resolving an alias-only DATA metric", func() {
+			birthMetrics := []*sparkplugb.Payload_Metric{
+				{
+					Name:     stringPtr("temp"),
+					Alias:    uint64Ptr(1),
+					Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt32),
+				},
+			}
+			Expect(cache.CacheAliases("Factory/Line1", birthMetrics)).To(Equal(1))
+
+			dataMetrics := []*sparkplugb.Payload_Metric{
+				{
+					Alias: uint64Ptr(1),
+					Value: &sparkplugb.Payload_Metric_IntValue{IntValue: 4294967284}, // -12 as Int32
+				},
+			}
+			Expect(cache.ResolveAliases("Factory/Line1", dataMetrics)).To(Equal(1))
+
+			Expect(dataMetrics[0].Name).NotTo(BeNil())
+			Expect(*dataMetrics[0].Name).To(Equal("temp"))
+			Expect(dataMetrics[0].Datatype).NotTo(BeNil(),
+				"datatype from the BIRTH certificate must be restored on DATA metrics")
+			Expect(*dataMetrics[0].Datatype).To(Equal(sparkplugplugin.SparkplugDataTypeInt32))
+		})
+
+		It("does not overwrite a datatype the DATA metric already carries", func() {
+			birthMetrics := []*sparkplugb.Payload_Metric{
+				{
+					Name:     stringPtr("temp"),
+					Alias:    uint64Ptr(1),
+					Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt32),
+				},
+			}
+			cache.CacheAliases("Factory/Line1", birthMetrics)
+
+			dataMetrics := []*sparkplugb.Payload_Metric{
+				{
+					Alias:    uint64Ptr(1),
+					Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt64),
+					Value:    &sparkplugb.Payload_Metric_LongValue{LongValue: 7},
+				},
+			}
+			cache.ResolveAliases("Factory/Line1", dataMetrics)
+
+			Expect(*dataMetrics[0].Datatype).To(Equal(sparkplugplugin.SparkplugDataTypeInt64))
+		})
+
+		It("resolves the name even when the BIRTH metric had no datatype", func() {
+			birthMetrics := []*sparkplugb.Payload_Metric{
+				{
+					Name:  stringPtr("legacy"),
+					Alias: uint64Ptr(9),
+				},
+			}
+			cache.CacheAliases("Factory/Line1", birthMetrics)
+
+			dataMetrics := []*sparkplugb.Payload_Metric{
+				{
+					Alias: uint64Ptr(9),
+					Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 1.5},
+				},
+			}
+			Expect(cache.ResolveAliases("Factory/Line1", dataMetrics)).To(Equal(1))
+			Expect(*dataMetrics[0].Name).To(Equal("legacy"))
+			Expect(dataMetrics[0].Datatype).To(BeNil())
+		})
+	})
+
+	Describe("NBIRTH→NDATA flow through the input", func() {
+		var (
+			wrapper   *sparkplugplugin.SparkplugInputTestWrapper
+			topicInfo *sparkplugplugin.TopicInfo
+		)
+
+		// signed wire value helper: Sparkplug packs signed ints as
+		// two's-complement into the unsigned protobuf fields.
+		wireInt32 := func(v int32) uint32 { return uint32(v) }
+
+		birth := func(metrics ...*sparkplugb.Payload_Metric) *sparkplugb.Payload {
+			return &sparkplugb.Payload{Seq: uint64Ptr(0), Metrics: metrics}
+		}
+		data := func(seq uint64, metrics ...*sparkplugb.Payload_Metric) *sparkplugb.Payload {
+			return &sparkplugb.Payload{Seq: uint64Ptr(seq), Metrics: metrics}
+		}
+
+		// runNDATA pushes an NBIRTH (full defs) then an NDATA (alias-only) through
+		// the same processing path processSparkplugMessage uses and returns the
+		// split messages produced for the NDATA.
+		runNDATA := func(birthMetric *sparkplugb.Payload_Metric, dataMetric *sparkplugb.Payload_Metric) (string, map[string]interface{}) {
+			birthPayload := birth(birthMetric)
+			wrapper.ProcessBirthMessage(sparkplugplugin.MessageTypeNBIRTH, birthPayload, topicInfo)
+
+			dataPayload := data(1, dataMetric)
+			wrapper.ProcessDataMessage(sparkplugplugin.MessageTypeNDATA, dataPayload, topicInfo)
+			batch := wrapper.CreateSplitMessages(dataPayload, sparkplugplugin.MessageTypeNDATA, topicInfo, "spBv1.0/Factory/NDATA/Line1")
+			Expect(batch).To(HaveLen(1))
+
+			msg := batch[0]
+			datatypeMeta, _ := msg.MetaGet("spb_datatype")
+
+			raw, err := msg.AsBytes()
+			Expect(err).NotTo(HaveOccurred())
+			var body map[string]interface{}
+			Expect(json.Unmarshal(raw, &body)).To(Succeed())
+
+			return datatypeMeta, body
+		}
+
+		BeforeEach(func() {
+			wrapper = sparkplugplugin.NewSparkplugInputForTesting()
+			topicInfo = &sparkplugplugin.TopicInfo{Group: "Factory", EdgeNode: "Line1"}
+		})
+
+		It("sets spb_datatype on NDATA messages from the cached BIRTH definition", func() {
+			datatypeMeta, body := runNDATA(
+				&sparkplugb.Payload_Metric{
+					Name:     stringPtr("temp"),
+					Alias:    uint64Ptr(1),
+					Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt32),
+					Value:    &sparkplugb.Payload_Metric_IntValue{IntValue: wireInt32(-7)},
+				},
+				&sparkplugb.Payload_Metric{
+					Alias: uint64Ptr(1),
+					Value: &sparkplugb.Payload_Metric_IntValue{IntValue: wireInt32(-12)},
+				},
+			)
+
+			Expect(datatypeMeta).To(Equal("Int32"),
+				"spb_datatype must be present on NDATA, sourced from the NBIRTH certificate")
+			Expect(body["name"]).To(Equal("temp"))
+		})
+
+		// setWireValue assigns an int_value/long_value oneof to a metric. The oneof
+		// interface type is unexported in the generated code, so entries pass the
+		// exported wrapper structs as interface{}.
+		setWireValue := func(m *sparkplugb.Payload_Metric, wire interface{}) {
+			switch v := wire.(type) {
+			case *sparkplugb.Payload_Metric_IntValue:
+				m.Value = v
+			case *sparkplugb.Payload_Metric_LongValue:
+				m.Value = v
+			default:
+				Fail("unsupported wire value type in test entry")
+			}
+		}
+
+		DescribeTable("decodes signed integer wire values using the BIRTH datatype",
+			func(datatype uint32, wire interface{}, expected float64) {
+				birthMetric := &sparkplugb.Payload_Metric{
+					Name:     stringPtr("temp"),
+					Alias:    uint64Ptr(1),
+					Datatype: uint32Ptr(datatype),
+				}
+				setWireValue(birthMetric, wire)
+
+				dataMetric := &sparkplugb.Payload_Metric{
+					Alias: uint64Ptr(1),
+				}
+				setWireValue(dataMetric, wire)
+
+				_, body := runNDATA(birthMetric, dataMetric)
+
+				Expect(body["value"]).To(BeNumerically("==", expected))
+			},
+			Entry("Int8 -7", sparkplugplugin.SparkplugDataTypeInt8,
+				&sparkplugb.Payload_Metric_IntValue{IntValue: 249}, float64(-7)),
+			Entry("Int16 -7", sparkplugplugin.SparkplugDataTypeInt16,
+				&sparkplugb.Payload_Metric_IntValue{IntValue: 65529}, float64(-7)),
+			Entry("Int32 -12", sparkplugplugin.SparkplugDataTypeInt32,
+				&sparkplugb.Payload_Metric_IntValue{IntValue: 4294967284}, float64(-12)),
+			Entry("Int64 -12", sparkplugplugin.SparkplugDataTypeInt64,
+				&sparkplugb.Payload_Metric_LongValue{LongValue: 18446744073709551604}, float64(-12)),
+			Entry("Int32 positive stays positive", sparkplugplugin.SparkplugDataTypeInt32,
+				&sparkplugb.Payload_Metric_IntValue{IntValue: 42}, float64(42)),
+			Entry("UInt32 unchanged", sparkplugplugin.SparkplugDataTypeUInt32,
+				&sparkplugb.Payload_Metric_IntValue{IntValue: 4294967284}, float64(4294967284)),
+			Entry("UInt64 unchanged", sparkplugplugin.SparkplugDataTypeUInt64,
+				&sparkplugb.Payload_Metric_LongValue{LongValue: 7}, float64(7)),
+		)
+
+		It("decodes signed values correctly on the BIRTH message itself", func() {
+			birthPayload := birth(&sparkplugb.Payload_Metric{
+				Name:     stringPtr("temp"),
+				Alias:    uint64Ptr(1),
+				Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeInt32),
+				Value:    &sparkplugb.Payload_Metric_IntValue{IntValue: wireInt32(-7)},
+			})
+			wrapper.ProcessBirthMessage(sparkplugplugin.MessageTypeNBIRTH, birthPayload, topicInfo)
+			batch := wrapper.CreateSplitMessages(birthPayload, sparkplugplugin.MessageTypeNBIRTH, topicInfo, "spBv1.0/Factory/NBIRTH/Line1")
+			Expect(batch).To(HaveLen(1))
+
+			raw, err := batch[0].AsBytes()
+			Expect(err).NotTo(HaveOccurred())
+			var body map[string]interface{}
+			Expect(json.Unmarshal(raw, &body)).To(Succeed())
+
+			Expect(body["value"]).To(BeNumerically("==", float64(-7)))
+		})
+
+		It("preserves float values untouched on NDATA", func() {
+			datatypeMeta, body := runNDATA(
+				&sparkplugb.Payload_Metric{
+					Name:     stringPtr("flow"),
+					Alias:    uint64Ptr(2),
+					Datatype: uint32Ptr(sparkplugplugin.SparkplugDataTypeFloat),
+					Value:    &sparkplugb.Payload_Metric_FloatValue{FloatValue: 3.5},
+				},
+				&sparkplugb.Payload_Metric{
+					Alias: uint64Ptr(2),
+					Value: &sparkplugb.Payload_Metric_FloatValue{FloatValue: 3.5},
+				},
+			)
+
+			Expect(datatypeMeta).To(Equal("Float"))
+			Expect(body["value"]).To(BeNumerically("==", 3.5))
+		})
+	})
+})

--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -1615,7 +1615,7 @@ func (s *sparkplugInput) extractMetricValueRaw(metric *sparkplugb.Payload_Metric
 // metric datatype. Sparkplug B packs signed integers (Int8/Int16/Int32) as
 // two's-complement into int_value (ENG-5126); without a signed datatype the raw
 // uint32 is returned unchanged (UInt8/UInt16/UInt32, or datatype unknown).
-func decodeIntValue(datatype *uint32, raw uint32) interface{} {
+func decodeIntValue(datatype *uint32, raw uint32) any {
 	if datatype == nil {
 		return raw
 	}
@@ -1634,7 +1634,7 @@ func decodeIntValue(datatype *uint32, raw uint32) interface{} {
 // decodeLongValue reinterprets the unsigned long_value wire field according to
 // the metric datatype: Int64 is two's-complement (ENG-5126); UInt64 and
 // DateTime pass through unchanged.
-func decodeLongValue(datatype *uint32, raw uint64) interface{} {
+func decodeLongValue(datatype *uint32, raw uint64) any {
 	if datatype != nil && *datatype == SparkplugDataTypeInt64 {
 		return int64(raw)
 	}

--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -170,9 +170,7 @@ type sparkplugInput struct {
 	typeConverter     *TypeConverter
 	mqttClientBuilder *MQTTClientBuilder
 
-	// Legacy alias cache for backward compatibility during transition
-	legacyAliasCache map[string]map[uint64]string // deviceKey -> (alias -> metric name)
-	stateMu          sync.RWMutex
+	stateMu sync.RWMutex
 
 	// Per-node REBIRTH throttle. Shared across every reason sendRebirthRequest
 	// dispatches (discovery, sequence gap, unresolved aliases) so concurrent
@@ -418,7 +416,6 @@ func newSparkplugInput(conf *service.ParsedConfig, mgr *service.Resources) (*spa
 		messages:                make(chan mqttMessage, 1000),
 		done:                    make(chan struct{}),
 		nodeStates:              make(map[string]*nodeState),
-		legacyAliasCache:        make(map[string]map[uint64]string),
 		birthRequested:          make(map[string]time.Time), // Per-node REBIRTH throttle
 		aliasCache:              NewAliasCache(),
 		topicParser:             NewTopicParser(),
@@ -1196,9 +1193,9 @@ func (s *sparkplugInput) extractMetricValue(metric *sparkplugb.Payload_Metric) [
 	} else if value := metric.GetValue(); value != nil {
 		switch v := value.(type) {
 		case *sparkplugb.Payload_Metric_IntValue:
-			result["value"] = v.IntValue
+			result["value"] = decodeIntValue(metric.Datatype, v.IntValue)
 		case *sparkplugb.Payload_Metric_LongValue:
-			result["value"] = v.LongValue
+			result["value"] = decodeLongValue(metric.Datatype, v.LongValue)
 		case *sparkplugb.Payload_Metric_FloatValue:
 			result["value"] = v.FloatValue
 		case *sparkplugb.Payload_Metric_DoubleValue:
@@ -1595,9 +1592,9 @@ func (s *sparkplugInput) extractMetricValueRaw(metric *sparkplugb.Payload_Metric
 	if value := metric.GetValue(); value != nil {
 		switch v := value.(type) {
 		case *sparkplugb.Payload_Metric_IntValue:
-			return v.IntValue
+			return decodeIntValue(metric.Datatype, v.IntValue)
 		case *sparkplugb.Payload_Metric_LongValue:
-			return v.LongValue
+			return decodeLongValue(metric.Datatype, v.LongValue)
 		case *sparkplugb.Payload_Metric_FloatValue:
 			return v.FloatValue
 		case *sparkplugb.Payload_Metric_DoubleValue:
@@ -1612,6 +1609,36 @@ func (s *sparkplugInput) extractMetricValueRaw(metric *sparkplugb.Payload_Metric
 	}
 
 	return nil
+}
+
+// decodeIntValue reinterprets the unsigned int_value wire field according to the
+// metric datatype. Sparkplug B packs signed integers (Int8/Int16/Int32) as
+// two's-complement into int_value (ENG-5126); without a signed datatype the raw
+// uint32 is returned unchanged (UInt8/UInt16/UInt32, or datatype unknown).
+func decodeIntValue(datatype *uint32, raw uint32) interface{} {
+	if datatype == nil {
+		return raw
+	}
+	switch *datatype {
+	case SparkplugDataTypeInt8:
+		return int8(uint8(raw))
+	case SparkplugDataTypeInt16:
+		return int16(uint16(raw))
+	case SparkplugDataTypeInt32:
+		return int32(raw)
+	default:
+		return raw
+	}
+}
+
+// decodeLongValue reinterprets the unsigned long_value wire field according to
+// the metric datatype: Int64 is two's-complement (ENG-5126); UInt64 and
+// DateTime pass through unchanged.
+func decodeLongValue(datatype *uint32, raw uint64) interface{} {
+	if datatype != nil && *datatype == SparkplugDataTypeInt64 {
+		return int64(raw)
+	}
+	return raw
 }
 
 // convertSparkplugDataTypeToString converts Sparkplug data type ID to format converter expected string

--- a/sparkplug_plugin/sparkplug_b_input_test_helper_test.go
+++ b/sparkplug_plugin/sparkplug_b_input_test_helper_test.go
@@ -89,7 +89,6 @@ func NewSparkplugInputForTestingWithRole(role Role) *SparkplugInputTestWrapper {
 		},
 		logger:                  logger,
 		nodeStates:              make(map[string]*nodeState),
-		legacyAliasCache:        make(map[string]map[uint64]string),
 		birthRequested:          make(map[string]time.Time),
 		aliasCache:              NewAliasCache(),
 		topicParser:             NewTopicParser(),


### PR DESCRIPTION
## Summary

Fixes [ENG-5126](https://linear.app/united-manufacturing-hub/issue/ENG-5126/sparkplug-b-input-metric-datatype-dropped-on-ndata-spb-datatype): community report that `spb_datatype` was missing in the Topic Browser on NDATA messages and values were wrong, while alias→name resolution worked.

Per the Sparkplug B spec, NDATA/DDATA carries only `alias + value`; the BIRTH certificate defines `name` and `datatype`, and the host must remember both. The input's `AliasCache` remembered only the name:

1. **Datatype never cached.** On DATA messages `metric.Datatype` stayed nil, so the `spb_datatype` metadata was never set and the UMH conversion path fell back to `"unknown"`.
2. **Datatype never applied.** Sparkplug packs signed integers as two's-complement into the unsigned `int_value`/`long_value` wire fields. Without the datatype, an `Int32` of `-12` surfaced as `4294967284` (wrong even on the BIRTH message itself).

## Changes

- `AliasCache` now stores `alias → {name, datatype}`; `ResolveAliases` restores the datatype onto DATA metrics the same way it already restored the name (a datatype sent on the DATA metric itself wins)
- New `decodeIntValue`/`decodeLongValue` helpers reinterpret the wire value per datatype in both extractors (`extractMetricValue` for the JSON payload, `extractMetricValueRaw` for UMH conversion), so `Int8`/`Int16`/`Int32`/`Int64` decode as signed; UInt*/Float/Double/Bool/String paths unchanged
- Dropped the dead `legacyAliasCache` field (declared and initialized, never read)
- Changelog entry under `## [Unreleased]` → `### Fixes`

## Testing

TDD: all new specs in `sparkplug_b_datatype_test.go` were written first and watched fail (8 failing, 5 control specs passing) before any production code changed.

- Cache-level specs: datatype restored on resolve, publisher-sent datatype not overwritten, datatype-less BIRTH still resolves the name
- NBIRTH→NDATA flow specs through the same path production uses: `spb_datatype` metadata present on NDATA, plus a signed/unsigned decode table (Int8/Int16/Int32/Int64 negative, positive passthrough, UInt32/UInt64 unchanged, Float untouched)
- Full suite: `make test-sparkplug` — 276/276 passing
- Reproduced live before the fix with a minimal Sparkplug publisher (retained NBIRTH `Int32 -7`, alias-only NDATA `-12`) against a umh-core bridge: `spb_datatype` absent, value read `4294967284`

## Notes

- DateTime metrics still pass through as raw epoch-millis — deliberate; converting them is a behavior change tracked in ENG-5126 as out of scope
- Complex types (DataSet/Template/Bytes) remain unhandled (dropped) as before — separate gap noted in the ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)
