### PR TITLE
fix(sparkplug): nest device data under edge node via include_edge_node_in_location (ENG-5175)

### DIFF
--- a/.changelog/unreleased/fixes-20260622-135906.yaml
+++ b/.changelog/unreleased/fixes-20260622-135906.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: Sparkplug B input can nest device data under its edge node via include_edge_node_in_location, so identically-named devices on different edge nodes no longer collide at the top of the hierarchy (ENG-5175)
+time: 2026-06-22T13:59:06.673049+02:00

--- a/docs/input/sparkplug-b-input.md
+++ b/docs/input/sparkplug-b-input.md
@@ -180,6 +180,44 @@ Here's how a Sparkplug B message maps to UMH-Core using the Modified Parris Meth
 | `request_birth_on_connect` | `bool` | `true` | Send REBIRTH when DATA arrives from a node with no prior BIRTH on this bridge. Typical after a bridge restart. Ignored under `secondary_passive`. Controls only the discovery path; sequence-gap and unresolved-aliases recovery always run for `secondary_active` and `primary`. |
 | `birth_request_throttle` | `duration` | `"1s"` | Minimum time between REBIRTH commands to the same node, shared across every rebirth reason. Collapses simultaneous discovery, sequence-gap, and unresolved-aliases signals into one broker command per window. Set to `0` to disable throttling. |
 
+### Hierarchy Section
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `include_edge_node_in_location` | `bool` | `false` | Nest device-level data under its Sparkplug edge node. When `true`, device data maps to `location_path = <edge_node>.<device>`; node-level data (no device) is unaffected. |
+
+**When to enable.** The default decode treats `device_id` as the full location path
+(UMH's Modified Parris Method, where `enterprise:site:area` → `enterprise.site.area` and
+the edge node is only a session identity). That is correct for UMH-published streams, but
+a **native / brownfield** Sparkplug producer uses `Group / EdgeNode / Device` as genuine
+nested levels — the `device_id` is just a device name. With the default, such device data
+lands at the top of the hierarchy and identically-named devices on different edge nodes
+collide. Set `include_edge_node_in_location: true` to put each device under the edge node
+that owns it:
+
+```yaml
+input:
+  sparkplug_b:
+    mqtt:
+      urls: ["tcp://localhost:1883"]
+    identity:
+      group_id: "FactoryA"
+    include_edge_node_in_location: true
+```
+
+| Topic | `include_edge_node_in_location: false` (default) | `true` |
+|-------|--------------------------------------------------|--------|
+| `spBv1.0/g/DDATA/Line1/IO Controller` | `IO_Controller` | `Line1.IO_Controller` |
+| `spBv1.0/g/DDATA/Line2/IO Controller` | `IO_Controller` (collides with Line1) | `Line2.IO_Controller` |
+| `spBv1.0/g/NDATA/Line1` (node-level) | `Line1` | `Line1` (unchanged) |
+
+Leave it `false` for Parris-encoded publishers, whose `device_id` already carries the full
+location path — enabling it there would prepend the edge node and corrupt the path.
+
+> **No-rebuild workaround:** on the default template you can achieve the same nesting in the
+> bridge's `tag_processor` by setting `location_path` from `spb_edge_node_id_sanitized` and
+> `virtual_path` from `spb_device_id_sanitized`.
+
 ---
 
 ## Technical Details

--- a/sparkplug_plugin/config.go
+++ b/sparkplug_plugin/config.go
@@ -74,6 +74,8 @@ type Config struct {
 	// Discovery REBIRTH configuration (secondary_active/primary only)
 	RequestBirthOnConnect bool          `yaml:"request_birth_on_connect"` // Send REBIRTH requests to newly discovered nodes
 	BirthRequestThrottle  time.Duration `yaml:"birth_request_throttle"`   // Minimum time between REBIRTH requests
+
+	IncludeEdgeNodeInLocation bool `yaml:"include_edge_node_in_location"`
 }
 
 // AutoDetectRole determines the role based on configuration (Host-only for INPUT plugin)

--- a/sparkplug_plugin/format_converter_test.go
+++ b/sparkplug_plugin/format_converter_test.go
@@ -605,6 +605,67 @@ func stringPtr(s string) *string {
 	return &s
 }
 
