### PR TITLE
sparkplug_b input: add passthrough_raw_metric flag (ENG-5242)

### DIFF
--- a/.changelog/unreleased/new-20260624-151831.yaml
+++ b/.changelog/unreleased/new-20260624-151831.yaml
@@ -1,0 +1,3 @@
+kind: new
+body: Sparkplug B input can attach the raw proto-encoded metric as base64 metadata (`spb_metric_raw`) via the `passthrough_raw_metric` flag, exposing proto2 extension fields for downstream decoding (ENG-5242)
+time: 2026-06-24T15:18:31.361763+02:00

--- a/docs/input/sparkplug-b-input.md
+++ b/docs/input/sparkplug-b-input.md
@@ -185,6 +185,7 @@ Here's how a Sparkplug B message maps to UMH-Core using the Modified Parris Meth
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `include_edge_node_in_location` | `bool` | `false` | Nest device-level data under its Sparkplug edge node. When `true`, device data maps to `location_path = <edge_node>.<device>`; node-level data (no device) is unaffected. |
+| `passthrough_raw_metric` | `bool` | `false` | Also attach the raw, proto-encoded metric as base64 metadata `spb_metric_raw`, alongside the normal decoded value, so a downstream protobuf decoder can read proto2 extension fields this input does not decode. Attached per metric only — death events carry none. The bytes duplicate the metric into a Kafka header, so very large metrics may hit broker message/header size limits. Off by default. |
 
 **When to enable.** The default decode treats `device_id` as the full location path
 (UMH's Modified Parris Method, where `enterprise:site:area` → `enterprise.site.area` and

--- a/sparkplug_plugin/config.go
+++ b/sparkplug_plugin/config.go
@@ -76,6 +76,10 @@ type Config struct {
 	BirthRequestThrottle  time.Duration `yaml:"birth_request_throttle"`   // Minimum time between REBIRTH requests
 
 	IncludeEdgeNodeInLocation bool `yaml:"include_edge_node_in_location"`
+
+	// PassthroughRawMetric attaches the raw, proto-encoded metric as base64 metadata
+	// (spb_metric_raw) so downstream decoders can read proto2 extension fields (ENG-5242).
+	PassthroughRawMetric bool `yaml:"passthrough_raw_metric"`
 }
 
 // AutoDetectRole determines the role based on configuration (Host-only for INPUT plugin)

--- a/sparkplug_plugin/passthrough_raw_metric_test.go
+++ b/sparkplug_plugin/passthrough_raw_metric_test.go
@@ -1,0 +1,117 @@
+//go:build !integration
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unit tests for the passthrough_raw_metric flag (ENG-5242).
+//
+// The flag attaches the whole re-marshaled Payload.Metric as base64 metadata
+// (spb_metric_raw) so a downstream decoder (ENG-5243) can read proto2 extension
+// fields the plugin's generated types don't declare. The test simulates an
+// extension with an unknown field 9 nested inside MetaData (the proto declares
+// `extensions 9 to max` at sparkplug_b_official.proto:62). Because that field is
+// nested, only re-marshaling the whole metric preserves it; the metric's
+// top-level GetUnknown() never sees it.
+
+package sparkplug_plugin_test
+
+import (
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	sparkplugplugin "github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin"
+	"github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin/sparkplugb"
+)
+
+var _ = Describe("Sparkplug B passthrough_raw_metric (ENG-5242)", func() {
+	const metaExtFieldNumber = 9 // a MetaData extension field number (proto: extensions 9 to max)
+	topicInfo := &sparkplugplugin.TopicInfo{Group: "test", EdgeNode: "edge1", Device: "dev1"}
+
+	// buildMetricWithExtension returns a metric carrying a declared name+value plus a
+	// proto2 extension simulated as an unknown field nested inside MetaData, and the
+	// raw bytes of that nested extension.
+	buildMetricWithExtension := func() (*sparkplugb.Payload_Metric, []byte) {
+		ext := protowire.AppendTag(nil, metaExtFieldNumber, protowire.VarintType)
+		ext = protowire.AppendVarint(ext, 1730986400123456789)
+
+		metric := &sparkplugb.Payload_Metric{
+			Name:     stringPtr("temperature"),
+			Datatype: uint32Ptr(SparkplugDataTypeInt32),
+			Value:    &sparkplugb.Payload_Metric_IntValue{IntValue: 42},
+			Metadata: &sparkplugb.Payload_MetaData{},
+		}
+		metric.Metadata.ProtoReflect().SetUnknown(protoreflect.RawFields(ext))
+		return metric, ext
+	}
+
+	newPayload := func(m *sparkplugb.Payload_Metric) *sparkplugb.Payload {
+		seq := uint64(1)
+		ts := uint64(1730986400000)
+		return &sparkplugb.Payload{Seq: &seq, Timestamp: &ts, Metrics: []*sparkplugb.Payload_Metric{m}}
+	}
+
+	When("passthrough_raw_metric is enabled", func() {
+		It("attaches the whole re-marshaled metric as base64 spb_metric_raw, preserving the nested extension", func() {
+			metric, extBytes := buildMetricWithExtension()
+			input := createMockSparkplugInput()
+			input.SetPassthroughRawMetric(true)
+
+			batch := input.CreateSplitMessages(newPayload(metric), "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/dev1")
+			Expect(batch).To(HaveLen(1))
+
+			raw, ok := batch[0].MetaGet("spb_metric_raw")
+			Expect(ok).To(BeTrue(), "spb_metric_raw must be set when passthrough is enabled")
+
+			decodedBytes, err := base64.StdEncoding.DecodeString(raw)
+			Expect(err).NotTo(HaveOccurred(), "spb_metric_raw must be valid base64")
+
+			var decoded sparkplugb.Payload_Metric
+			Expect(proto.Unmarshal(decodedBytes, &decoded)).To(Succeed())
+
+			Expect(proto.Equal(metric, &decoded)).To(BeTrue(), "round-trip must reproduce the full metric, including unknown fields")
+			Expect(decoded.GetMetadata()).NotTo(BeNil(), "MetaData must survive the round-trip")
+			Expect([]byte(decoded.GetMetadata().ProtoReflect().GetUnknown())).To(Equal(extBytes),
+				"the nested MetaData extension bytes must survive marshal->unmarshal")
+		})
+	})
+
+	When("passthrough_raw_metric is disabled (default)", func() {
+		It("does not attach spb_metric_raw", func() {
+			metric, _ := buildMetricWithExtension()
+			input := createMockSparkplugInput() // default: passthrough off
+
+			batch := input.CreateSplitMessages(newPayload(metric), "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/dev1")
+			Expect(batch).To(HaveLen(1))
+
+			_, ok := batch[0].MetaGet("spb_metric_raw")
+			Expect(ok).To(BeFalse(), "spb_metric_raw must be absent when passthrough is disabled")
+
+			// Spec property 2: the standard decoded output is unchanged when the flag is off.
+			name, nameOK := batch[0].MetaGet("spb_metric_name")
+			Expect(nameOK).To(BeTrue())
+			Expect(name).To(Equal("temperature"), "standard metadata must be untouched")
+			datatype, dtOK := batch[0].MetaGet("spb_datatype")
+			Expect(dtOK).To(BeTrue(), "standard metadata must be untouched")
+			Expect(datatype).NotTo(BeEmpty())
+			payloadBytes, err := batch[0].AsBytes()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(payloadBytes).NotTo(BeEmpty(), "decoded value payload must still be present")
+		})
+	})
+})

--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -16,6 +16,7 @@ package sparkplug_plugin
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -130,6 +131,11 @@ Key features:
 			Optional()).
 		Field(service.NewBoolField("include_edge_node_in_location").
 			Description("Nest device-level data under its Sparkplug edge node, so location_path becomes <edge_node>.<device> (e.g. 'Line1.IO_Controller'). Enable for native/brownfield Sparkplug where the edge node is a real hierarchy level and devices on different nodes may share a name. Leave disabled (default) for UMH Parris-encoded publishers where device_id already carries the full location path. Node-level data (no device) is unaffected.").
+			Default(false).
+			Examples(true, false).
+			Advanced()).
+		Field(service.NewBoolField("passthrough_raw_metric").
+			Description("Also attach the raw, re-marshaled `Payload.Metric` as base64 metadata `spb_metric_raw`, preserving proto2 extension fields this input does not decode. Pair with a downstream protobuf decoder that has the device's `.proto`. Travels as a Kafka header and roughly doubles per-metric size, so large metrics may hit broker size limits. Off by default.").
 			Default(false).
 			Examples(true, false).
 			Advanced()).
