### PR TITLE
nodered_js: add protobuf.decode/encode with inline descriptor set (ENG-5298)

### DIFF
--- a/.changelog/unreleased/new-20260624-160831.yaml
+++ b/.changelog/unreleased/new-20260624-160831.yaml
@@ -1,0 +1,3 @@
+kind: new
+body: Node-RED JS and tag processor expose a `protobuf` namespace (`protobuf.decode` / `protobuf.encode`) to decode and encode protobuf messages inline using an embedded base64 descriptor set, including proto2 extension fields (ENG-5243)
+time: 2026-06-24T16:08:31.625342+02:00

--- a/docs/processing/javascript-api.md
+++ b/docs/processing/javascript-api.md
@@ -139,3 +139,27 @@ return msg;
 - **In-memory only** — state is lost when the Benthos process restarts. A persistent backend is planned.
 - **No size limits** — the cache grows unboundedly if keys are never deleted. Use `cache.delete` to clean up unused keys. A memory safeguard (threshold, eviction) is planned.
 - **Cache scope in `tag_processor`** — the cache is shared across all stages (`defaults`, `conditions`, `advancedProcessing`). A value set in `defaults` is visible in `advancedProcessing` within the same message.
+
+## protobuf
+
+Decode and encode protobuf messages inline, against a schema passed as a base64-encoded `FileDescriptorSet` (no files on disk). Useful for reading data the standard inputs don't decode — for example the raw Sparkplug B metric bytes attached by the `sparkplug_b` input's `passthrough_raw_metric` flag, including proto2 extension fields.
+
+```javascript
+protobuf.decode(dataB64, descriptorSetB64, msgName)  // base64 proto bytes -> object
+protobuf.encode(obj, descriptorSetB64, msgName)      // object -> base64 proto bytes
+```
+
+- `descriptorSetB64` — base64 of a self-contained `FileDescriptorSet`. Compile it once with `protoc --include_imports --descriptor_set_out=schema.pb your.proto`, then base64-encode `schema.pb` and paste the string into your script.
+- `msgName` — fully-qualified message name, e.g. `com.example.Payload.Metric` (no leading dot).
+- The decoded object follows protojson conventions: `int64`/`uint64` and `bytes` come back as strings, enums as their names, and **proto2 extensions appear as `[package.extension]` keys**. For `encode`, pass 64-bit integers as strings.
+- Both functions throw on error (invalid base64, unknown message, malformed descriptor set); wrap calls in `try/catch` to handle failures in script.
+
+```javascript
+// Decode the raw Sparkplug metric attached by passthrough_raw_metric, reading an extension field.
+var DESC = "CtIB..."; // base64 FileDescriptorSet, compiled once
+var metric = protobuf.decode(msg.meta.spb_metric_raw, DESC, "com.example.Payload.Metric");
+msg.payload = { value: metric.value, extra: metric["[com.example.my_extension]"] };
+return msg;
+```
+
+Available in both `nodered_js` and `tag_processor` — they share the same JavaScript environment.

--- a/docs/processing/node-red-javascript-processor.md
+++ b/docs/processing/node-red-javascript-processor.md
@@ -4,7 +4,7 @@ The Node-RED JavaScript processor allows you to write JavaScript code to process
 
 Use the `nodered_js` processor instead of the `tag_processor` when you need full control over the payload and require custom processing logic that goes beyond standard tag or time series data handling. This processor allows you to write custom JavaScript code to manipulate both the payload and metadata, providing the flexibility to implement complex transformations, conditional logic, or integrate with other systems.
 
-For the full list of available JavaScript globals (`msg`, `console`, `cache`), see the [JavaScript API Reference](javascript-api.md).
+For the full list of available JavaScript globals (`msg`, `console`, `cache`, `protobuf`), see the [JavaScript API Reference](javascript-api.md).
 
 **Configuration**
 

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -31,6 +31,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/cache"
+	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/protobuf"
 )
 
 // NodeREDJSProcessor defines the processor that wraps the JavaScript processor.
