### PR TITLE
chore(deps): bump gopcua to v0.9.0

### DIFF
--- a/.changelog/unreleased/fixes-20260618-163816.yaml
+++ b/.changelog/unreleased/fixes-20260618-163816.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: 'OPC UA: reading or subscribing to large tag sets (roughly a thousand or more) over an encrypted connection no longer drops the connection with an `EOF` error'
+time: 2026-06-18T16:38:16.000000+02:00

--- a/.changelog/unreleased/fixes-20260618-163817.yaml
+++ b/.changelog/unreleased/fixes-20260618-163817.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: 'OPC UA: subscriptions now survive a reconnect, so data collection resumes automatically after a network interruption instead of stalling until the input is restarted'
+time: 2026-06-18T16:38:17.000000+02:00

--- a/.changelog/unreleased/fixes-20260618-163818.yaml
+++ b/.changelog/unreleased/fixes-20260618-163818.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: 'OPC UA: connecting to servers that present their certificate as a chain (leaf plus intermediates), such as Siemens WinCC Unified, now works'
+time: 2026-06-18T16:38:18.000000+02:00

--- a/.changelog/unreleased/fixes-20260618-163819.yaml
+++ b/.changelog/unreleased/fixes-20260618-163819.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: 'OPC UA: a single unreadable or invalid node ID no longer blocks monitoring the rest of a subscribed batch'
+time: 2026-06-18T16:38:19.000000+02:00

--- a/.changelog/unreleased/fixes-20260618-163820.yaml
+++ b/.changelog/unreleased/fixes-20260618-163820.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: 'OPC UA: browsing certain servers no longer crashes the input'
+time: 2026-06-18T16:38:20.000000+02:00

--- a/.changelog/unreleased/improvements-20260618-163815.yaml
+++ b/.changelog/unreleased/improvements-20260618-163815.yaml
@@ -1,0 +1,3 @@
+kind: improvements
+body: 'OPC UA: encrypted connections (`Basic256Sha256`, both `Sign` and `Sign & Encrypt`) now complete reliably, including signing-only mode which previously failed to connect'
+time: 2026-06-18T16:38:15.000000+02:00

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
-	github.com/gopcua/opcua v0.8.0
+	github.com/gopcua/opcua v0.9.0
 	github.com/grid-x/modbus v0.0.0-20260527064858-ef3bed576432
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kaptinlin/jsonschema v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -940,8 +940,8 @@ github.com/googleapis/go-sql-spanner v1.24.1 h1:bHxQHLHkuTdf7tMSQNpsq8nlV9K+c6rh
 github.com/googleapis/go-sql-spanner v1.24.1/go.mod h1:5QDpkIaULC+pbwIgzwzTmXj4Jq5iFGVHQ3F1eEw8+vY=
 github.com/gookit/color v1.6.0 h1:JjJXBTk1ETNyqyilJhkTXJYYigHG24TM9Xa2M1xAhRA=
 github.com/gookit/color v1.6.0/go.mod h1:9ACFc7/1IpHGBW8RwuDm/0YEnhg3dwwXpoMsmtyHfjs=
-github.com/gopcua/opcua v0.8.0 h1:nB9vDewEmuXmSQf1C9inCHPblFwsH21FeB2Kk6o6Y7U=
-github.com/gopcua/opcua v0.8.0/go.mod h1:Z6aellk0gIzznZd2UX+Syd/hUMBt65gRlTakpGo6se8=
+github.com/gopcua/opcua v0.9.0 h1:IWkQSOOr4ZxzqbvYTUPzT4Ld4I927ldfFcJMInHvYiI=
+github.com/gopcua/opcua v0.9.0/go.mod h1:Z6aellk0gIzznZd2UX+Syd/hUMBt65gRlTakpGo6se8=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=


### PR DESCRIPTION
## What this does

Bumps `github.com/gopcua/opcua` from `v0.8.0` to `v0.9.0`. Drop-in: no plugin code changes were needed (build + vet clean). The OPC UA input/output inherit a year of upstream client fixes.

Validated against live hardware before bumping (see the test-results comment below): on a real Kepware KEPServerEX, `v0.8.0` dropped an encrypted 1000-tag subscription with `EOF`, while `v0.9.0` subscribes cleanly. The full CI unit suite is green.

Changelog entries are added as changie fragments under `.changelog/unreleased/` (the `(client)` runtime items below are the ones our users get automatically).

## Full gopcua v0.9.0 changelog

The release ships a client and a server. Each item is tagged **(client)** or **(server)**; **API** items only matter to Go code written against the library. Through benthos-umh we use the client, so the plain **(client)** items are the runtime behavior we inherit.

### New

- `Basic256Sha256` channels now complete a handshake end to end in both `Sign` and `SignAndEncrypt` mode between a gopcua client and server, so you can run signed and encrypted connections (client + server)
- A `StateChangedFunc` callback lets a client run your own code on every connection-state change (Connected, Connecting, Disconnected, Reconnecting) (client, API)

### Improvements

- Monitoring a batch of nodes now succeeds for the valid ones instead of failing the whole batch when one node ID is bad; each rejected node is reported individually as a `monitor.ItemError` you can read with `errors.As` (client)
- Node operations now run against a client interface, so you can inject a mocked client when unit-testing code that calls node methods (client, API)

### Fixes

- Reading or subscribing to large sets of nodes (roughly a thousand or more) over an encrypted connection no longer drops the connection with an `EOF`; smaller requests and unencrypted connections were not affected (client + server)
- Subscriptions now survive a reconnect: after a network interruption the client no longer loses its subscriptions and stops receiving data until it is restarted (client)
- Recovering missed data after a reconnect no longer hangs in an endless retry loop or silently drops the recovered notifications (client)
- Connecting to servers that present their certificate as a chain of leaf plus intermediate certificates, such as Siemens WinCC Unified Runtime, now works (client)
- Browsing now returns a usable node ID for references typed as `ExpandedNodeID` instead of nil, which previously caused a panic (client)
- Calling `Close` on a client that never established a session no longer panics (client)
- expvar counters (read, send, dial, subscription) render again under `/debug/vars` on Go 1.23 (client, API)
- A server no longer crashes when a client writes to a node in a namespace that does not exist; it returns `Bad_NodeIdUnknown` (server)
- Server writes to non-Value attributes such as Description or DisplayName now report success instead of a false bad-attribute error (server)
- Server responses larger than the negotiated chunk size are now split across multiple chunks instead of dropping the connection (server)
- A server now returns a valid, non-zero session timeout, so strict clients such as UaExpert no longer fail to connect with `BadTimeout` (server)
- Creating a folder node in a server address space no longer panics (server)
- A server now sets the `ReceiverCertificateThumbprint` on its handshake response, so strict clients (Prosys, UaExpert) accept encrypted channels against a gopcua server (server)

**Full gopcua changelog**: https://github.com/gopcua/opcua/compare/v0.8.0...v0.9.0-rc1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
