### PR TITLE
fix(ci): add staging for automation guard on changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   generate-changelog:
-    if: startsWith(github.event.pull_request.title, 'v')
+    if: startsWith(github.event.pull_request.title, 'v') && github.head_ref == 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token


### PR DESCRIPTION
# Description

#384 was mistakenly created as the original Pull-Request for that were coming from `v0.13.0` -> `main` and not `staging`-> `main`.

Therefore this PR introduces a guard for this automated changelog-behaviour only from `staging` -> `main`.