@@ -317,6 +318,11 @@ func (u *NodeREDJSProcessor) SetupJSEnvironment(ctx context.Context, vm *goja.Ru
 		return fmt.Errorf("failed to set cache in JS environment: %w", err)
 	}
 
+	err = u.setupProtobuf(vm)
+	if err != nil {
+		return fmt.Errorf("failed to set protobuf in JS environment: %w", err)
+	}
+
 	return nil
 }
 
@@ -359,6 +365,35 @@ func (u *NodeREDJSProcessor) setupCache(ctx context.Context, vm *goja.Runtime) e
 		},
 	}
 	return vm.Set("cache", cacheObj)
+}
+
+// setupProtobuf exposes protobuf.decode/encode to the JS runtime. The functions
+// decode/encode against an inline base64 FileDescriptorSet and throw on error
+// (goja converts the Go (T, error) return into a throwing JS function). The
+// tag_processor shares this environment, so it gets `protobuf` too (ENG-5243).
+func (u *NodeREDJSProcessor) setupProtobuf(vm *goja.Runtime) error {
+	// Recover any panic into an error: the descriptor set and data are untrusted, and
+	// goja does not recover Go panics from native functions, so a panic here would crash
+	// the whole process rather than throw a catchable JS error.
+	protobufObj := map[string]any{
+		"decode": func(dataB64 string, descriptorSetB64 string, msgName string) (_ map[string]any, err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("protobuf.decode panicked: %v", r)
+				}
+			}()
+			return protobuf.Decode(dataB64, descriptorSetB64, msgName)
+		},
+		"encode": func(obj any, descriptorSetB64 string, msgName string) (_ string, err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("protobuf.encode panicked: %v", r)
+				}
+			}()
+			return protobuf.Encode(obj, descriptorSetB64, msgName)
+		},
+	}
+	return vm.Set("protobuf", protobufObj)
 }
 
 // HandleExecutionResult handles JavaScript execution results.

