### PR TITLE
chore: generate changelog for v0.13.0

### DIFF
--- a/.changelog/unreleased/fixes-20260618-163816.yaml
+++ b/.changelog/unreleased/fixes-20260618-163816.yaml
@@ -1,3 +1,0 @@
-kind: fixes
-body: 'OPC UA: reading or subscribing to large tag sets (roughly a thousand or more) over an encrypted connection no longer drops the connection with an `EOF` error'
-time: 2026-06-18T16:38:16.000000+02:00

--- a/.changelog/unreleased/fixes-20260618-163817.yaml
+++ b/.changelog/unreleased/fixes-20260618-163817.yaml
@@ -1,3 +1,0 @@
-kind: fixes
-body: 'OPC UA: subscriptions now survive a reconnect, so data collection resumes automatically after a network interruption instead of stalling until the input is restarted'
-time: 2026-06-18T16:38:17.000000+02:00

--- a/.changelog/unreleased/fixes-20260618-163818.yaml
+++ b/.changelog/unreleased/fixes-20260618-163818.yaml
@@ -1,3 +1,0 @@
-kind: fixes
-body: 'OPC UA: connecting to servers that present their certificate as a chain (leaf plus intermediates), such as Siemens WinCC Unified, now works'
-time: 2026-06-18T16:38:18.000000+02:00

--- a/.changelog/unreleased/fixes-20260618-163819.yaml
+++ b/.changelog/unreleased/fixes-20260618-163819.yaml
@@ -1,3 +1,0 @@
-kind: fixes
-body: 'OPC UA: a single unreadable or invalid node ID no longer blocks monitoring the rest of a subscribed batch'
-time: 2026-06-18T16:38:19.000000+02:00

--- a/.changelog/unreleased/fixes-20260618-163820.yaml
+++ b/.changelog/unreleased/fixes-20260618-163820.yaml
@@ -1,3 +1,0 @@
-kind: fixes
-body: 'OPC UA: browsing certain servers no longer crashes the input'
-time: 2026-06-18T16:38:20.000000+02:00

--- a/.changelog/unreleased/improvements-20260618-163815.yaml
+++ b/.changelog/unreleased/improvements-20260618-163815.yaml
@@ -1,3 +1,0 @@
-kind: improvements
-body: 'OPC UA: encrypted connections (`Basic256Sha256`, both `Sign` and `Sign & Encrypt`) now complete reliably, including signing-only mode which previously failed to connect'
-time: 2026-06-18T16:38:15.000000+02:00

--- a/.changelog/v0.13.0.md
+++ b/.changelog/v0.13.0.md
@@ -1,0 +1,13 @@
+## [v0.13.0]
+
+### Improvements
+
+- OPC UA: encrypted connections (`Basic256Sha256`, both `Sign` and `Sign & Encrypt`) now complete reliably, including signing-only mode which previously failed to connect
+
+### Fixes
+
+- OPC UA: reading or subscribing to large tag sets (roughly a thousand or more) over an encrypted connection no longer drops the connection with an `EOF` error
+- OPC UA: subscriptions now survive a reconnect, so data collection resumes automatically after a network interruption instead of stalling until the input is restarted
+- OPC UA: connecting to servers that present their certificate as a chain (leaf plus intermediates), such as Siemens WinCC Unified, now works
+- OPC UA: a single unreadable or invalid node ID no longer blocks monitoring the rest of a subscribed batch
+- OPC UA: browsing certain servers no longer crashes the input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v0.13.0]
+
+### Improvements
+
+- OPC UA: encrypted connections (`Basic256Sha256`, both `Sign` and `Sign & Encrypt`) now complete reliably, including signing-only mode which previously failed to connect
+
+### Fixes
+
+- OPC UA: reading or subscribing to large tag sets (roughly a thousand or more) over an encrypted connection no longer drops the connection with an `EOF` error
+- OPC UA: subscriptions now survive a reconnect, so data collection resumes automatically after a network interruption instead of stalling until the input is restarted
+- OPC UA: connecting to servers that present their certificate as a chain (leaf plus intermediates), such as Siemens WinCC Unified, now works
+- OPC UA: a single unreadable or invalid node ID no longer blocks monitoring the rest of a subscribed batch
+- OPC UA: browsing certain servers no longer crashes the input
+
 ## [v0.12.7]
 
 ### Fixes


### PR DESCRIPTION
Generates the v0.13.0 changelog from the 6 unreleased fragments (1 Improvements + 5 Fixes — the OPC UA / gopcua-v0.9.0 items).

```make changelog-merge VERSION=v0.13.0```

- Moves `.changelog/unreleased/*.yaml` → `.changelog/v0.13.0.md`
- Regenerates `CHANGELOG.md` with the new `## [v0.13.0]` section at the top

Minor bump (improvements: encrypted OPC UA connections now complete reliably). Mirrors the v0.12.7 changelog PR (#372).