@@ -396,6 +402,8 @@ func newSparkplugInput(conf *service.ParsedConfig, mgr *service.Resources) (*spa
 	config.BirthRequestThrottle, _ = conf.FieldDuration("birth_request_throttle")
 
 	config.IncludeEdgeNodeInLocation, _ = conf.FieldBool("include_edge_node_in_location")
+
+	config.PassthroughRawMetric, _ = conf.FieldBool("passthrough_raw_metric")
 
 	// Parse subscription section using namespace (optional)
 	if conf.Contains("subscription") {
@@ -1130,6 +1138,15 @@ func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metr
 		msg.MetaSet("spb_bdseq", fmt.Sprintf("%d", state.BdSeq))
 	}
 	s.stateMu.RUnlock()
+
+	// Best-effort: a marshal error attaches nothing rather than dropping the message (ENG-5242).
+	if s.config.PassthroughRawMetric {
+		if raw, err := proto.Marshal(metric); err != nil {
+			s.logger.Warnf("passthrough_raw_metric: failed to marshal metric %q: %v", metricName, err)
+		} else {
+			msg.MetaSet("spb_metric_raw", base64.StdEncoding.EncodeToString(raw))
+		}
+	}
 
 	// Try to add UMH conversion metadata (optional, non-failing)
 	s.tryAddUMHMetadata(msg, metric, payload, topicInfo)

--- a/sparkplug_plugin/sparkplug_b_input_test_helper_test.go
+++ b/sparkplug_plugin/sparkplug_b_input_test_helper_test.go
@@ -128,6 +128,12 @@ func (w *SparkplugInputTestWrapper) SetRequestBirthOnConnect(enabled bool) {
 	w.input.config.RequestBirthOnConnect = enabled
 }
 
+// SetPassthroughRawMetric overrides the PassthroughRawMetric flag (ENG-5242) for tests
+// that exercise the raw-metric metadata attachment in createMessageFromMetric.
+func (w *SparkplugInputTestWrapper) SetPassthroughRawMetric(enabled bool) {
+	w.input.config.PassthroughRawMetric = enabled
+}
+
 // SeedAliasCache pre-populates the alias cache for the given deviceKey from the supplied
 // (name, alias) pair metrics. Tests use this for a "BIRTH already applied" baseline.
 func (w *SparkplugInputTestWrapper) SeedAliasCache(deviceKey string, metrics []*sparkplugb.Payload_Metric) {


### PR DESCRIPTION
## Background

The `sparkplug_b` input decodes the standard Sparkplug B payload but drops anything carried in proto2 extension fields. The plugin's generated types don't declare those fields, so they never reach the decoded value. The bytes aren't lost on the wire (proto2 retains unknown fields); they're just never exposed.

Some Sparkplug B publishers carry data in those extensions and need it decoded inside UMH-core rather than in an external service.

## What this adds

An opt-in `passthrough_raw_metric` flag on the input. When enabled, each per-metric message also carries the raw, re-marshaled `Payload.Metric` as base64 metadata `spb_metric_raw`. A downstream protobuf decoder that has the device's `.proto` (ENG-5243's `nodered_js` `protobuf.decode`, or the Redpanda `protobuf` processor) reads the extension fields from there.

- The **whole** metric is marshaled, not the top-level `GetUnknown()` fragment: an extension may be nested inside a sub-message such as `MetaData`, and the decoder needs a complete `Payload.Metric`.
- Off by default; output is byte-for-byte unchanged when disabled.
- Best-effort: a marshal error attaches nothing rather than dropping the message.

Deliverable 1 of 2 for ENG-5229; the downstream decoder is ENG-5243.

## Tests

`passthrough_raw_metric_test.go`: the enabled case round-trips the metric and asserts a nested `MetaData` extension survives marshal→unmarshal via `spb_metric_raw`; the disabled case asserts standard metadata and payload are untouched and no key is added.

## For reviewers

The raw bytes travel to Kafka headers downstream and roughly double per-metric size, so very large metrics may approach broker message/header size limits. Called out in the field description and `docs/input/sparkplug-b-input.md`. Opt-in, off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