--- a/nodered_js_plugin/protobuf/protobuf.go
+++ b/nodered_js_plugin/protobuf/protobuf.go
@@ -1,0 +1,197 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package protobuf decodes and encodes arbitrary protobuf messages against an
+// inline base64 FileDescriptorSet, for use from the nodered_js / tag_processor JS
+// runtime. Extensions are registered so they surface in protojson as "[pkg.ext]"
+// keys (ENG-5243).
+package protobuf
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// registry holds the descriptors and extension types built from one descriptor set.
+type registry struct {
+	files *protoregistry.Files
+	types *protoregistry.Types
+}
+
+// maxCachedRegistries bounds the memo cache. The descriptor set is untrusted input
+// from a user script, so an unbounded cache would be a memory-exhaustion vector if a
+// script decoded with many distinct descriptor sets. Realistic use is one or a few
+// static per-bridge descriptors, well under this cap.
+const maxCachedRegistries = 128
+
+// registryCache memoizes built registries keyed by the base64 descriptor set, so the
+// hot path skips decoding and building. Building the registry dominates per-call cost;
+// a cached registry is read-only (Find* reads are concurrency-safe).
+var (
+	registryMu    sync.Mutex
+	registryCache = map[string]*registry{}
+)
+
+// Decode decodes base64 proto bytes of message msgName against an inline base64
+// FileDescriptorSet, returning the message in protojson shape. Extensions surface
+// as "[pkg.ext]" keys.
+func Decode(dataB64 string, descriptorSetB64 string, msgName string) (map[string]any, error) {
+	reg, err := loadRegistry(descriptorSetB64)
+	if err != nil {
+		return nil, err
+	}
+	md, err := reg.messageDescriptor(msgName)
+	if err != nil {
+		return nil, err
+	}
+	data, err := base64.StdEncoding.DecodeString(dataB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode data base64: %w", err)
+	}
+	msg := dynamicpb.NewMessage(md)
+	if err = (proto.UnmarshalOptions{Resolver: reg.types}).Unmarshal(data, msg); err != nil {
+		return nil, fmt.Errorf("unmarshal proto: %w", err)
+	}
+	jsonBytes, err := (protojson.MarshalOptions{Resolver: reg.types}).Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal protojson: %w", err)
+	}
+	out := map[string]any{}
+	if err = json.Unmarshal(jsonBytes, &out); err != nil {
+		return nil, fmt.Errorf("decode json: %w", err)
+	}
+	return out, nil
+}
+
+// Encode is the inverse of Decode: it encodes a protojson-shaped object to base64
+// proto bytes of message msgName against an inline base64 FileDescriptorSet.
+func Encode(obj any, descriptorSetB64 string, msgName string) (string, error) {
+	m, ok := obj.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("encode input must be an object, got %T", obj)
+	}
+	reg, err := loadRegistry(descriptorSetB64)
+	if err != nil {
+		return "", err
+	}
+	md, err := reg.messageDescriptor(msgName)
+	if err != nil {
+		return "", err
+	}
+	jsonBytes, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("encode json: %w", err)
+	}
+	msg := dynamicpb.NewMessage(md)
+	if err = (protojson.UnmarshalOptions{Resolver: reg.types}).Unmarshal(jsonBytes, msg); err != nil {
+		return "", fmt.Errorf("unmarshal protojson: %w", err)
+	}
+	out, err := proto.Marshal(msg)
+	if err != nil {
+		return "", fmt.Errorf("marshal proto: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(out), nil
+}
+
+func loadRegistry(descriptorSetB64 string) (*registry, error) {
+	registryMu.Lock()
+	if reg, ok := registryCache[descriptorSetB64]; ok {
+		registryMu.Unlock()
+		return reg, nil
+	}
+	registryMu.Unlock()
+
+	// Build outside the lock — parsing is the expensive part, and a concurrent
+	// double-build is harmless because the result is identical (idempotent).
+	reg, err := buildRegistry(descriptorSetB64)
+	if err != nil {
+		return nil, err
+	}
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if existing, ok := registryCache[descriptorSetB64]; ok {
+		return existing, nil // a concurrent caller won the race; reuse its registry
+	}
+	if len(registryCache) >= maxCachedRegistries {
+		// The cache is a pure optimization, so evicting an arbitrary entry to stay
+		// bounded never affects correctness — the next call rebuilds it.
+		for k := range registryCache {
+			delete(registryCache, k)
+			break
+		}
+	}
+	registryCache[descriptorSetB64] = reg
+	return reg, nil
+}
+
+func buildRegistry(descriptorSetB64 string) (*registry, error) {
+	descBytes, err := base64.StdEncoding.DecodeString(descriptorSetB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode descriptor set base64: %w", err)
+	}
+	var fds descriptorpb.FileDescriptorSet
+	if err = proto.Unmarshal(descBytes, &fds); err != nil {
+		return nil, fmt.Errorf("parse FileDescriptorSet: %w", err)
+	}
+	files, err := protodesc.NewFiles(&fds)
+	if err != nil {
+		return nil, fmt.Errorf("build descriptor files: %w", err)
+	}
+
+	types := new(protoregistry.Types)
+	files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		registerExtensions(types, fd.Extensions())
+		registerMessageExtensions(types, fd.Messages())
+		return true
+	})
+	return &registry{files: files, types: types}, nil
+}
+
+func (r *registry) messageDescriptor(msgName string) (protoreflect.MessageDescriptor, error) {
+	d, err := r.files.FindDescriptorByName(protoreflect.FullName(msgName))
+	if err != nil {
+		return nil, fmt.Errorf("message %q not found in descriptor set: %w", msgName, err)
+	}
+	md, ok := d.(protoreflect.MessageDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("%q is not a message", msgName)
+	}
+	return md, nil
+}
+
+func registerExtensions(types *protoregistry.Types, xs protoreflect.ExtensionDescriptors) {
+	for i := 0; i < xs.Len(); i++ {
+		// A duplicate-registration error can't occur within a single fresh build; ignore.
+		_ = types.RegisterExtension(dynamicpb.NewExtensionType(xs.Get(i)))
+	}
+}
+
+func registerMessageExtensions(types *protoregistry.Types, ms protoreflect.MessageDescriptors) {
+	for i := 0; i < ms.Len(); i++ {
+		m := ms.Get(i)
+		registerExtensions(types, m.Extensions())
+		registerMessageExtensions(types, m.Messages())
+	}
+}