+var _ = Describe("Edge node in location path (ENG-5175)", func() {
+	var converter *FormatConverter
+
+	BeforeEach(func() {
+		converter = NewFormatConverter()
+	})
+
+	locationOf := func(edgeNode string, device string, includeEdgeNode bool) string {
+		deviceID := composeLocationDeviceID(edgeNode, device, includeEdgeNode)
+		result, err := converter.DecodeSparkplugToUMH(&SparkplugMessage{
+			GroupID:    "FactoryA",
+			EdgeNodeID: edgeNode,
+			DeviceID:   deviceID,
+			MetricName: "AmbientTemp",
+			Value:      25.5,
+			DataType:   "double",
+			Timestamp:  time.Now(),
+		}, "_raw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.TopicInfo.Level0).NotTo(BeEmpty())
+		loc := result.TopicInfo.Level0
+		if len(result.TopicInfo.LocationSublevels) > 0 {
+			for _, sub := range result.TopicInfo.LocationSublevels {
+				loc = loc + "." + sub
+			}
+		}
+		return loc
+	}
+
+	Context("when include_edge_node_in_location is enabled", func() {
+		It("nests device data under its edge node", func() {
+			Expect(locationOf("Line1", "IO Controller", true)).
+				To(Equal("Line1.IO_Controller"))
+		})
+
+		It("namespaces identically-named devices on different edge nodes to distinct location paths", func() {
+			node1 := locationOf("Line1", "IO Controller", true)
+			node2 := locationOf("Line2", "IO Controller", true)
+			Expect(node1).NotTo(Equal(node2))
+			Expect(node1).To(Equal("Line1.IO_Controller"))
+			Expect(node2).To(Equal("Line2.IO_Controller"))
+		})
+
+		It("leaves node-level data (empty device) at the edge node", func() {
+			Expect(locationOf("Line1", "", true)).To(Equal("Line1"))
+		})
+	})
+
+	Context("when include_edge_node_in_location is disabled (default, backward compatible)", func() {
+		It("keeps device data at the device level, dropping the edge node", func() {
+			Expect(locationOf("Line1", "IO Controller", false)).
+				To(Equal("IO_Controller"))
+		})
+
+		It("leaves Parris-encoded multi-level device IDs unchanged", func() {
+			Expect(locationOf("EdgeNode1", "enterprise:site:area", false)).
+				To(Equal("enterprise.site.area"))
+		})
+	})
+})
+
 var _ = Describe("Sanitization for UMH compatibility", func() {
 	var converter *FormatConverter
 

--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -128,6 +128,11 @@ Key features:
 			Description("Minimum time between REBIRTH commands to the same node, applied across every rebirth reason. Prevents the alias-recovery storm where DATA arriving in the BIRTH round-trip window fires another rebirth. Set to `0` to disable throttling.").
 			Default("1s").
 			Optional()).
+		Field(service.NewBoolField("include_edge_node_in_location").
+			Description("Nest device-level data under its Sparkplug edge node, so location_path becomes <edge_node>.<device> (e.g. 'Line1.IO_Controller'). Enable for native/brownfield Sparkplug where the edge node is a real hierarchy level and devices on different nodes may share a name. Leave disabled (default) for UMH Parris-encoded publishers where device_id already carries the full location path. Node-level data (no device) is unaffected.").
+			Default(false).
+			Examples(true, false).
+			Advanced()).
 		// Subscription Configuration
 		Field(service.NewObjectField("subscription",
 			service.NewStringListField("groups").
@@ -389,6 +394,8 @@ func newSparkplugInput(conf *service.ParsedConfig, mgr *service.Resources) (*spa
 	// Parse discovery REBIRTH configuration
 	config.RequestBirthOnConnect, _ = conf.FieldBool("request_birth_on_connect")
 	config.BirthRequestThrottle, _ = conf.FieldDuration("birth_request_throttle")
+
+	config.IncludeEdgeNodeInLocation, _ = conf.FieldBool("include_edge_node_in_location")
 
 	// Parse subscription section using namespace (optional)
 	if conf.Contains("subscription") {
@@ -1456,6 +1463,16 @@ func ValidateSequenceNumber(lastSeq uint8, currentSeq uint8) bool {
 	return currentSeq == expectedNext
 }
 
+func composeLocationDeviceID(edgeNode string, device string, includeEdgeNode bool) string {
+	if device == "" {
+		return edgeNode
+	}
+	if includeEdgeNode {
+		return edgeNode + ":" + device
+	}
+	return device
+}
+
 // tryAddUMHMetadata attempts to convert Sparkplug B data to UMH format and add UMH metadata.
 // This is a non-failing operation - if conversion fails, it adds status flags and continues.
 func (s *sparkplugInput) tryAddUMHMetadata(msg *service.Message, metric *sparkplugb.Payload_Metric, payload *sparkplugb.Payload, topicInfo *TopicInfo) {
@@ -1500,19 +1517,19 @@ func (s *sparkplugInput) tryAddUMHMetadata(msg *service.Message, metric *sparkpl
 	}
 
 	// For NDATA messages (node-level data), use EdgeNode as DeviceID when Device is empty
-	deviceID := topicInfo.Device
-	if deviceID == "" {
-		deviceID = topicInfo.EdgeNode
+	if topicInfo.Device == "" {
 		// Set spb_device_id metadata for consistency (used by Topic Browser and other downstream processors)
 		// Even though this is NDATA (node-level), we're treating EdgeNode as the device identifier
-		msg.MetaSet("spb_device_id", deviceID)
-		msg.MetaSet("spb_device_id_sanitized", s.sanitizeForTopic(deviceID))
+		msg.MetaSet("spb_device_id", topicInfo.EdgeNode)
+		msg.MetaSet("spb_device_id_sanitized", s.sanitizeForTopic(topicInfo.EdgeNode))
 	}
+
+	locationDeviceID := composeLocationDeviceID(topicInfo.EdgeNode, topicInfo.Device, s.config.IncludeEdgeNodeInLocation)
 
 	sparkplugMsg := &SparkplugMessage{
 		GroupID:    topicInfo.Group,
 		EdgeNodeID: topicInfo.EdgeNode,
-		DeviceID:   deviceID,
+		DeviceID:   locationDeviceID,
 		Value:      rawValue,
 		DataType:   dataType,
 		Timestamp:  time.Now(), // Will be overridden below if payload has timestamp


### PR DESCRIPTION
## What

The Sparkplug B input built `umh_location_path` from the **device ID alone**, dropping the edge node. Device-level metrics landed at the top of the UNS hierarchy, and two edge nodes that each expose an identically-named device collided into one location.

## Why it happened

The decoder assumes UMH's **Modified Parris Method**, where the full location lives in `device_id` (`enterprise:site:area` → `enterprise.site.area`) and the Sparkplug edge node is just a session-identity label. That's correct for UMH-published streams, but a **native / brownfield** producer uses `Group / EdgeNode / Device` as genuine nested levels and `device_id` is a leaf device name. Feeding native data into a Parris decoder treats the leaf name as the whole path and discards the edge node — which in native Sparkplug is the parent level.

The two encodings are mutually exclusive readings of the same topic fields, so "always prepend the edge node" would corrupt every real Parris stream. The choice is a deployment intent, not something derivable from the data.

## The fix

Add an opt-in input option **`include_edge_node_in_location`** (bool, default `false`):

| Topic | `false` (default) | `true` |
|-------|-------------------|--------|
| `…/DDATA/Line1/IO Controller` | `IO_Controller` | `Line1.IO_Controller` |
| `…/DDATA/Line2/IO Controller` | `IO_Controller` *(collides)* | `Line2.IO_Controller` |
| `…/NDATA/Line1` (node-level) | `Line1` | `Line1` *(unchanged)* |

Default `false` keeps Parris-encoded deployments byte-for-byte unchanged — they never set it. The raw `spb_device_id` metadata is untouched; only the location derivation changes.

## Changes

- `sparkplug_b_input.go` — pure helper `composeLocationDeviceID`, wired into `tryAddUMHMetadata`; new `include_edge_node_in_location` config field (`Default(false).Advanced()`) + parsing
- `config.go` — `IncludeEdgeNodeInLocation` on the `Config` struct
- `format_converter_test.go` — 5 specs (distinct paths for same-named devices on different nodes; node-level unchanged; flag-off regression guards for device-level and Parris multi-level)
- `docs/input/sparkplug-b-input.md` — new Hierarchy Section: option, native-vs-Parris explanation, before/after table, no-rebuild workaround
- changelog fragment (`fixes`)

## Test plan

- [x] `make test-sparkplug` — full package passes; 5 new specs pass
- [x] `go build ./...`, `go vet ./sparkplug_plugin/`, `gofumpt -l` — clean

Closes ENG-5175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)