--- a/nodered_js_plugin/protobuf/protobuf_internal_test.go
+++ b/nodered_js_plugin/protobuf/protobuf_internal_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protobuf
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func descriptorForPackage(pkg string) string {
+	fds := &descriptorpb.FileDescriptorSet{File: []*descriptorpb.FileDescriptorProto{{
+		Name:    proto.String(pkg + ".proto"),
+		Package: proto.String(pkg),
+		Syntax:  proto.String("proto2"),
+		MessageType: []*descriptorpb.DescriptorProto{{
+			Name: proto.String("Sample"),
+			Field: []*descriptorpb.FieldDescriptorProto{{
+				Name:   proto.String("a"),
+				Number: proto.Int32(1),
+				Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
+			}},
+		}},
+	}}}
+	b, err := proto.Marshal(fds)
+	Expect(err).NotTo(HaveOccurred())
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+var _ = Describe("registry cache bound (ENG-5243)", func() {
+	It("never grows past maxCachedRegistries despite many distinct descriptor sets", func() {
+		for i := 0; i < maxCachedRegistries+50; i++ {
+			_, err := loadRegistry(descriptorForPackage(fmt.Sprintf("testpkg%d", i)))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		registryMu.Lock()
+		n := len(registryCache)
+		registryMu.Unlock()
+		Expect(n).To(BeNumerically("<=", maxCachedRegistries),
+			"the cache must stay bounded so an untrusted script can't exhaust memory")
+	})
+})

--- a/nodered_js_plugin/protobuf/protobuf_suite_test.go
+++ b/nodered_js_plugin/protobuf/protobuf_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protobuf_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProtobuf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeREDJS Protobuf Suite")
+}

--- a/nodered_js_plugin/protobuf/protobuf_test.go
+++ b/nodered_js_plugin/protobuf/protobuf_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protobuf_test
+
+import (
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	pb "github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/protobuf"
+)
+
+// descriptorSetB64 hand-builds a self-contained proto2 FileDescriptorSet — no protoc.
+// Message: testpb.Sample { optional int32 a = 1; extensions 100 to max; }
+// Extension: extend Sample { optional int64 ext_field = 100; } (an unregistered
+// extension is exactly the shape this feature must surface as a "[pkg.ext]" key).
+func descriptorSetB64() string {
+	fdp := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("test.proto"),
+		Package: proto.String("testpb"),
+		Syntax:  proto.String("proto2"),
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("Sample"),
+				Field: []*descriptorpb.FieldDescriptorProto{{
+					Name:   proto.String("a"),
+					Number: proto.Int32(1),
+					Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+					Type:   descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
+				}},
+				ExtensionRange: []*descriptorpb.DescriptorProto_ExtensionRange{{
+					Start: proto.Int32(100),
+					End:   proto.Int32(536870912), // max extension number + 1
+				}},
+			},
+			{
+				// Holder declares a message-NESTED extension of Sample, exercising the
+				// recursive extension walk (a top-level extend would not).
+				Name: proto.String("Holder"),
+				Extension: []*descriptorpb.FieldDescriptorProto{{
+					Name:     proto.String("nested_ext"),
+					Number:   proto.Int32(101),
+					Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+					Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+					Extendee: proto.String(".testpb.Sample"),
+				}},
+			},
+		},
+		Extension: []*descriptorpb.FieldDescriptorProto{{
+			Name:     proto.String("ext_field"),
+			Number:   proto.Int32(100),
+			Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+			Type:     descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum(),
+			Extendee: proto.String(".testpb.Sample"), // fully qualified, leading dot
+		}},
+	}
+	fds := &descriptorpb.FileDescriptorSet{File: []*descriptorpb.FileDescriptorProto{fdp}}
+	b, err := proto.Marshal(fds)
+	Expect(err).NotTo(HaveOccurred())
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+var _ = Describe("protobuf decode/encode (ENG-5243)", func() {
+	const msgName = "testpb.Sample" // bare FQN, no leading dot
+	var desc string
+
+	BeforeEach(func() {
+		desc = descriptorSetB64()
+	})
+
+	It("round-trips a message including top-level and message-nested proto2 extensions", func() {
+		obj := map[string]any{
+			"a":                          1,
+			"[testpb.ext_field]":         "123",   // top-level extension
+			"[testpb.Holder.nested_ext]": "hello", // message-nested extension
+		}
+
+		encoded, err := pb.Encode(obj, desc, msgName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(encoded).NotTo(BeEmpty())
+
+		decoded, err := pb.Decode(encoded, desc, msgName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decoded).To(HaveKeyWithValue("a", BeNumerically("==", 1)))
+		Expect(decoded).To(HaveKeyWithValue("[testpb.ext_field]", "123"),
+			"the top-level extension must surface as a bracketed key")
+		Expect(decoded).To(HaveKeyWithValue("[testpb.Holder.nested_ext]", "hello"),
+			"the message-nested extension must surface too (recursive registration)")
+	})
+
+	It("errors when the name resolves to a non-message (not a panic)", func() {
+		encoded, err := pb.Encode(map[string]any{"a": 1}, desc, msgName)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pb.Decode(encoded, desc, "testpb.ext_field") // an extension field, not a message
+		Expect(err).To(MatchError(ContainSubstring("is not a message")))
+	})
+
+	It("errors on invalid base64 data", func() {
+		_, err := pb.Decode("!!!not base64!!!", desc, msgName)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("errors on an unknown message name", func() {
+		encoded, err := pb.Encode(map[string]any{"a": 1}, desc, msgName)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pb.Decode(encoded, desc, "testpb.DoesNotExist")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("errors on a malformed descriptor set", func() {
+		_, err := pb.Decode("AAAA", "not a valid descriptor set", msgName)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("errors when the encode input is not an object", func() {
+		_, err := pb.Encode("not an object", desc, msgName)
+		Expect(err).To(MatchError(ContainSubstring("must be an object")))
+	})
+
+	It("returns identical results across calls (memoized registry is transparent)", func() {
+		encoded, err := pb.Encode(map[string]any{"a": 5, "[testpb.ext_field]": "42"}, desc, msgName)
+		Expect(err).NotTo(HaveOccurred())
+
+		d1, err := pb.Decode(encoded, desc, msgName)
+		Expect(err).NotTo(HaveOccurred())
+		d2, err := pb.Decode(encoded, desc, msgName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(d1).To(Equal(d2))
+	})
+})

--- a/nodered_js_plugin/protobuf_wiring_test.go
+++ b/nodered_js_plugin/protobuf_wiring_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodered_js_plugin_test
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/dop251/goja"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin"
+	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/cache"
+	protobufpkg "github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/protobuf"
+)
+
+// minimalDescriptorB64 builds a base64 FileDescriptorSet for testpb.Sample { int32 a = 1 }.
+func minimalDescriptorB64() string {
+	fds := &descriptorpb.FileDescriptorSet{File: []*descriptorpb.FileDescriptorProto{{
+		Name:    proto.String("wiring.proto"),
+		Package: proto.String("testpb"),
+		Syntax:  proto.String("proto2"),
+		MessageType: []*descriptorpb.DescriptorProto{{
+			Name: proto.String("Sample"),
+			Field: []*descriptorpb.FieldDescriptorProto{{
+				Name:   proto.String("a"),
+				Number: proto.Int32(1),
+				Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
+			}},
+		}},
+	}}}
+	b, err := proto.Marshal(fds)
+	Expect(err).NotTo(HaveOccurred())
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// Proves SetupJSEnvironment registers the `protobuf` namespace (the full decode/encode
+// behavior is covered by the protobuf package's own suite). tag_processor calls the same
+// SetupJSEnvironment, so this also covers its wiring (ENG-5243).
+var _ = Describe("protobuf in the JS environment (ENG-5243)", func() {
+	var vm *goja.Runtime
+
+	BeforeEach(func() {
+		resources := service.MockResources()
+		proc, err := nodered_js_plugin.NewNodeREDJSProcessor("", resources.Logger(), resources.Metrics(), cache.NewMemoryStore(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		vm = goja.New()
+		Expect(proc.SetupJSEnvironment(context.Background(), vm, map[string]interface{}{})).To(Succeed())
+	})
+
+	It("exposes protobuf.decode and protobuf.encode as functions", func() {
+		v, err := vm.RunString(`typeof protobuf.decode === "function" && typeof protobuf.encode === "function"`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v.ToBoolean()).To(BeTrue())
+	})
+
+	It("throws a catchable error from JS when decode fails", func() {
+		v, err := vm.RunString(`(function () {
+			try { protobuf.decode("!!not base64!!", "!!not a descriptor!!", "X"); return "no throw"; }
+			catch (e) { return "threw"; }
+		})()`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v.String()).To(Equal("threw"))
+	})
+
+	It("decodes a message through the JS boundary and returns a usable object", func() {
+		desc := minimalDescriptorB64()
+		encoded, err := protobufpkg.Encode(map[string]any{"a": 7}, desc, "testpb.Sample")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(vm.Set("DESC", desc)).To(Succeed())
+		Expect(vm.Set("ENC", encoded)).To(Succeed())
+
+		v, err := vm.RunString(`protobuf.decode(ENC, DESC, "testpb.Sample").a`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v.ToInteger()).To(Equal(int64(7)))
+	})
+})


### PR DESCRIPTION
## What this adds

A `protobuf` namespace in the JS runtime, so bridges that ingest protobuf can decode and re-encode messages inside a JS processing step — reaching fields the standard inputs don't decode. The schema is passed inline as a base64 `FileDescriptorSet` (compile once with `protoc --include_imports --descriptor_set_out`), because no proto compiler ships in the binary and the schema can't be a file on disk (no file-injection; airgapped installs have no toolchain).

```javascript
protobuf.decode(dataB64, descriptorSetB64, msgName)  // -> object
protobuf.encode(obj, descriptorSetB64, msgName)      // -> base64 string
```

- Extension types are registered, so proto2 extensions surface as protojson `[pkg.ext]` keys.
- Both throw a catchable JS error on failure.
- Available in both `nodered_js` and `tag_processor` (they share `SetupJSEnvironment`).
- Built registries are memoized by descriptor set.

Tracked by ENG-5298.

## Background

This started as deliverable 2 of the Sparkplug B extension work (ENG-5229), which needed a JS-side way to decode proto2 extension fields. That decode moved inside the `sparkplug_b` input directly (PR #392), so a JS protobuf surface is no longer needed for Sparkplug B. It stands on its own, though: any bridge ingesting protobuf can use it. Shipping it as a general `nodered_js` feature, decoupled from Sparkplug B.

## Security

The descriptor set and data are untrusted input from a user script, so:

- The registry cache is bounded (128 entries, eviction) — an unbounded cache would let a script exhaust process memory by decoding with many distinct descriptor sets.
- The JS-facing `decode`/`encode` closures recover any Go panic into a returned error — goja does not recover Go panics, so without this a malformed descriptor hitting a latent panic would crash the whole process.

## Tests

`nodered_js_plugin/protobuf/`: round-trip with top-level and message-nested extensions; error paths (bad base64 / unknown or non-message name / malformed descriptor / non-object encode); memo transparency; the cache bound. A goja-level test proves decode works through the JS boundary and that errors throw. gremlins mutation testing reports 100% efficacy on the package.

## For reviewers

No proto compiler ships — the user supplies a precompiled descriptor set. protojson conventions apply to the decoded object (int64/bytes as strings, enums as names), documented in `docs/processing/javascript-api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
