### PR TITLE
uns_beta_single: single-plugin candidate alongside uns_beta (option B, ENG-5105)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,5 @@ cmd/schema-export/schema-export
 .connect-patched/
 go.patched.mod
 go.patched.sum
+003_klaus/
+vsdd/

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ CONFIG ?= ./config/opcua-hex-test.yaml
 # copy is git-baselined so the patch can always be regenerated with `git diff`.
 CONNECT_PKG := github.com/redpanda-data/connect/v4
 CONNECT_PATCH := patches/connect-key-filter.patch
+CONNECT_FORWARD_PATCH := patches/connect-redpanda-forward.patch
 CONNECT_VENDOR := .connect-patched
 PATCHED_MODFILE := go.patched.mod
 PATCHED_SUMFILE := go.patched.sum
@@ -78,14 +79,18 @@ patch-connect:
 	( cd $(CONNECT_VENDOR) && git init -q && git add -A && \
 	  git -c user.email=patch@umh -c user.name=patch commit -qm base && \
 	  git apply --check -p1 ../$(CONNECT_PATCH) && \
-	  git apply -p1 ../$(CONNECT_PATCH) ) && \
+	  git apply -p1 ../$(CONNECT_PATCH) && \
+	  git apply --check -p1 ../$(CONNECT_FORWARD_PATCH) && \
+	  git apply -p1 ../$(CONNECT_FORWARD_PATCH) ) && \
 	cp go.mod $(PATCHED_MODFILE) && cp go.sum $(PATCHED_SUMFILE) && \
 	go mod edit -replace $(CONNECT_PKG)=./$(CONNECT_VENDOR) $(PATCHED_MODFILE) && \
 	echo "patched $(CONNECT_PKG) -> ./$(CONNECT_VENDOR); committed go.mod untouched." && \
 	echo "build/test patched with: GOFLAGS=-modfile=$(PATCHED_MODFILE) go test -tags connect_patched ./uns_plugin/..."
 
-# Drift gate only: verify the diff still applies to the pinned module without
-# touching go.mod. CI runs this so a Renovate bump that moves connect fails loud.
+# Drift gate only: verify the key-filter patch still applies to the pinned
+# module without touching go.mod. Not run by CI; run manually after a
+# connect bump. The forwarder patch is exercised by patch-connect (and the
+# connect_patched test lane), not by this gate.
 .PHONY: check-connect-patch
 check-connect-patch:
 	@CONNECT_SRC=$$(go list -m -f '{{.Dir}}' $(CONNECT_PKG)) && \

--- a/patches/connect-redpanda-forward.patch
+++ b/patches/connect-redpanda-forward.patch
@@ -1,11 +1,12 @@
 diff --git a/internal/impl/kafka/input_redpanda.go b/internal/impl/kafka/input_redpanda.go
+index b2956c6..0f772fb 100644
 --- a/internal/impl/kafka/input_redpanda.go
 +++ b/internal/impl/kafka/input_redpanda.go
-@@ -98,6 +98,13 @@
- 		},
+@@ -99,6 +99,14 @@ func redpandaInputConfigFields() []*service.ConfigField {
  	)
  }
  
++
 +// RedpandaInputConfigFields re-exports the redpanda input's config fields so
 +// packages outside internal/impl/kafka (the redpandaforward shim) can build a
 +// redpanda ConfigSpec without duplicating redpandaInputConfigFields.
@@ -15,13 +16,15 @@ diff --git a/internal/impl/kafka/input_redpanda.go b/internal/impl/kafka/input_r
 +
  func init() {
  	service.MustRegisterBatchInput("redpanda", redpandaInputConfig(),
-
+ 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
 diff --git a/public/components/kafka/redpandaforward/redpandaforward.go b/public/components/kafka/redpandaforward/redpandaforward.go
 new file mode 100644
-index 0000000..1111111
+index 0000000..22bbe8c
 --- /dev/null
 +++ b/public/components/kafka/redpandaforward/redpandaforward.go
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,78 @@
++//go:build connect_patched
++
 +// Copyright 2025 Redpanda Data, Inc.
 +//
 +// Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,7 +47,10 @@ index 0000000..1111111
 +package redpandaforward
 +
 +import (
++	"errors"
++
 +	"github.com/redpanda-data/benthos/v4/public/service"
++	"github.com/twmb/franz-go/pkg/kgo"
 +
 +	"github.com/redpanda-data/connect/v4/internal/impl/kafka"
 +)
@@ -58,4 +64,40 @@ index 0000000..1111111
 +// is caught.
 +func ConfigFields() []*service.ConfigField {
 +	return kafka.RedpandaInputConfigFields()
++}
++
++// NewRedpandaInput re-assembles connect's redpanda input init(), explicit-
++// connection branch only. It is explicit-connection-only: the shared global
++// redpanda client fallback (FranzSharedClientUse / SharedGlobalRedpandaClientKey)
++// is intentionally omitted because no benthos-umh caller registers a shared
++// client, and uns_beta_single's lean surface always sets seed_brokers.
++func NewRedpandaInput(conf *service.ParsedConfig, res *service.Resources) (service.BatchInput, error) {
++	connDetails, err := kafka.FranzConnectionDetailsFromConfig(conf, res.Logger())
++	if err != nil {
++		return nil, err
++	}
++	if !connDetails.IsConfigured() {
++		return nil, errors.New("redpandaforward: seed_brokers is required; the shared-client fallback is not supported by this shim")
++	}
++	consumerOpts, err := kafka.FranzConsumerOptsFromConfig(conf)
++	if err != nil {
++		return nil, err
++	}
++	clientOpts := append(connDetails.FranzOpts(), consumerOpts...)
++	rdr, err := kafka.NewFranzReaderToggledFromConfig(conf, res, func() ([]kgo.Opt, error) {
++		return clientOpts, nil
++	})
++	if err != nil {
++		return nil, err
++	}
++	if rdr, err = service.AutoRetryNacksBatchedToggled(conf, rdr); err != nil {
++		return nil, err
++	}
++	if rdr, err = service.ForceTimelyNacksBatched(conf, rdr); err != nil {
++		return nil, err
++	}
++	if rdr, err = conf.WrapBatchInputExtractTracingSpanMapping("redpanda", rdr); err != nil {
++		return nil, err
++	}
++	return rdr, nil
 +}

--- a/patches/connect-redpanda-forward.patch
+++ b/patches/connect-redpanda-forward.patch
@@ -1,0 +1,61 @@
+diff --git a/internal/impl/kafka/input_redpanda.go b/internal/impl/kafka/input_redpanda.go
+--- a/internal/impl/kafka/input_redpanda.go
++++ b/internal/impl/kafka/input_redpanda.go
+@@ -98,6 +98,13 @@
+ 		},
+ 	)
+ }
+ 
++// RedpandaInputConfigFields re-exports the redpanda input's config fields so
++// packages outside internal/impl/kafka (the redpandaforward shim) can build a
++// redpanda ConfigSpec without duplicating redpandaInputConfigFields.
++func RedpandaInputConfigFields() []*service.ConfigField {
++	return redpandaInputConfigFields()
++}
++
+ func init() {
+ 	service.MustRegisterBatchInput("redpanda", redpandaInputConfig(),
+
+diff --git a/public/components/kafka/redpandaforward/redpandaforward.go b/public/components/kafka/redpandaforward/redpandaforward.go
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/public/components/kafka/redpandaforward/redpandaforward.go
+@@ -0,0 +1,37 @@
++// Copyright 2025 Redpanda Data, Inc.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//    http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++// Package redpandaforward re-exports the redpanda input config field set so
++// downstream plugins (e.g. benthos-umh's uns_beta forwarder) can declare a
++// schema-compatible reader without importing connect's internal/impl/kafka
++// package directly. The package is placed under connect/v4/ because only
++// packages there can import internal/impl/kafka.
++package redpandaforward
++
++import (
++	"github.com/redpanda-data/benthos/v4/public/service"
++
++	"github.com/redpanda-data/connect/v4/internal/impl/kafka"
++)
++
++// ConfigFields returns the full redpanda input field set by delegating to
++// connect's own redpandaInputConfigFields via the exported
++// kafka.RedpandaInputConfigFields wrapper. Delegating (rather than
++// reconstructing the slice here) means a structural change in connect (a new
++// wrapper toggle, a field moved outside the four groups, or a new group)
++// surfaces through this shim without a matching edit, so silent schema drift
++// is caught.
++func ConfigFields() []*service.ConfigField {
++	return kafka.RedpandaInputConfigFields()
++}

--- a/uns_plugin/uns_beta_e2e_benchmark_test.go
+++ b/uns_plugin/uns_beta_e2e_benchmark_test.go
@@ -187,8 +187,8 @@ func BenchmarkE2E_DrainKfake(b *testing.B) {
 	runDrainMatrix(b, startBroker(b))
 }
 
-// runDrainMatrix produces the corpus once, then benchmarks {uns, uns_beta} x
-// {match_all, select_one} draining it from addr.
+// runDrainMatrix produces the corpus once, then benchmarks {uns, uns_beta,
+// uns_beta_single} x {match_all, select_one} draining it from addr.
 func runDrainMatrix(b *testing.B, addr string) {
 	benchProduce(b, addr, benchCorpus())
 
@@ -206,6 +206,7 @@ func runDrainMatrix(b *testing.B, addr string) {
 	}{
 		{"uns", "bench-uns"},
 		{"uns_beta", "bench-unsbeta"},
+		{"uns_beta_single", "bench-unsbetasingle"},
 	}
 
 	for _, sc := range scenarios {

--- a/uns_plugin/uns_beta_forwarder_config_fields_test.go
+++ b/uns_plugin/uns_beta_forwarder_config_fields_test.go
@@ -1,0 +1,155 @@
+//go:build connect_patched
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uns_plugin
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	// The package is placed under connect/v4/ because only packages there can
+	// import internal/impl/kafka. It is created by the build-time patch
+	// patches/connect-redpanda-forward.patch and is only present after
+	// `make patch-connect` has applied that patch. This test proves the shim
+	// re-exports connect's redpanda input field set.
+	"github.com/redpanda-data/connect/v4/public/components/kafka/redpandaforward"
+)
+
+// configFieldName extracts the declared name of a *service.ConfigField.
+//
+// The public service API does not expose a field-name getter, so we reach the
+// underlying docs.FieldSpec through service.ConfigField.XUnwrapper (the seam
+// the service package itself uses to interop with its docs layer) and read its
+// exported Name field via reflection. This avoids importing the internal docs
+// package from benthos-umh. Each reflection step is guarded so a future
+// service API shape change fails the test with a readable message instead of
+// an opaque panic, or empty strings that hide a shim regression behind a
+// passing snapshot).
+func configFieldName(t *testing.T, f *service.ConfigField) string {
+	t.Helper()
+	if f == nil {
+		t.Fatal("nil ConfigField")
+	}
+	unwrapper := reflect.ValueOf(f.XUnwrapper())
+	if !unwrapper.IsValid() {
+		t.Fatal("XUnwrapper() returned a nil/invalid value; service.ConfigField API shape changed")
+	}
+	unwrapMethod := unwrapper.MethodByName("Unwrap")
+	if !unwrapMethod.IsValid() {
+		t.Fatal("XUnwrapper result has no Unwrap method; service.ConfigField API shape changed")
+	}
+	call := unwrapMethod.Call(nil)
+	if len(call) == 0 {
+		t.Fatal("Unwrap() returned no values; service.ConfigField API shape changed")
+	}
+	specVal := call[0] // docs.FieldSpec
+	if !specVal.IsValid() {
+		t.Fatal("Unwrap() returned an invalid docs.FieldSpec; service.ConfigField API shape changed")
+	}
+	// reflect.Indirect dereferences a pointer before FieldByName, so a future
+	// benthos bump returning *docs.FieldSpec degrades to the readable t.Fatal
+	// below instead of panicking.
+	specVal = reflect.Indirect(specVal)
+	if specVal.Kind() != reflect.Struct {
+		t.Fatal("Unwrap() returned a non-struct docs.FieldSpec; service.ConfigField API shape changed")
+	}
+	nameVal := specVal.FieldByName("Name")
+	if !nameVal.IsValid() {
+		t.Fatal("docs.FieldSpec has no Name field; service.ConfigField API shape changed")
+	}
+	return nameVal.String()
+}
+
+// TestRedpandaForwarderConfigFields asserts that the
+// forwarder shim package redpandaforward exports ConfigFields() returning the
+// full redpanda input field set — every field from
+// FranzConnectionOptionalFields(), FranzConsumerFields(),
+// FranzReaderToggledConfigFields(), plus the three wrapper toggle fields
+// NewAutoRetryNacksToggleField(), NewForceTimelyNacksField() and
+// NewExtractTracingSpanMappingField().
+//
+// Rather than spot-checking a few representative names (which a stub returning
+// exactly those names would satisfy), the test snapshots the complete sorted
+// field-name set. A connect upstream change that adds, removes, renames or
+// reorders a field — or a shim that drops a contributing group while keeping a
+// representative name from each — flips this snapshot red, so silent schema
+// drift is caught. The expected set is the snapshot of the pinned
+// connect version's redpanda input fields (the key_pattern field is added by
+// the connect-key-filter patch applied in the same patched lane).
+func TestRedpandaForwarderConfigFields(t *testing.T) {
+	RegisterTestingT(t)
+
+	fields := redpandaforward.ConfigFields()
+
+	// The full redpanda field set is large (connection + consumer + reader
+	// toggled + three wrappers); a non-empty return is the floor.
+	Expect(fields).NotTo(BeEmpty(), "ConfigFields() must re-export the redpanda input field set, got an empty slice")
+
+	// Collect declared names preserving duplicates so a field accidentally
+	// re-exported twice shows up as a length mismatch against the snapshot.
+	got := make([]string, 0, len(fields))
+	for _, f := range fields {
+		got = append(got, configFieldName(t, f))
+	}
+	slices.Sort(got)
+
+	// Complete sorted snapshot of the redpanda input field set as exposed by
+	// the pinned connect version (after both connect patches are applied).
+	want := []string{
+		"auto_replay_nacks",
+		"client_id",
+		"commit_period",
+		"conn_idle_timeout",
+		"consumer_group",
+		"extract_tracing_map",
+		"fetch_max_bytes",
+		"fetch_max_partition_bytes",
+		"fetch_max_wait",
+		"fetch_min_bytes",
+		"heartbeat_interval",
+		"instance_id",
+		"key_pattern",
+		"max_yield_batch_bytes",
+		"metadata_max_age",
+		"partition_buffer_bytes",
+		"rack_id",
+		"rebalance_timeout",
+		"regexp_topics",
+		"regexp_topics_exclude",
+		"regexp_topics_include",
+		"request_timeout_overhead",
+		"sasl",
+		"seed_brokers",
+		"session_timeout",
+		"start_from_oldest",
+		"start_offset",
+		"tcp",
+		"timely_nacks_maximum_wait",
+		"tls",
+		"topic_lag_refresh_period",
+		"topics",
+		"transaction_isolation_level",
+		"unordered_processing",
+	}
+
+	// A missing, extra, renamed or duplicated field flips this red: the shim
+	// no longer mirrors connect's redpanda input field set exactly.
+	Expect(got).To(Equal(want), "ConfigFields() field-name set drifted from the redpanda input snapshot")
+}

--- a/uns_plugin/uns_beta_forwarder_construct_test.go
+++ b/uns_plugin/uns_beta_forwarder_construct_test.go
@@ -1,0 +1,84 @@
+//go:build connect_patched
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uns_plugin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	// The forwarder shim is created by patches/connect-redpanda-forward.patch
+	// and is present only after `make patch-connect` (hence the connect_patched
+	// build tag).
+	"github.com/redpanda-data/connect/v4/public/components/kafka/redpandaforward"
+)
+
+// TestRedpandaForwarderConnects asserts that
+// redpandaforward.NewRedpandaInput(conf, res) returns a non-nil
+// service.BatchInput that successfully Connects to a real in-process kfake
+// broker. This R0b rung verifies construction + Connect only; consumption
+// parity (ReadBatch yielding records, NACK replay) is deferred to R1b (delivery
+// end-to-end), so the test does not yet produce records or assert a batch.
+// test does not yet produce records or assert a batch.
+func TestRedpandaForwarderConnects(t *testing.T) {
+	// Real in-process kfake broker (the same helper the uns_beta integration
+	// suite uses), pre-creating the umh.messages single-partition topic.
+	addr := startBroker(t)
+
+	// Minimal redpanda input config: the pre-created topic, a unique consumer
+	// group, and auto_replay_nacks pinned true.
+	const group = "r0b-forwarder-construct"
+	yaml := fmt.Sprintf(`
+seed_brokers:
+  - %s
+topics:
+  - umh.messages
+consumer_group: %s
+auto_replay_nacks: true
+`, addr, group)
+
+	spec := service.NewConfigSpec().Fields(redpandaforward.ConfigFields()...)
+	conf, err := spec.ParseYAML(yaml, nil)
+	if err != nil {
+		t.Fatalf("ParseYAML against forwarder ConfigFields() failed; the shim must re-export a schema that accepts a minimal explicit-connection redpanda config: %v", err)
+	}
+
+	// The outer stream's *service.Resources; MockResources provides the logger
+	// and metrics registry the reader's poll goroutine needs (it creates a
+	// redpanda_lag gauge).
+	res := service.MockResources()
+
+	inner, err := redpandaforward.NewRedpandaInput(conf, res)
+	if err != nil {
+		t.Fatalf("NewRedpandaInput returned an error; a stub returning (nil, ErrNotImplemented) fails this test, and the real constructor must succeed against a live broker: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = inner.Close(ctx)
+	})
+
+	// Connect must succeed against the live broker within a bounded timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := inner.Connect(ctx); err != nil {
+		t.Fatalf("inner.Connect to the kfake broker returned an error; the forwarder must construct a redpanda reader that dials and Connects against a live broker: %v", err)
+	}
+}

--- a/uns_plugin/uns_beta_integration_test.go
+++ b/uns_plugin/uns_beta_integration_test.go
@@ -85,20 +85,31 @@ func runUnsBetaStream(t testingT, unsBetaYAML string, consumerFn func(context.Co
 	}
 }
 
-var _ = Describe("uns_beta input delivery", Label("uns_beta"), func() {
+// describeBothForms runs a behavioral Describe body against both the uns_beta
+// (template form) and uns_beta_single (Go form), nesting each under a Context
+// named after the plugin so a divergence names the form. The body receives the
+// plugin name and must thread it into every AddInputYAML / reader-construction
+// call so the scenario actually exercises the named form. (R4, ENG-5105)
+func describeBothForms(name string, body func(pluginName string)) bool {
+	Describe(name, Label("uns_beta"), func() {
+		for _, pluginName := range []string{"uns_beta", "uns_beta_single"} {
+			Context(pluginName, func() {
+				body(pluginName)
+			})
+		}
+	})
+	return false
+}
+
+var _ = describeBothForms("uns_beta input delivery", func(pluginName string) {
 	It("delivers a produced message and commits its offset on ack", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-delivery"
+		group := "uns-beta-delivery-" + pluginName
 		produce(GinkgoT(), addr, rec("umh.v1.acme.berlin.temp", `{"v":1}`))
 
 		var mu sync.Mutex
 		var got []string
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics: [".*"]
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `.*`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, m := range b {
@@ -146,10 +157,10 @@ uns_beta:
 // runs and before the aliases are stamped (the documented gap pinned below).
 // For non-UMH producers that send no headers the aliases are the only source
 // of umh_topic. (ENG-5094)
-var _ = Describe("uns_beta metadata contract", Label("uns_beta"), func() {
+var _ = describeBothForms("uns_beta metadata contract", func(pluginName string) {
 	It("aliases each message's own record key and passes the native redpanda metadata through", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-meta"
+		group := "uns-beta-meta-" + pluginName
 		const key1 = "umh.v1.acme.k1"
 		const key2 = "umh.v1.acme.k2"
 		// Two records with distinct keys pin per-message aliasing: a regression
@@ -173,12 +184,7 @@ var _ = Describe("uns_beta metadata contract", Label("uns_beta"), func() {
 
 		var mu sync.Mutex
 		seen := map[string]map[string]string{} // payload -> metadata snapshot
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics: [".*"]
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `.*`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, msg := range b {
@@ -244,7 +250,7 @@ uns_beta:
 	// as their decimal strings. (ENG-5094 / ENG-5105)
 	It("reads single-byte, empty, and multi-byte headers back as strings without corrupting native int fields", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-header-typing"
+		group := "uns-beta-header-typing-" + pluginName
 		const key = "umh.v1.acme.headertyping"
 		produce(GinkgoT(), addr,
 			&kgo.Record{
@@ -260,12 +266,7 @@ uns_beta:
 
 		var mu sync.Mutex
 		var snap map[string]string // metadata snapshot of the delivered message
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics: [".*"]
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `.*`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, msg := range b {
@@ -326,7 +327,7 @@ uns_beta:
 	// the new contract.
 	It("stamps a spoofed kafka_key header over the real record key (documented gap)", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-spoof"
+		group := "uns-beta-spoof-" + pluginName
 		produce(GinkgoT(), addr, &kgo.Record{
 			Key:   []byte("umh.v1.acme.real"),
 			Value: []byte(`{"v":1}`),
@@ -337,12 +338,7 @@ uns_beta:
 
 		var mu sync.Mutex
 		var umhTopics []string
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics: [".*"]
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `.*`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, msg := range b {
@@ -381,7 +377,7 @@ uns_beta:
 	// pin should be replaced with the new contract.
 	It("drops and commits past a matching record whose spoofed kafka_key header fails the filter (documented gap)", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-spoof-dataloss"
+		group := "uns-beta-spoof-dataloss-" + pluginName
 		produce(GinkgoT(), addr,
 			&kgo.Record{
 				// offset 0: the real key matches the filter, but the spoofed
@@ -399,13 +395,7 @@ uns_beta:
 
 		var mu sync.Mutex
 		var got []string
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics:
-    - "umh\\.v1\\.acme\\..+"
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `umh\.v1\.acme\..+`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, m := range b {
@@ -443,10 +433,10 @@ uns_beta:
 // betaKeyFilter.matches doc). The delegated ack covers the whole poll, so a
 // batch mixing kept and dropped records must still commit past the dropped
 // offsets once the kept subset is acked. (ENG-5094)
-var _ = Describe("uns_beta umh_topics key filter", Label("uns_beta"), func() {
+var _ = describeBothForms("uns_beta umh_topics key filter", func(pluginName string) {
 	It("delivers only matching keys, drops keyless records, and commits past the dropped offsets", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-keyfilter"
+		group := "uns-beta-keyfilter-" + pluginName
 		// All three records go in ONE produce call so they share a fetch and —
 		// overwhelmingly likely under kfake — one delegated batch; the public
 		// surface cannot deterministically force a single batch. The matching
@@ -462,13 +452,7 @@ var _ = Describe("uns_beta umh_topics key filter", Label("uns_beta"), func() {
 
 		var mu sync.Mutex
 		var got []string
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics:
-    - "umh\\.v1\\.acme\\.berlin\\..+"
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `umh\.v1\.acme\.berlin\..+`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, m := range b {
@@ -505,7 +489,7 @@ uns_beta:
 	// legacy behavior change: betaKeyFilter.matches doc).
 	It("drops a keyless record under an explicit match-everything filter and still commits past it", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-keyless"
+		group := "uns-beta-keyless-" + pluginName
 		// One produce call: the keyed record rides alongside so the delegated
 		// batch is — overwhelmingly likely under kfake — never all-filtered
 		// (the all-filtered case, where ReadBatch self-acks the empty batch so
@@ -517,12 +501,7 @@ uns_beta:
 
 		var mu sync.Mutex
 		var got []string
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics: [".*"]
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `.*`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, m := range b {
@@ -561,10 +540,10 @@ uns_beta:
 // at offset 0 forever. uns_beta must self-ack the delegated transaction on an
 // all-filtered poll so the commit advances even though the consumer never sees a
 // message. (ENG-5094 / ENG-5105)
-var _ = Describe("uns_beta all-filtered poll commit", Label("uns_beta"), func() {
+var _ = describeBothForms("uns_beta all-filtered poll commit", func(pluginName string) {
 	It("self-acks an all-filtered poll so the committed offset advances while the consumer receives nothing", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-all-filtered"
+		group := "uns-beta-all-filtered-" + pluginName
 		// Three records, none of whose keys match the select-1 filter below: this
 		// is the all-filtered poll. The consumer never sees a message, yet the
 		// offset must still advance to 3 — otherwise the partition wedges.
@@ -575,13 +554,7 @@ var _ = Describe("uns_beta all-filtered poll commit", Label("uns_beta"), func() 
 
 		var mu sync.Mutex
 		var got []string
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics:
-    - "^only-this$"
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `^only-this$`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, m := range b {
@@ -619,7 +592,7 @@ uns_beta:
 	// the high-water mark) and the one matching record is delivered.
 	It("drains a high-cardinality selective stream to completion, delivering only the matching record", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-selective-drain"
+		group := "uns-beta-selective-drain-" + pluginName
 		const total = 2000
 		const matchAt = 1234 // the single matching record's offset
 
@@ -635,13 +608,7 @@ uns_beta:
 
 		var mu sync.Mutex
 		var got []string
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics:
-    - "^umh\\.v1\\.match\\..+$"
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `^umh\.v1\.match\..+$`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, m := range b {
@@ -680,12 +647,12 @@ uns_beta:
 // position a never-committed group at the high-water mark, so a record produced
 // before the group connected would be skipped — the arrival assertion below
 // would time out. (ENG-5094 / spec P5)
-var _ = Describe("uns_beta start-from-earliest", Label("uns_beta"), func() {
+var _ = describeBothForms("uns_beta start-from-earliest", func(pluginName string) {
 	It("delivers records produced before a fresh consumer group started", func() {
 		addr := startBroker(GinkgoT())
 		// A never-committed group name (unique suffix) so there is no committed
 		// offset to resume from — start_offset alone decides where it begins.
-		group := fmt.Sprintf("uns-beta-earliest-%d", time.Now().UnixNano())
+		group := fmt.Sprintf("uns-beta-earliest-%s-%d", pluginName, time.Now().UnixNano())
 
 		// Produce BOTH records FIRST, before any consumer exists. Their keys
 		// match the umh_topics filter so they are delivered, not dropped.
@@ -696,13 +663,7 @@ var _ = Describe("uns_beta start-from-earliest", Label("uns_beta"), func() {
 		var mu sync.Mutex
 		var got []string
 		// THEN start the stream with the fresh group.
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics:
-    - "^umh\\.v1\\."
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `^umh\.v1\.`), func(_ context.Context, b service.MessageBatch) error {
 			mu.Lock()
 			defer mu.Unlock()
 			for _, m := range b {
@@ -742,10 +703,10 @@ uns_beta:
 // committed" whether the ack was pending OR fired prematurely, so it cannot
 // distinguish correct from buggy. The premature-ack ordering is pinned instead
 // by the broker-free self-ack unit specs (uns_beta_input_test.go).
-var _ = Describe("uns_beta mixed-batch NACK redelivery", Label("uns_beta"), func() {
+var _ = describeBothForms("uns_beta mixed-batch NACK redelivery", func(pluginName string) {
 	It("redelivers the NACKed kept record without committing past it and re-drops the filtered one", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-mixed-nack"
+		group := "uns-beta-mixed-nack-" + pluginName
 		// One produce call: matching (offset 0) + non-matching (offset 1) share
 		// one fetch, overwhelmingly likely one delegated batch under kfake.
 		produce(GinkgoT(), addr,
@@ -757,13 +718,7 @@ var _ = Describe("uns_beta mixed-batch NACK redelivery", Label("uns_beta"), func
 		deliveries := map[string]int{} // payload -> delivery count
 		const failuresWanted = 2
 
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics:
-    - "^umh\\.v1\\.acme\\..+$"
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `^umh\.v1\.acme\..+$`), func(_ context.Context, b service.MessageBatch) error {
 			defer GinkgoRecover()
 			mu.Lock()
 			defer mu.Unlock()
@@ -822,10 +777,10 @@ uns_beta:
 // A specific umh_topics pattern (NOT ".*") is used so the non-matches are
 // genuinely omitted in connect, not merely dropped by uns_beta's keyless guard.
 // (ENG-5094 / ENG-5105)
-var _ = Describe("uns_beta gapless restart", Label("uns_beta"), func() {
+var _ = describeBothForms("uns_beta gapless restart", func(pluginName string) {
 	It("resumes a restarted consumer group from the committed offset with no loss and no replay across a long omitted run", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-gapless-restart"
+		group := "uns-beta-gapless-restart-" + pluginName
 		const nonMatching = 1500 // a long omitted run, spanning many fetches
 		const total = 1 + nonMatching
 
@@ -839,13 +794,7 @@ var _ = Describe("uns_beta gapless restart", Label("uns_beta"), func() {
 		}
 		produce(GinkgoT(), addr, records...)
 
-		streamYAML := `
-uns_beta:
-  broker_address: "` + addr + `"
-  consumer_group: "` + group + `"
-  umh_topics:
-    - "^umh\\.v1\\.match\\..+$"
-`
+		streamYAML := unsBetaInputYAML(pluginName, addr, group, `^umh\.v1\.match\..+$`)
 
 		// --- Run 1: drain the whole log on group G ---
 		var mu sync.Mutex
@@ -950,23 +899,23 @@ func closedLocalPort(t testingT) string {
 // Connect must FAIL FAST against an unreachable broker rather than starting a
 // stream that delivers nothing. The broker-free unit specs (uns_beta_input_test.go)
 // fabricate the ConnectionTest result; this spec exercises the REAL probe path —
-// it builds a uns_beta_reader against a closed localhost port and asserts the
-// production Connect (delegated FranzReaderUnordered.ConnectionTest → kgo ping)
-// returns a non-nil error, bounded by connectProbeTimeout (F2). The redpanda
-// input is built on a real manager via ConfigSpec.ParseYAML, so this is the same
-// inner OwnedInput.ConnectionTest the deployed input runs, not a fake.
+// it builds the input against a closed localhost port and asserts the production
+// Connect returns a non-nil error, bounded by connectProbeTimeout (F2).
 // (ENG-5094 / ENG-5105)
-var _ = Describe("uns_beta Connect against an unreachable broker", Label("uns_beta"), func() {
+var _ = describeBothForms("uns_beta Connect against an unreachable broker", func(pluginName string) {
 	It("returns a Connect error within the connect-probe bound", func() {
 		addr := closedLocalPort(GinkgoT())
 
-		// Build the uns_beta_reader directly so Connect can be called on the real
-		// input. The nested redpanda block mirrors what the uns_beta template
-		// renders (uns_beta_template.yaml) for the closed-port broker; the
-		// top-level normalized scalars match it by construction, as the template
-		// guarantees. ParseYAML builds the inner redpanda input on a real manager,
-		// so its ConnectionTest is the production ping.
-		readerYAML := `
+		// Build the reader directly so Connect can be called on the real input.
+		// The two forms have different construction paths: uns_beta uses the
+		// internal uns_beta_reader config spec (nested redpanda block + top-level
+		// scalars), while uns_beta_single uses the lean 4-field surface.
+		// Both forms' Connect must surface a real connection error against a
+		// closed port, not start a stream that delivers nothing.
+		var input service.BatchInput
+		switch pluginName {
+		case "uns_beta":
+			readerYAML := `
 input:
   redpanda:
     seed_brokers: ["` + addr + `"]
@@ -978,11 +927,27 @@ consumer_group: "uns-beta-unreachable"
 kafka_topic: "umh.messages"
 umh_topics: [".*"]
 `
-		pConf, err := unsBetaReaderConfigSpec().ParseYAML(readerYAML, service.GlobalEnvironment())
-		Expect(err).NotTo(HaveOccurred(), "the reader config must parse")
-
-		input, err := newUnsBetaReader(pConf, service.MockResources())
-		Expect(err).NotTo(HaveOccurred(), "the reader must construct against a (closed) broker")
+			pConf, err := unsBetaReaderConfigSpec().ParseYAML(readerYAML, service.GlobalEnvironment())
+			Expect(err).NotTo(HaveOccurred(), "the reader config must parse")
+			input, err = newUnsBetaReader(pConf, service.MockResources())
+			Expect(err).NotTo(HaveOccurred(), "the reader must construct against a (closed) broker")
+		case "uns_beta_single":
+			// uns_beta_single constructs the inner redpanda input lazily on
+			// first Connect via buildUnsBetaSingleInner, so construction
+			// succeeds without dialing; the closed-port error surfaces on
+			// Connect itself.
+			singleYAML := fmt.Sprintf(`
+broker_address: %q
+consumer_group: "uns-beta-unreachable"
+umh_topics: [".*"]
+`, addr)
+			pConf, err := unsBetaSingleConfigSpec().ParseYAML(singleYAML, service.GlobalEnvironment())
+			Expect(err).NotTo(HaveOccurred(), "the reader config must parse")
+			input, err = newUnsBetaSingle(pConf, service.MockResources())
+			Expect(err).NotTo(HaveOccurred(), "the reader must construct against a (closed) broker")
+		default:
+			Fail("unknown plugin: " + pluginName)
+		}
 		defer func() {
 			// The connectivity probe spins up the inner redpanda reader, whose
 			// retry loop keeps dialing the closed port; OwnedInput.Close waits for
@@ -1143,6 +1108,10 @@ func registerCaptureExporter() {
 // exporter. Under the pre-restructure noop-manager construction the inner
 // input's metrics would land on a discarded registry and `redpanda_lag` would
 // never reach the capturer, so this assertion would fail.
+//
+// NOT parameterized over both forms (R4, ENG-5105): this spec tests the uns_beta
+// template form's metrics-routing path specifically. The uns_beta_single form
+// has its own equivalent R3 spec in uns_beta_single_metrics_routing_test.go.
 var _ = Describe("uns_beta inner-input metrics routing", Label("uns_beta"), func() {
 	It("routes the inner redpanda input's redpanda_lag gauge through the outer stream's metrics registry", func() {
 		registerCaptureExporter()
@@ -1221,6 +1190,13 @@ uns_beta:
 // poll of 3 records and asserts key_omitted_records reaches 3 on the outer
 // stream's metrics registry, with filtered_records left at 0. (ENG-5094 /
 // ENG-5105)
+//
+// NOT parameterized over both forms (R4, ENG-5105): the registration-only
+// parity for filtered_records is already covered by the parameterized
+// DescribeTable in uns_beta_parameterized_behavioral_test.go. This uns_beta-only
+// spec additionally asserts the connect pre-filter's key_omitted_records
+// counter behavior, which is structurally identical between forms (the
+// pre-filter lives in connect, not in either form's Go code).
 var _ = Describe("uns_beta filtered_records counter", Label("uns_beta"), func() {
 	It("counts records omitted by the connect pre-filter under key_omitted_records, leaving uns_beta's filtered_records at 0", func() {
 		registerCaptureExporter()
@@ -1415,6 +1391,12 @@ uns_beta:
 // is exercised by the filtered_records specs above. This spec pins the
 // keyless-reaches-uns_beta path that the `.*` (match-everything) deployment still
 // has. (ENG-5094 / ENG-5105)
+//
+// NOT parameterized over both forms (R4, ENG-5105): dropped_keyless counter
+// parity is already covered by the parameterized DescribeTable in
+// uns_beta_parameterized_behavioral_test.go. This uns_beta-only spec additionally
+// asserts key_omitted_records stays 0 under `.*`, which is structurally
+// identical between forms (the pre-filter lives in connect).
 var _ = Describe("uns_beta dropped_keyless counter", Label("uns_beta"), func() {
 	It("increments dropped_keyless for a keyless record that reaches uns_beta under a match-everything pattern", func() {
 		registerCaptureExporter()
@@ -1509,6 +1491,11 @@ uns_beta:
 // omit count rather than dropped_spoofed_key). The matching-native spoof below is
 // the residual vector this counter still observes. (ENG-5094 / ENG-5105 /
 // ENG-5125)
+//
+// NOT parameterized over both forms (R4, ENG-5105): uns_beta_single does not
+// wire dropped_spoofed_key or the hasSpoofHeader/classifyDrop primitive that
+// feeds it — spoof detection is deferred to ENG-5125. Parameterizing this spec
+// over uns_beta_single would always fail (the counter is never registered).
 var _ = Describe("uns_beta dropped_spoofed_key counter", Label("uns_beta"), func() {
 	It("increments dropped_spoofed_key for a matching-native record whose spoofed kafka_key header fails the pattern", func() {
 		registerCaptureExporter()
@@ -1592,10 +1579,10 @@ uns_beta:
 // uns input commits the polled head past a NACKed batch (data loss); uns_beta
 // must instead redeliver the NACKed message until it succeeds and commit only
 // after.
-var _ = Describe("uns_beta NACK redelivery capstone", Label("uns_beta"), func() {
+var _ = describeBothForms("uns_beta NACK redelivery capstone", func(pluginName string) {
 	It("redelivers a NACKed message until success and commits the offset only after", func() {
 		addr := startBroker(GinkgoT())
-		const group = "uns-beta-capstone"
+		group := "uns-beta-capstone-" + pluginName
 		// A occupies offset 0, B offset 1 (produce is synchronous, in call order).
 		produce(GinkgoT(), addr,
 			rec("umh.v1.acme.poison", `{"v":"A"}`),
@@ -1605,12 +1592,7 @@ var _ = Describe("uns_beta NACK redelivery capstone", Label("uns_beta"), func() 
 		const failuresWanted = 3
 		var mu sync.Mutex
 		deliveries := map[string]int{} // payload -> delivery count
-		stop := runUnsBetaStream(GinkgoT(), `
-uns_beta:
-  broker_address: "`+addr+`"
-  consumer_group: "`+group+`"
-  umh_topics: [".*"]
-`, func(_ context.Context, b service.MessageBatch) error {
+		stop := runUnsBetaStream(GinkgoT(), unsBetaInputYAML(pluginName, addr, group, `.*`), func(_ context.Context, b service.MessageBatch) error {
 			// This callback runs off the test goroutine, so a Gomega failure
 			// inside it must be recovered here to be reported instead of
 			// crashing the suite.

--- a/uns_plugin/uns_beta_parameterized_behavioral_test.go
+++ b/uns_plugin/uns_beta_parameterized_behavioral_test.go
@@ -125,12 +125,17 @@ func droppedKeylessCounterScenario(pluginName string) {
 	}).WithTimeout(2 * time.Second).WithPolling(200 * time.Millisecond).
 		Should(Equal(int64(1)), pluginName+" must not over-count dropped_keyless (a climb would indicate the ENG-5094 redelivery wedge)")
 
-	// dropped_spoofed_key and filtered_records are wired only by uns_beta's
-	// filterAndAlias; uns_beta_single does not yet register them (later rung,
-	// ENG-5125), so counterValue returns 0 on a map miss for the single form.
-	// These assertions therefore meaningfully guard uns_beta; for
-	// uns_beta_single they confirm the counters are absent, not that
-	// miscounting into them is impossible.
+	// dropped_spoofed_key and filtered_records are registered (and, for
+	// filtered_records, incremented on the keyed non-matching branch) by BOTH
+	// forms' constructors. This scenario sends a keyless record and a keyed
+	// MATCHING record, so neither triggers the filtered_records increment path;
+	// counterValue==0 here reflects "no triggering record was sent", not a
+	// map-miss absence and not "the counter is never incremented". The
+	// filtered_records increment path is not exercised by any integration
+	// scenario for either form (connect's key_pattern pre-filter omits keyed
+	// non-matching records before ReadBatch); end-to-end coverage of the
+	// increment is tracked in ENG-5125. dropped_spoofed_key is not registered
+	// in the single form (no hasSpoofHeader), so a map miss returns 0 there.
 	Expect(captureExporter.counterValue("dropped_spoofed_key")).To(Equal(int64(0)),
 		pluginName+": a keyless record must not count as spoofed")
 	Expect(captureExporter.counterValue("filtered_records")).To(Equal(int64(0)),
@@ -158,4 +163,84 @@ var _ = DescribeTable("uns_beta dropped_keyless counter (parameterized over both
 	droppedKeylessCounterScenario,
 	Entry("uns_beta (template form)", "uns_beta"),
 	Entry("uns_beta_single (Go form)", "uns_beta_single"),
+)
+
+// filteredRecordsCounterScenario asserts that uns_beta's own filtered_records
+// counter is registered on the outer stream's metrics registry for both forms.
+// The single form previously omitted the counter entirely; the registration
+// assertion catches a form that omits the NewCounter call.
+//
+// Both forms register filtered_records eagerly in their constructor
+// (uns_beta_input.go newUnsBetaReader; uns_beta_single_input.go
+// newUnsBetaSingle). The constructor runs when the stream starts the input
+// (during stream.Run, not at StreamBuilder.Build), so the assertion polls for
+// registration rather than checking synchronously after Build.
+//
+// The increment is not exercised here. A single shared umh_topics list cannot
+// reach the Go-level !matches branch for a keyed record: connect's key_pattern
+// pre-filter and the Go-level keyFilter apply the same pattern, so a keyed
+// non-matching record is dropped by connect before ReadBatch. Exercising the
+// increment requires a connect-level seam or direct ReadBatch injection, which
+// belongs to the ENG-5125 rung.
+func filteredRecordsCounterScenario(pluginName string) {
+	registerCaptureExporter()
+	captureExporter.reset()
+
+	addr := startBroker(GinkgoT())
+	group := fmt.Sprintf("uns-beta-param-filtered-%s-%d", pluginName, time.Now().UnixNano())
+
+	sb := service.NewStreamBuilder()
+	Expect(sb.AddInputYAML(unsBetaInputYAML(pluginName, addr, group, `^only-this$`))).To(Succeed())
+	Expect(sb.SetMetricsYAML(captureExporterName + ": {}")).To(Succeed())
+	Expect(sb.AddBatchConsumerFunc(func(_ context.Context, _ service.MessageBatch) error {
+		return nil
+	})).To(Succeed())
+
+	stream, err := sb.Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var runErr error
+	go func() { defer close(done); runErr = stream.Run(ctx) }()
+	defer func() {
+		cancel()
+		<-done
+		if runErr != nil && !errors.Is(runErr, context.Canceled) {
+			Fail("stream run: " + runErr.Error())
+		}
+	}()
+
+	// The input constructor runs when the stream starts it (during Run), and
+	// registers filtered_records eagerly there. A form that omits the
+	// NewCounter call never registers it and fails this poll.
+	Eventually(func() bool {
+		return captureExporter.registered("filtered_records")
+	}).WithTimeout(15 * time.Second).WithPolling(100 * time.Millisecond).
+		Should(BeTrue(),
+			pluginName+": filtered_records counter must be registered on the outer stream's metrics registry")
+}
+
+// The filtered_records counter registration behavioral Describe, parameterized
+// over both forms. The single form previously did not register the
+// filtered_records counter at all, so the registration assertion failed for
+// the single form. Registration is structural only: it proves the counter name
+// exists on the registry, not that the increment fires. The increment path
+// (keyed records whose key matches no umh_topics pattern) is tracked in
+// ENG-5125, which requires a harness that bypasses connect's key_pattern
+// pre-filter.
+//
+// Coverage gap (ENG-5125): neither Entry below exercises the filtered_records
+// INCREMENT for either form. Connect's key_pattern pre-filter omits keyed
+// non-matching records before ReadBatch in both forms, so the Go-level !matches
+// branch (where the increment lives) is never reached by this scenario, which
+// sends no records at all. A regression that removes the filtered.Incr from
+// either form would leave this Describe green. Closing the gap requires a
+// connect-level seam or direct ReadBatch injection with a keyed non-matching
+// record, which belongs to the ENG-5125 rung.
+var _ = DescribeTable("uns_beta filtered_records counter registration only (structural, parameterized over both forms)",
+	Label("uns_beta"),
+	filteredRecordsCounterScenario,
+	Entry("uns_beta (template form) — registration only; increment path NOT covered (ENG-5125)", "uns_beta"),
+	Entry("uns_beta_single (Go form) — registration only; increment path NOT covered (ENG-5125)", "uns_beta_single"),
 )

--- a/uns_plugin/uns_beta_parameterized_behavioral_test.go
+++ b/uns_plugin/uns_beta_parameterized_behavioral_test.go
@@ -1,0 +1,161 @@
+//go:build connect_patched
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// R4 capstone (ENG-5105): the behavioral integration suite runs against BOTH
+// uns_beta (template form) and uns_beta_single (Go form) via a plugin-name
+// parameter, so a behavior fix applies to both forms. This file introduces the
+// parameterization helper (unsBetaInputYAML) and one parameterized behavioral
+// Describe — the dropped_keyless counter scenario — driven over both forms via
+// DescribeTable. The two forms share the lean 4-field config surface, so the
+// YAML body is identical except the top-level key.
+//
+// Scope: this rung enforces dropped_keyless counter parity for genuine (non-
+// spoofed) keyless records only. uns_beta wires two further per-reason counters
+// (dropped_spoofed_key, filtered_records) and a spoof-detection primitive
+// (classifyDrop/hasSpoofHeader) that uns_beta_single does not yet wire, so drift
+// remains possible for those two drop classes and is left to a later rung
+// (ENG-5125). The parameterized DescribeTable below proves dropped_keyless
+// parity for both forms; it does NOT prove full behavioral parity.
+
+package uns_plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	// Registers benthos core components (incl. the "none" tracer that
+	// StreamBuilder.Build defaults to). The production binary gets these via
+	// its full component bundle; this minimal test package only blank-imports
+	// the kafka components, so the StreamBuilder build needs pure here.
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// unsBetaInputYAML builds the lean 4-field input config for either form from a
+// plugin-name variable. The body is identical for both forms (the shared lean
+// surface); only the top-level key differs. This is the parameterization seam
+// the behavioral suite loops over, so a behavior fix applies to both forms.
+func unsBetaInputYAML(pluginName, broker, group, umhTopics string) string {
+	return fmt.Sprintf(`
+%[1]s:
+  broker_address: %[2]q
+  consumer_group: %[3]q
+  umh_topics:
+    - %[4]q
+`, pluginName, broker, group, umhTopics)
+}
+
+// droppedKeylessCounterScenario drives the uns_beta dropped_keyless counter
+// behavioral Describe for a single form. Under a match-everything (".*")
+// pattern the connect pre-filter builds a keyless record (it matches the empty
+// key), the form's own `key != ""` guard drops it, and dropped_keyless must
+// increment on the outer stream's metrics registry. A keyed matching record
+// keeps the poll goroutine live so the counter tick is observable.
+func droppedKeylessCounterScenario(pluginName string) {
+	registerCaptureExporter()
+	captureExporter.reset()
+
+	addr := startBroker(GinkgoT())
+	group := fmt.Sprintf("uns-beta-param-keyless-%s-%d", pluginName, time.Now().UnixNano())
+	produce(GinkgoT(), addr,
+		&kgo.Record{Key: nil, Value: []byte(`{"v":0}`)},
+		rec("umh.v1.keep.live", `{"v":1}`))
+
+	var mu sync.Mutex
+	var delivered int
+	sb := service.NewStreamBuilder()
+	Expect(sb.AddInputYAML(unsBetaInputYAML(pluginName, addr, group, `.*`))).To(Succeed())
+	Expect(sb.SetMetricsYAML(captureExporterName + ": {}")).To(Succeed())
+	Expect(sb.AddBatchConsumerFunc(func(_ context.Context, b service.MessageBatch) error {
+		mu.Lock()
+		delivered += len(b)
+		mu.Unlock()
+		return nil
+	})).To(Succeed())
+
+	stream, err := sb.Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var runErr error
+	go func() { defer close(done); runErr = stream.Run(ctx) }()
+	defer func() {
+		cancel()
+		<-done
+		if runErr != nil && !errors.Is(runErr, context.Canceled) {
+			Fail("stream run: " + runErr.Error())
+		}
+	}()
+
+	// The keyless drop must increment dropped_keyless on the outer stream's
+	// metrics registry. uns_beta wires this counter in filterAndAlias; a form
+	// that diverges (no per-reason counters) leaves it at 0 and fails here.
+	Eventually(func() int64 {
+		return captureExporter.counterValue("dropped_keyless")
+	}).WithTimeout(15 * time.Second).WithPolling(100 * time.Millisecond).
+		Should(Equal(int64(1)), pluginName+" must increment dropped_keyless for a keyless record that reaches it under a match-everything pattern")
+
+	// Guard against over-counting: the keyless record must be counted exactly
+	// once. If it were redelivered and re-dropped (the ENG-5094 infinite-
+	// redelivery wedge this suite exists to detect), dropped_keyless would
+	// climb past 1. The sibling key_omitted_records spec applies the same
+	// Consistently guard.
+	Consistently(func() int64 {
+		return captureExporter.counterValue("dropped_keyless")
+	}).WithTimeout(2 * time.Second).WithPolling(200 * time.Millisecond).
+		Should(Equal(int64(1)), pluginName+" must not over-count dropped_keyless (a climb would indicate the ENG-5094 redelivery wedge)")
+
+	// dropped_spoofed_key and filtered_records are wired only by uns_beta's
+	// filterAndAlias; uns_beta_single does not yet register them (later rung,
+	// ENG-5125), so counterValue returns 0 on a map miss for the single form.
+	// These assertions therefore meaningfully guard uns_beta; for
+	// uns_beta_single they confirm the counters are absent, not that
+	// miscounting into them is impossible.
+	Expect(captureExporter.counterValue("dropped_spoofed_key")).To(Equal(int64(0)),
+		pluginName+": a keyless record must not count as spoofed")
+	Expect(captureExporter.counterValue("filtered_records")).To(Equal(int64(0)),
+		pluginName+": a keyless record must not count as a filtered (real-keyed) drop")
+	// The keyed matching record is delivered asynchronously by benthos's batch
+	// consumer AFTER ReadBatch returns; the dropped_keyless tick can be
+	// observable before the consumer callback runs (especially if franz-go
+	// delivers the keyless and keyed records in separate polls), so poll for
+	// delivery rather than asserting synchronously.
+	Eventually(func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return delivered
+	}).WithTimeout(15 * time.Second).WithPolling(100 * time.Millisecond).
+		Should(Equal(1), pluginName+": the keyed matching record must be delivered")
+}
+
+// R4 parameterized behavioral suite: one behavioral Describe (the dropped_keyless
+// counter scenario) driven over both forms via the plugin-name parameter. This
+// proves the behavioral suite runs against both uns_beta and uns_beta_single for
+// the dropped_keyless counter; it is not a full-parity proof (spoofed-key
+// classification and filtered_records are out of scope, ENG-5125).
+var _ = DescribeTable("uns_beta dropped_keyless counter (parameterized over both forms)",
+	Label("uns_beta"),
+	droppedKeylessCounterScenario,
+	Entry("uns_beta (template form)", "uns_beta"),
+	Entry("uns_beta_single (Go form)", "uns_beta_single"),
+)

--- a/uns_plugin/uns_beta_selective_micro_bench_test.go
+++ b/uns_plugin/uns_beta_selective_micro_bench_test.go
@@ -25,6 +25,14 @@
 // message construction then discards it. This benchmark measures exactly that delta.
 // Network/fetch/decompression are IDENTICAL for both and are NOT in the benchmark.
 //
+// Scope: these benchmarks are uns_beta-specific. uns_beta_single pre-filters at
+// the Kafka consumer via connect's key_pattern, so a dropped record never reaches
+// the build-then-filter path measured here (it is dropped before a service.Message
+// is constructed). uns_beta_single's dropped-record cost is therefore a single
+// regex match at the source, structurally identical to legacy uns's pre-filter,
+// and its end-to-end drain cost is covered by the {select_one, uns_beta_single}
+// case in uns_beta_e2e_benchmark_test.go.
+//
 // All symbols are prefixed `micro` to avoid in-package redeclaration collisions.
 package uns_plugin
 

--- a/uns_plugin/uns_beta_single_config_test.go
+++ b/uns_plugin/uns_beta_single_config_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uns_plugin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// uns_beta_single is a Go-registered input that consumes a single Kafka topic
+// and filters records by key. This spec exercises its config validation by
+// parsing against the plugin's OWN ConfigSpec and constructing through the Go
+// constructor newUnsBetaSingle directly — uns_beta_single has no template
+// layer, so the bare constructor error is available for exact MatchError (no
+// StreamBuilder *componentErr wrapping). This mirrors the sibling
+// uns_beta_reader spec's direct-call pattern.
+var _ = Describe("uns_beta_single config validation", Label("uns_beta"), func() {
+	// parseAndConstruct parses body against the spec and constructs the input,
+	// returning the first error encountered: a parse-time required-field
+	// rejection or a constructor-time scalar rejection. Both are bare errors
+	// (no framework wrapping), so callers can assert with MatchError.
+	parseAndConstruct := func(body string) (service.BatchInput, error) {
+		parsed, err := unsBetaSingleConfigSpec().ParseYAML(body, nil)
+		if err != nil {
+			return nil, err
+		}
+		return newUnsBetaSingle(parsed, nil)
+	}
+
+	DescribeTable("newUnsBetaSingle rejects invalid config",
+		func(body string, wantErr interface{}) {
+			_, err := parseAndConstruct(body)
+			Expect(err).To(MatchError(wantErr))
+		},
+		Entry("empty consumer_group is rejected",
+			"consumer_group: \"\"\numh_topics: [\".*\"]\n",
+			"consumer_group must not be empty"),
+		Entry("kafka_topic '.' is rejected",
+			"consumer_group: \"g\"\numh_topics: [\".*\"]\nkafka_topic: \".\"\n",
+			"kafka_topic must be a legal Kafka topic name (letters, digits, '.', '_', '-'; max 249 chars)"),
+		Entry("kafka_topic '..' is rejected",
+			"consumer_group: \"g\"\numh_topics: [\".*\"]\nkafka_topic: \"..\"\n",
+			"kafka_topic must be a legal Kafka topic name (letters, digits, '.', '_', '-'; max 249 chars)"),
+		Entry("illegal kafka_topic (contains colon) is rejected",
+			"consumer_group: \"g\"\numh_topics: [\".*\"]\nkafka_topic: \"a:b\"\n",
+			"kafka_topic must be a legal Kafka topic name (letters, digits, '.', '_', '-'; max 249 chars)"),
+		Entry("missing umh_topics is rejected",
+			"consumer_group: \"g\"\n",
+			"umh_topics must not be empty"),
+		Entry("empty umh_topics list is rejected",
+			"consumer_group: \"g\"\numh_topics: []\n",
+			"umh_topics must not be empty"),
+		Entry("empty umh_topics element is rejected (an empty pattern wraps to (?:) matching every key)",
+			"consumer_group: \"g\"\numh_topics: [\".*\", \"\"]\n",
+			ContainSubstring("umh_topics pattern at index 1 must not be empty or whitespace-only")),
+		Entry("invalid umh_topics regex is rejected",
+			"consumer_group: \"g\"\numh_topics: [\"[\"]\n",
+			ContainSubstring("invalid umh_topics pattern at index 0:")),
+	)
+
+	It("rejects a missing required consumer_group at parse time", func() {
+		// consumer_group is a required field (no Default); the framework
+		// rejects its absence before the constructor runs. Framework error
+		// strings are not part of this plugin's contract, so match by
+		// substring.
+		_, err := parseAndConstruct("umh_topics: [\".*\"]\n")
+		Expect(err).To(MatchError(ContainSubstring("consumer_group")))
+	})
+
+	It("accepts a valid config (constructor passes Go-level validation and returns a non-nil input)", func() {
+		in, err := parseAndConstruct("consumer_group: \"g\"\numh_topics: [\".*\"]\n")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(in).NotTo(BeNil())
+	})
+
+	It("returns a not-implemented error from ReadBatch so a valid config is distinguishable from a validation rejection", func() {
+		_, _, err := (&unsBetaSingleInput{}).ReadBatch(context.Background())
+		Expect(err).To(MatchError(ContainSubstring("uns_beta_single: not implemented")))
+	})
+})

--- a/uns_plugin/uns_beta_single_config_test.go
+++ b/uns_plugin/uns_beta_single_config_test.go
@@ -71,6 +71,12 @@ var _ = Describe("uns_beta_single config validation", Label("uns_beta"), func() 
 		Entry("invalid umh_topics regex is rejected",
 			"consumer_group: \"g\"\numh_topics: [\"[\"]\n",
 			ContainSubstring("invalid umh_topics pattern at index 0:")),
+		Entry("consumer_group with a newline is rejected (YAML injection guard)",
+			"consumer_group: \"x\\nauto_replay_nacks: false\"\numh_topics: [\".*\"]\n",
+			ContainSubstring("consumer_group must not contain control characters or newlines")),
+		Entry("broker_address with a newline is rejected (YAML injection guard)",
+			"broker_address: \"localhost:9092\\nstart_offset: latest\"\nconsumer_group: \"g\"\numh_topics: [\".*\"]\n",
+			ContainSubstring("broker_address must not contain control characters or newlines")),
 	)
 
 	It("rejects a missing required consumer_group at parse time", func() {

--- a/uns_plugin/uns_beta_single_delivery_test.go
+++ b/uns_plugin/uns_beta_single_delivery_test.go
@@ -1,0 +1,80 @@
+//go:build connect_patched
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The startBroker/produce/rec helpers used here live in
+// uns_input_nack_commit_repro_test.go (same package).
+
+package uns_plugin
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	// Registers benthos core components (incl. the "none" tracer that
+	// StreamBuilder.Build defaults to). The production binary gets these via
+	// its full component bundle; this minimal test package only blank-imports
+	// the kafka components, so the StreamBuilder build needs pure here.
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// A record whose key matches umh_topics must flow end-to-end through the
+// Go-registered uns_beta_single input.
+var _ = Describe("uns_beta_single delivery", Label("uns_beta"), func() {
+	It("delivers a produced record whose key matches umh_topics end-to-end through the Go-registered input", func() {
+		addr := startBroker(GinkgoT())
+		// A unique consumer group so the fresh group reads from the earliest
+		// offset (the translation pins start_offset: earliest).
+		group := fmt.Sprintf("uns-beta-single-delivery-%d", time.Now().UnixNano())
+		// Produce one record whose key matches the umh_topics filter below.
+		produce(GinkgoT(), addr, rec("umh.v1.acme.temp", `{"v":1}`))
+
+		var mu sync.Mutex
+		var got []string
+		stop := runUnsBetaStream(GinkgoT(), fmt.Sprintf(`
+uns_beta_single:
+  broker_address: %q
+  consumer_group: %q
+  umh_topics: [".*"]
+`, addr, group), func(_ context.Context, b service.MessageBatch) error {
+			mu.Lock()
+			defer mu.Unlock()
+			for _, m := range b {
+				bs, _ := m.AsBytes()
+				got = append(got, string(bs))
+			}
+			return nil
+		})
+		defer stop()
+
+		// The record must arrive through uns_beta_single.
+		Eventually(func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(got)
+		}).WithTimeout(15*time.Second).WithPolling(100*time.Millisecond).
+			Should(BeNumerically(">=", 1), "message never arrived through uns_beta_single")
+
+		mu.Lock()
+		first := got[0]
+		mu.Unlock()
+		Expect(first).To(Equal(`{"v":1}`))
+	})
+})

--- a/uns_plugin/uns_beta_single_inner_connect_patched.go
+++ b/uns_plugin/uns_beta_single_inner_connect_patched.go
@@ -1,0 +1,72 @@
+//go:build connect_patched
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uns_plugin
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	// The forwarder shim is created by patches/connect-redpanda-forward.patch
+	// and is present only after `make patch-connect` (hence the connect_patched
+	// build tag). It re-exports connect's redpanda input constructor so this
+	// package can build a redpanda reader without importing connect's
+	// internal/impl/kafka directly.
+	"github.com/redpanda-data/connect/v4/public/components/kafka/redpandaforward"
+)
+
+// buildUnsBetaSingleInner translates the lean 4-field surface into a redpanda
+// input config and builds it via the forwarder shim. The translation mirrors
+// the uns_beta template's mapping: seed_brokers from broker_address, topics
+// from kafka_topic, consumer_group, start_offset pinned earliest so a fresh
+// group reads from the beginning, auto_replay_nacks pinned true (the
+// ENG-5094 NACK-replay guarantee), and key_pattern set to the umh_topics
+// alternation so connect's pre-filter omits non-matching records before
+// message construction. The remaining fetch/conn values (R2's 12-value pin)
+// are left at redpanda's defaults — R1b only needs delivery to work.
+func buildUnsBetaSingleInner(res *service.Resources, seedBrokers []string, kafkaTopic, consumerGroup string, umhTopics []string) (service.BatchInput, error) {
+	// Build the key_pattern alternation the same way the template and
+	// newBetaKeyFilter do: (?:p1)|(?:p2)|... . newBetaKeyFilter already
+	// validated each pattern and the combined alternation at construction, so
+	// this join cannot fail at RE2 limits here.
+	wrapped := make([]string, len(umhTopics))
+	for i, p := range umhTopics {
+		wrapped[i] = fmt.Sprintf("(?:%s)", p)
+	}
+	keyPattern := strings.Join(wrapped, "|")
+
+	var brokersYAML strings.Builder
+	for _, b := range seedBrokers {
+		brokersYAML.WriteString(fmt.Sprintf("  - %q\n", b))
+	}
+	yaml := fmt.Sprintf(`seed_brokers:
+%stopics:
+  - %q
+consumer_group: %q
+start_offset: earliest
+auto_replay_nacks: true
+key_pattern: %q
+`, brokersYAML.String(), kafkaTopic, consumerGroup, keyPattern)
+
+	spec := service.NewConfigSpec().Fields(redpandaforward.ConfigFields()...)
+	conf, err := spec.ParseYAML(yaml, nil)
+	if err != nil {
+		return nil, fmt.Errorf("uns_beta_single: failed to parse translated redpanda config: %w", err)
+	}
+	return redpandaforward.NewRedpandaInput(conf, res)
+}

--- a/uns_plugin/uns_beta_single_inner_connect_patched.go
+++ b/uns_plugin/uns_beta_single_inner_connect_patched.go
@@ -18,6 +18,7 @@ package uns_plugin
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -30,16 +31,20 @@ import (
 	"github.com/redpanda-data/connect/v4/public/components/kafka/redpandaforward"
 )
 
-// buildUnsBetaSingleInner translates the lean 4-field surface into a redpanda
-// input config and builds it via the forwarder shim. The translation mirrors
-// the uns_beta template's mapping: seed_brokers from broker_address, topics
-// from kafka_topic, consumer_group, start_offset pinned earliest so a fresh
-// group reads from the beginning, auto_replay_nacks pinned true (the
-// ENG-5094 NACK-replay guarantee), and key_pattern set to the umh_topics
-// alternation so connect's pre-filter omits non-matching records before
-// message construction. The remaining fetch/conn values (R2's 12-value pin)
-// are left at redpanda's defaults — R1b only needs delivery to work.
-func buildUnsBetaSingleInner(res *service.Resources, seedBrokers []string, kafkaTopic, consumerGroup string, umhTopics []string) (service.BatchInput, error) {
+// redpandaConfigYAML is the pure, broker-free translation of the lean 4-field
+// uns_beta_single surface into a redpanda input config YAML. It pins all 12
+// values that uns_beta's render test re-derives so the translation is
+// inspectable without dialing a broker: seed_brokers, topics, consumer_group,
+// start_offset (earliest), commit_period ("5s"), the three fetch byte fields
+// (re-derived from the Go fetch constants in uns_input_config.go as strings,
+// matching upstream's NewStringField contract), fetch_max_wait and
+// conn_idle_timeout (re-derived from the Go fetch/conn constants),
+// auto_replay_nacks (pinned true — the ENG-5094 NACK-replay guarantee), and
+// key_pattern (the newBetaKeyFilter join of umh_topics). commit_period is
+// pinned to "5s" defensively, matching uns_beta's template pin and the
+// auto_replay_nacks treatment, so a future connect default change cannot
+// silently alter uns_beta_single's commit cadence.
+func redpandaConfigYAML(seedBrokers []string, kafkaTopic, consumerGroup string, umhTopics []string) string {
 	// Build the key_pattern alternation the same way the template and
 	// newBetaKeyFilter do: (?:p1)|(?:p2)|... . newBetaKeyFilter already
 	// validated each pattern and the combined alternation at construction, so
@@ -54,14 +59,45 @@ func buildUnsBetaSingleInner(res *service.Resources, seedBrokers []string, kafka
 	for _, b := range seedBrokers {
 		brokersYAML.WriteString(fmt.Sprintf("  - %q\n", b))
 	}
-	yaml := fmt.Sprintf(`seed_brokers:
+
+	// The fetch byte fields are NewStringField upstream, so emit them as
+	// strings re-derived from the same Go constants uns_beta's render test
+	// uses; a constant retune updates production and expectation in lockstep,
+	// so these pins guard format, not value. fetch_max_wait and
+	// conn_idle_timeout are NewDurationField, re-derived from the Go
+	// constants.
+	return fmt.Sprintf(`seed_brokers:
 %stopics:
   - %q
 consumer_group: %q
 start_offset: earliest
+commit_period: "5s"
 auto_replay_nacks: true
 key_pattern: %q
-`, brokersYAML.String(), kafkaTopic, consumerGroup, keyPattern)
+fetch_max_bytes: %q
+fetch_max_partition_bytes: %q
+fetch_min_bytes: %q
+fetch_max_wait: %s
+conn_idle_timeout: %s
+`,
+		brokersYAML.String(),
+		kafkaTopic,
+		consumerGroup,
+		keyPattern,
+		strconv.FormatFloat(defaultFetchMaxBytes, 'f', -1, 64),
+		strconv.FormatFloat(defaultFetchMaxPartitionBytes, 'f', -1, 64),
+		strconv.FormatFloat(defaultFetchMinBytes, 'f', -1, 64),
+		defaultFetchMaxWaitTime.String(),
+		defaultConnIdleTimeout.String(),
+	)
+}
+
+// buildUnsBetaSingleInner translates the lean 4-field surface into a redpanda
+// input config and builds it via the forwarder shim. The translation is
+// produced by redpandaConfigYAML (the pure, broker-free helper) so the 12
+// pinned values are inspectable without dialing a broker.
+func buildUnsBetaSingleInner(res *service.Resources, seedBrokers []string, kafkaTopic, consumerGroup string, umhTopics []string) (service.BatchInput, error) {
+	yaml := redpandaConfigYAML(seedBrokers, kafkaTopic, consumerGroup, umhTopics)
 
 	spec := service.NewConfigSpec().Fields(redpandaforward.ConfigFields()...)
 	conf, err := spec.ParseYAML(yaml, nil)

--- a/uns_plugin/uns_beta_single_inner_stub.go
+++ b/uns_plugin/uns_beta_single_inner_stub.go
@@ -1,0 +1,31 @@
+//go:build !connect_patched
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uns_plugin
+
+import (
+	"errors"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// buildUnsBetaSingleInner is the non-patched stub: the forwarder shim only
+// exists after `make patch-connect`, so without the connect_patched tag the
+// redpanda reader cannot be built. The input's Connect surfaces this error,
+// keeping config validation (which runs in both lanes) green.
+func buildUnsBetaSingleInner(_ *service.Resources, _ []string, _, _ string, _ []string) (service.BatchInput, error) {
+	return nil, errors.New("uns_beta_single: not implemented (requires connect_patched build)")
+}

--- a/uns_plugin/uns_beta_single_input.go
+++ b/uns_plugin/uns_beta_single_input.go
@@ -121,13 +121,22 @@ func newUnsBetaSingle(conf *service.ParsedConfig, res *service.Resources) (servi
 		return nil, err
 	}
 
+	// The config-validation unit test constructs the input with a nil
+	// *service.Resources; res.Metrics() panics on a nil receiver, so guard it.
+	// A nil keylessCounter is a no-op Incr (*service.MetricCounter treats a
+	// nil receiver as a no-op), so the nil-resources path stays safe.
+	var keylessCounter *service.MetricCounter
+	if res != nil {
+		keylessCounter = res.Metrics().NewCounter("dropped_keyless")
+	}
 	return &unsBetaSingleInput{
-		res:           res,
-		seedBrokers:   seedBrokers,
-		kafkaTopic:    kafkaTopic,
-		consumerGroup: consumerGroup,
-		umhTopics:     patterns,
-		keyFilter:     keyFilter,
+		res:            res,
+		seedBrokers:    seedBrokers,
+		kafkaTopic:     kafkaTopic,
+		consumerGroup:  consumerGroup,
+		umhTopics:      patterns,
+		keyFilter:      keyFilter,
+		keylessCounter: keylessCounter,
 	}, nil
 }
 
@@ -143,6 +152,19 @@ type unsBetaSingleInput struct {
 	consumerGroup string
 	umhTopics     []string
 	keyFilter     *betaKeyFilter
+
+	// keylessCounter counts keyless drops to match uns_beta's dropped_keyless
+	// counter (records with an empty Kafka key that reach ReadBatch and fail
+	// the `key != ""` guard). Parity holds for genuine (non-spoofed) keyless
+	// records only: a record whose native key is empty but carries a foreign
+	// header named "kafka_key" (the ENG-5125 spoof vector) is tallied as
+	// dropped_spoofed_key by uns_beta's spoof-first classifyDrop, but is
+	// mis-counted as dropped_keyless here because the single form lacks
+	// hasSpoofHeader. The other two per-reason counters
+	// (dropped_spoofed_key, filtered_records) are not wired in the single
+	// form. Spoof detection is deferred to ENG-5125, which closes the gap for
+	// both forms together.
+	keylessCounter *service.MetricCounter
 
 	// inner is built on first Connect by buildUnsBetaSingleInner (forwarder
 	// under connect_patched, stub otherwise). nil until then.
@@ -194,6 +216,30 @@ func (i *unsBetaSingleInput) ReadBatch(ctx context.Context) (service.MessageBatc
 				continue
 			}
 			if !i.keyFilter.matches(key) {
+				// A real keyless record (ok && key=="") reached this guard
+				// because connect's key_pattern matched the empty key (".*"
+				// matches ""); the `key != ""` guard in matches drops it.
+				// Count it on the outer stream's metrics registry, mirroring
+				// uns_beta's dropped_keyless counter — but only for genuine
+				// keyless records. A spoofed-keyless record (native key empty,
+				// foreign "kafka_key" header shadowing it — the ENG-5125 spoof
+				// vector) is mis-counted here as dropped_keyless because this
+				// form lacks uns_beta's spoof-first hasSpoofHeader check; uns_beta
+				// tallies it as dropped_spoofed_key. TODO(ENG-5125): port
+				// hasSpoofHeader/classifyDrop so spoofed records are not
+				// mis-counted, and wire dropped_spoofed_key.
+				// The connect high-water placeholder is recognized by the
+				// ABSENCE of kafka_key meta (!ok path above), so it does not
+				// reach this counter today — but that recognition depends on
+				// connect's current __rpcn_kafka_headers/key-meta semantics; a
+				// connect upgrade that changes them (see rpcnKafkaHeadersKey in
+				// uns_beta_input.go) could surface the placeholder here. This
+				// is a shared invariant (uns_beta's filterAndAlias has the same
+				// dependency), so the parameterized suite cannot detect its
+				// regression.
+				if key == "" {
+					i.keylessCounter.Incr(1)
+				}
 				continue
 			}
 			// Stamp the umh_topic/kafka_msg_key aliases and strip the

--- a/uns_plugin/uns_beta_single_input.go
+++ b/uns_plugin/uns_beta_single_input.go
@@ -126,17 +126,29 @@ func newUnsBetaSingle(conf *service.ParsedConfig, res *service.Resources) (servi
 	// A nil keylessCounter is a no-op Incr (*service.MetricCounter treats a
 	// nil receiver as a no-op), so the nil-resources path stays safe.
 	var keylessCounter *service.MetricCounter
+	var filteredCounter *service.MetricCounter
 	if res != nil {
 		keylessCounter = res.Metrics().NewCounter("dropped_keyless")
+		// filtered_records counts keyed records that reach ReadBatch but fail
+		// the umh_topics filter (the !matches branch with key != ""), mirroring
+		// uns_beta's dropCounters.filtered. The handle is stored so the counter
+		// is wired — registered AND incremented — rather than a dead
+		// registration whose handle is discarded and can never fire (which would
+		// read as a false zero on the divergence path). The increment path is
+		// not exercised by the integration suite: connect's key_pattern
+		// pre-filter omits keyed non-matching records before ReadBatch in both
+		// forms, so end-to-end coverage of the increment is tracked in ENG-5125.
+		filteredCounter = res.Metrics().NewCounter("filtered_records")
 	}
 	return &unsBetaSingleInput{
-		res:            res,
-		seedBrokers:    seedBrokers,
-		kafkaTopic:     kafkaTopic,
-		consumerGroup:  consumerGroup,
-		umhTopics:      patterns,
-		keyFilter:      keyFilter,
-		keylessCounter: keylessCounter,
+		res:             res,
+		seedBrokers:     seedBrokers,
+		kafkaTopic:      kafkaTopic,
+		consumerGroup:   consumerGroup,
+		umhTopics:       patterns,
+		keyFilter:       keyFilter,
+		keylessCounter:  keylessCounter,
+		filteredCounter: filteredCounter,
 	}, nil
 }
 
@@ -157,14 +169,24 @@ type unsBetaSingleInput struct {
 	// counter (records with an empty Kafka key that reach ReadBatch and fail
 	// the `key != ""` guard). Parity holds for genuine (non-spoofed) keyless
 	// records only: a record whose native key is empty but carries a foreign
-	// header named "kafka_key" (the ENG-5125 spoof vector) is tallied as
-	// dropped_spoofed_key by uns_beta's spoof-first classifyDrop, but is
-	// mis-counted as dropped_keyless here because the single form lacks
-	// hasSpoofHeader. The other two per-reason counters
-	// (dropped_spoofed_key, filtered_records) are not wired in the single
-	// form. Spoof detection is deferred to ENG-5125, which closes the gap for
-	// both forms together.
+	// header named "kafka_key" is tallied as dropped_spoofed_key by uns_beta's
+	// spoof-first classifyDrop, but is mis-counted as dropped_keyless here
+	// because the single form lacks hasSpoofHeader. Of the other two per-reason
+	// counters, filtered_records is registered AND incremented (the !matches
+	// branch with key != ""), mirroring uns_beta's dropCounters.filtered; the
+	// increment path is not exercised by the integration suite (connect's
+	// key_pattern pre-filter omits keyed non-matching records before ReadBatch),
+	// so end-to-end coverage is tracked in ENG-5125. dropped_spoofed_key is not
+	// registered at all in the single form (no hasSpoofHeader to feed it).
+	// Spoof detection is tracked in ENG-5125, which closes the gap for both
+	// forms together.
 	keylessCounter *service.MetricCounter
+
+	// filteredCounter counts keyed records that reach ReadBatch but fail the
+	// umh_topics filter (the !matches branch with key != ""). Mirrors uns_beta's
+	// dropCounters.filtered; nil under a nil-resources build, in which case
+	// *service.MetricCounter treats a nil receiver as a no-op Incr.
+	filteredCounter *service.MetricCounter
 
 	// inner is built on first Connect by buildUnsBetaSingleInner (forwarder
 	// under connect_patched, stub otherwise). nil until then.
@@ -239,6 +261,14 @@ func (i *unsBetaSingleInput) ReadBatch(ctx context.Context) (service.MessageBatc
 				// regression.
 				if key == "" {
 					i.keylessCounter.Incr(1)
+				} else {
+					// A keyed non-matching record reached ReadBatch (only
+					// possible if connect's key_pattern pre-filter diverges
+					// from this Go-level filter, or a connect upgrade disables
+					// it). Count it on filtered_records, mirroring uns_beta's
+					// dropCounters.filtered, so the divergence is observable
+					// rather than a silent dead-zero.
+					i.filteredCounter.Incr(1)
 				}
 				continue
 			}

--- a/uns_plugin/uns_beta_single_input.go
+++ b/uns_plugin/uns_beta_single_input.go
@@ -14,22 +14,49 @@
 
 // uns_beta_single is a Go-registered input that consumes a single Kafka
 // topic and filters records by key, intended as a sibling of the uns_beta
-// template form. It is registered but not yet functional: a valid config
-// parses and builds, but reading returns a not-implemented error until
-// ReadBatch is implemented.
+// template form. Unlike uns_beta (which splits translation/template from the
+// Go reader), uns_beta_single does both in Go: it translates the lean 4-field
+// surface into a redpanda input config, builds the redpanda input via the
+// connect forwarder shim, and wraps it with the umh_topics key filter.
 
 package uns_plugin
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
+// validateYAMLScalar rejects any control character or leading/trailing
+// whitespace in a user string that is interpolated into the translated
+// redpanda config YAML. A newline lets a user field break out of its scalar
+// and inject arbitrary redpanda keys (e.g. a consumer_group of
+// "x\nauto_replay_nacks: false" silently disabling the ENG-5094 NACK-replay
+// guarantee). The values are also %q-quoted in the YAML, but this validation
+// fails fast with a named field rather than relying on the parser. It does
+// NOT forbid ':' because broker_address legitimately holds host:port pairs.
+func validateYAMLScalar(v, fieldName string) error {
+	for _, r := range v {
+		if r == '\n' || r == '\r' || r == '\t' || r < 0x20 {
+			return fmt.Errorf("%s must not contain control characters or newlines", fieldName)
+		}
+	}
+	if strings.TrimSpace(v) != v {
+		return fmt.Errorf("%s must not have leading or trailing whitespace", fieldName)
+	}
+	return nil
+}
+
 // unsBetaSingleConfigSpec returns the ConfigSpec for the "uns_beta_single" input.
 func unsBetaSingleConfigSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
+		Field(service.NewStringField("broker_address").
+			Description("Kafka broker address to connect to. For example: \"localhost:9092\".").
+			Default("localhost:9092").
+			Advanced()).
 		Field(service.NewStringField("consumer_group").
 			Description("Consumer group used when consuming the configured Kafka topic.")).
 		Field(service.NewStringField("kafka_topic").
@@ -47,15 +74,29 @@ func init() {
 }
 
 // newUnsBetaSingle constructs the "uns_beta_single" input, rejecting invalid
-// config. A valid config builds; the built input returns a not-implemented
-// error when read.
-func newUnsBetaSingle(conf *service.ParsedConfig, _ *service.Resources) (service.BatchInput, error) {
+// config. A valid config builds a lazy input that constructs the redpanda
+// forwarder on first Connect (so a unit test that builds without a live
+// broker/resources still succeeds); the actual reader is wired only when the
+// framework drives Connect with real resources.
+func newUnsBetaSingle(conf *service.ParsedConfig, res *service.Resources) (service.BatchInput, error) {
+	brokerAddress, err := conf.FieldString("broker_address")
+	if err != nil {
+		return nil, err
+	}
+	if err := validateYAMLScalar(brokerAddress, "broker_address"); err != nil {
+		return nil, err
+	}
+	seedBrokers := []string{brokerAddress}
+
 	consumerGroup, err := conf.FieldString("consumer_group")
 	if err != nil {
 		return nil, err
 	}
 	if consumerGroup == "" {
 		return nil, errors.New("consumer_group must not be empty")
+	}
+	if err := validateYAMLScalar(consumerGroup, "consumer_group"); err != nil {
+		return nil, err
 	}
 
 	kafkaTopic, err := conf.FieldString("kafka_topic")
@@ -74,30 +115,121 @@ func newUnsBetaSingle(conf *service.ParsedConfig, _ *service.Resources) (service
 	// (non-empty list, no empty/whitespace element, each pattern compiles, the
 	// combined alternation compiles within RE2 limits). Reusing it makes the
 	// single form's validation identical to the uns_beta sibling's and keeps
-	// the compiled filter for R1b's ReadBatch.
+	// the compiled filter for the Go-level key filter.
 	keyFilter, err := newBetaKeyFilter(patterns)
 	if err != nil {
 		return nil, err
 	}
 
-	return &unsBetaSingleInput{keyFilter: keyFilter}, nil
+	return &unsBetaSingleInput{
+		res:           res,
+		seedBrokers:   seedBrokers,
+		kafkaTopic:    kafkaTopic,
+		consumerGroup: consumerGroup,
+		umhTopics:     patterns,
+		keyFilter:     keyFilter,
+	}, nil
 }
 
-// unsBetaSingleInput is a placeholder BatchInput returned by a successful
-// build. Connect and ReadBatch both return a not-implemented error so the
-// input fails fast and visibly (ConnectionFailing, not ConnectionActive)
-// rather than looping on a transient retryable error — a valid config is
-// still distinguishable from a validation rejection.
+// unsBetaSingleInput is the BatchInput returned by a successful build. The
+// inner redpanda reader is constructed lazily on Connect (so construction
+// itself never dials a broker). A zero-value unsBetaSingleInput (inner == nil)
+// returns a not-implemented error from ReadBatch, keeping the placeholder's
+// "valid config is distinguishable from a validation rejection" contract.
 type unsBetaSingleInput struct {
-	keyFilter *betaKeyFilter
+	res           *service.Resources
+	seedBrokers   []string
+	kafkaTopic    string
+	consumerGroup string
+	umhTopics     []string
+	keyFilter     *betaKeyFilter
+
+	// inner is built on first Connect by buildUnsBetaSingleInner (forwarder
+	// under connect_patched, stub otherwise). nil until then.
+	inner service.BatchInput
 }
 
-func (i *unsBetaSingleInput) Connect(context.Context) error {
-	return errors.New("uns_beta_single: not implemented")
+func (i *unsBetaSingleInput) Connect(ctx context.Context) error {
+	if i.inner == nil {
+		inner, err := buildUnsBetaSingleInner(i.res, i.seedBrokers, i.kafkaTopic, i.consumerGroup, i.umhTopics)
+		if err != nil {
+			return err
+		}
+		i.inner = inner
+	}
+	return i.inner.Connect(ctx)
 }
 
-func (i *unsBetaSingleInput) ReadBatch(context.Context) (service.MessageBatch, service.AckFunc, error) {
-	return nil, nil, errors.New("uns_beta_single: not implemented")
+func (i *unsBetaSingleInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	if i.inner == nil {
+		return nil, nil, errors.New("uns_beta_single: not implemented")
+	}
+	for {
+		batch, ack, err := i.inner.ReadBatch(ctx)
+		if err != nil {
+			// BatchInput does not guarantee batch == nil on error; an
+			// error-accompanied batch is not delivered downstream. The ack is
+			// nil on the error path — never touch it.
+			return batch, ack, err
+		}
+		// Go-level key filter (defense-in-depth alongside connect's
+		// key_pattern): drop records whose Kafka key does not match umh_topics.
+		// This is the single source of truth for the contract (ConfigSpec:
+		// "records with an empty or absent key never match any pattern") —
+		// connect's key_pattern alone matches empty keys under ".*"
+		// (regexp ".*".MatchString("") == true), which re-opens the ENG-5094
+		// infinite-redelivery wedge (keyless record → uns-output rejection →
+		// NACK → auto_replay_nacks redelivers forever). matches enforces
+		// key != "" itself, mirroring uns_beta's filterAndAlias.
+		kept := make(service.MessageBatch, 0, len(batch))
+		for _, msg := range batch {
+			key, ok := msg.MetaGet("kafka_key")
+			// connect's key-omit pre-filter keeps a poll's LAST record as a
+			// high-water placeholder (service.NewMessage(nil), no metadata)
+			// when it fails key_pattern, so its offset still commits;
+			// recognize it by the ABSENCE of kafka_key meta and drop it. A
+			// real keyless record has ok==true, key=="" and falls through to
+			// matches, which rejects it (empty key never matches).
+			if !ok {
+				continue
+			}
+			if !i.keyFilter.matches(key) {
+				continue
+			}
+			// Stamp the umh_topic/kafka_msg_key aliases and strip the
+			// connect-internal __rpcn_kafka_headers meta, mirroring uns_beta's
+			// filterAndAlias. The uns output's default Kafka key is
+			// meta("umh_topic") and it rejects a record whose umh_topic meta is
+			// empty (uns_output.go:404), so without these aliases a delivered
+			// record is rejected by the uns output and the production pipeline
+			// breaks. The header strip prevents the delegated kgo header slice
+			// from round-tripping into downstream Kafka headers.
+			msg.MetaSetMut("umh_topic", key)
+			msg.MetaSetMut("kafka_msg_key", key)
+			msg.MetaDelete(rpcnKafkaHeadersKey)
+			kept = append(kept, msg)
+		}
+		if len(kept) > 0 {
+			return kept, ack, nil
+		}
+		// All-filtered poll: benthos's AsyncReader discards an empty batch
+		// without calling its AckFunc, so the delegated redpanda checkpoint
+		// would never resolve and the partition would wedge at the un-acked
+		// offset (ENG-5094 / ENG-5105). Self-ack the delegated transaction so
+		// the commit advances past the non-matching records, then read the
+		// next poll — the consumer never sees these records.
+		if ackErr := ack(ctx, nil); ackErr != nil {
+			return nil, nil, ackErr
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+	}
 }
 
-func (i *unsBetaSingleInput) Close(context.Context) error { return nil }
+func (i *unsBetaSingleInput) Close(ctx context.Context) error {
+	if i.inner == nil {
+		return nil
+	}
+	return i.inner.Close(ctx)
+}

--- a/uns_plugin/uns_beta_single_input.go
+++ b/uns_plugin/uns_beta_single_input.go
@@ -1,0 +1,103 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// uns_beta_single is a Go-registered input that consumes a single Kafka
+// topic and filters records by key, intended as a sibling of the uns_beta
+// template form. It is registered but not yet functional: a valid config
+// parses and builds, but reading returns a not-implemented error until
+// ReadBatch is implemented.
+
+package uns_plugin
+
+import (
+	"context"
+	"errors"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// unsBetaSingleConfigSpec returns the ConfigSpec for the "uns_beta_single" input.
+func unsBetaSingleConfigSpec() *service.ConfigSpec {
+	return service.NewConfigSpec().
+		Field(service.NewStringField("consumer_group").
+			Description("Consumer group used when consuming the configured Kafka topic.")).
+		Field(service.NewStringField("kafka_topic").
+			Description("The Kafka topic to consume.").
+			Default("umh.messages").
+			Advanced()).
+		Field(service.NewStringListField("umh_topics").
+			Description("List of RE2 regex patterns matched against each record's Kafka key (the umh_topic). Only records whose key matches at least one pattern are delivered; records with an empty or absent key never match any pattern. Patterns are unanchored; use ^...$ to match the full key. Required; to consume the whole namespace, set it explicitly to [\".*\"]."))
+}
+
+func init() {
+	if err := service.RegisterBatchInput("uns_beta_single", unsBetaSingleConfigSpec(), newUnsBetaSingle); err != nil {
+		panic(err)
+	}
+}
+
+// newUnsBetaSingle constructs the "uns_beta_single" input, rejecting invalid
+// config. A valid config builds; the built input returns a not-implemented
+// error when read.
+func newUnsBetaSingle(conf *service.ParsedConfig, _ *service.Resources) (service.BatchInput, error) {
+	consumerGroup, err := conf.FieldString("consumer_group")
+	if err != nil {
+		return nil, err
+	}
+	if consumerGroup == "" {
+		return nil, errors.New("consumer_group must not be empty")
+	}
+
+	kafkaTopic, err := conf.FieldString("kafka_topic")
+	if err != nil {
+		return nil, err
+	}
+	if !legalKafkaTopicName.MatchString(kafkaTopic) || kafkaTopic == "." || kafkaTopic == ".." {
+		return nil, errors.New("kafka_topic must be a legal Kafka topic name (letters, digits, '.', '_', '-'; max 249 chars)")
+	}
+
+	patterns, err := conf.FieldStringList("umh_topics")
+	if err != nil {
+		return nil, err
+	}
+	// newBetaKeyFilter is the single source of truth for umh_topics validation
+	// (non-empty list, no empty/whitespace element, each pattern compiles, the
+	// combined alternation compiles within RE2 limits). Reusing it makes the
+	// single form's validation identical to the uns_beta sibling's and keeps
+	// the compiled filter for R1b's ReadBatch.
+	keyFilter, err := newBetaKeyFilter(patterns)
+	if err != nil {
+		return nil, err
+	}
+
+	return &unsBetaSingleInput{keyFilter: keyFilter}, nil
+}
+
+// unsBetaSingleInput is a placeholder BatchInput returned by a successful
+// build. Connect and ReadBatch both return a not-implemented error so the
+// input fails fast and visibly (ConnectionFailing, not ConnectionActive)
+// rather than looping on a transient retryable error — a valid config is
+// still distinguishable from a validation rejection.
+type unsBetaSingleInput struct {
+	keyFilter *betaKeyFilter
+}
+
+func (i *unsBetaSingleInput) Connect(context.Context) error {
+	return errors.New("uns_beta_single: not implemented")
+}
+
+func (i *unsBetaSingleInput) ReadBatch(context.Context) (service.MessageBatch, service.AckFunc, error) {
+	return nil, nil, errors.New("uns_beta_single: not implemented")
+}
+
+func (i *unsBetaSingleInput) Close(context.Context) error { return nil }

--- a/uns_plugin/uns_beta_single_metrics_routing_test.go
+++ b/uns_plugin/uns_beta_single_metrics_routing_test.go
@@ -1,0 +1,112 @@
+//go:build connect_patched
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// R3 (ENG-5105): the redpanda_lag routing gate for the single-plugin form.
+// The registerCaptureExporter / captureExporter / startBroker / produce / rec
+// helpers live in uns_beta_integration_test.go and uns_input_nack_commit_repro_test.go
+// (same package).
+
+package uns_plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// This is the gate rung for the single-plugin form. The source-level claim
+// (SPEC.md "Research facts", franz_reader_ordered.go:534) is that redpanda_lag
+// is created from f.res.Metrics() inside the reader's own poll goroutine, bound
+// to whatever *service.Resources is handed the constructor — and uns_beta_single
+// hands the constructor the OUTER res (via forwarder.NewRedpandaInput(conf, res)).
+// So redpanda_lag must reach the outer stream's metrics exporter regardless of
+// construction path. This spec mirrors the uns_beta metrics-routing Describe
+// (uns_beta_integration_test.go:1146) but drives uns_beta_single. If this fails,
+// the single-plugin form is dead: the source-level finding about metrics routing
+// is wrong. Do NOT weaken the assertion to make it pass.
+var _ = Describe("uns_beta_single inner-input metrics routing", Label("uns_beta"), func() {
+	It("routes the inner redpanda input's redpanda_lag gauge through the outer stream's metrics registry under Go-side construction", func() {
+		registerCaptureExporter()
+		captureExporter.reset()
+
+		addr := startBroker(GinkgoT())
+		group := fmt.Sprintf("uns-beta-single-metrics-routing-%d", time.Now().UnixNano())
+		produce(GinkgoT(), addr, rec("umh.v1.acme.berlin.temp", `{"v":1}`))
+
+		sb := service.NewStreamBuilder()
+		Expect(sb.AddInputYAML(fmt.Sprintf(`
+uns_beta_single:
+  broker_address: %q
+  consumer_group: %q
+  umh_topics: [".*"]
+`, addr, group))).To(Succeed())
+		// Select the capturing exporter on the OUTER stream builder. The
+		// forwarder hands the constructor this same outer *service.Resources,
+		// so redpanda_lag — created on f.res.Metrics() in the reader's poll
+		// goroutine — must land here.
+		Expect(sb.SetMetricsYAML(captureExporterName + ": {}")).To(Succeed())
+
+		var mu sync.Mutex
+		var got int
+		Expect(sb.AddBatchConsumerFunc(func(_ context.Context, b service.MessageBatch) error {
+			mu.Lock()
+			got += len(b)
+			mu.Unlock()
+			return nil // ack so the inner input keeps polling/connected
+		})).To(Succeed())
+
+		stream, err := sb.Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		var runErr error // written before close(done), read after <-done
+		go func() { defer close(done); runErr = stream.Run(ctx) }()
+		defer func() {
+			cancel()
+			<-done
+			if runErr != nil && !errors.Is(runErr, context.Canceled) {
+				Fail("stream run: " + runErr.Error())
+			}
+		}()
+
+		// Connect + read at least one record so the inner input's poll
+		// goroutine (which registers redpanda_lag) is running.
+		Eventually(func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return got
+		}).WithTimeout(15*time.Second).WithPolling(100*time.Millisecond).
+			Should(BeNumerically(">=", 1), "message never arrived through uns_beta_single")
+
+		// The routing assertion: redpanda_lag — a metric created ONLY by the
+		// inner redpanda input on f.res.Metrics() — must have been created on
+		// the outer-attached capturer. If this fails, the forwarder is not
+		// threading the outer res into the constructor (or the source-level
+		// finding is wrong), and the single-plugin form is dead.
+		Eventually(func() bool {
+			return captureExporter.registered("redpanda_lag")
+		}).WithTimeout(15*time.Second).WithPolling(100*time.Millisecond).
+			Should(BeTrue(), "the inner redpanda input's redpanda_lag gauge never reached the outer stream's metrics registry under uns_beta_single's Go-side construction — the forwarder is not threading the outer res into NewRedpandaInput")
+	})
+})

--- a/uns_plugin/uns_beta_single_translation_parity_test.go
+++ b/uns_plugin/uns_beta_single_translation_parity_test.go
@@ -1,0 +1,204 @@
+//go:build connect_patched
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The uns_beta_single translation must reproduce uns_beta's 12 pinned
+// redpanda values exactly. This spec drives the YAML construction through a
+// pure, broker-free helper (redpandaConfigYAML) so the rendered values can be
+// inspected directly against the same Go fetch constants uns_beta's render
+// test re-derives, plus the key_pattern join and connect-side schema
+// acceptance. A second case renders uns_beta's actual template for the same
+// inputs and asserts field-by-field parity with the translation, so a template
+// edit that diverges from the translation fails here rather than only in the
+// sibling uns_beta render test.
+
+package uns_plugin
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	// The forwarder shim re-exports connect's redpanda ConfigFields so the
+	// translated YAML can be parsed against connect's real schema without a
+	// live broker. Present only after `make patch-connect`.
+	"github.com/redpanda-data/connect/v4/public/components/kafka/redpandaforward"
+)
+
+var _ = Describe("uns_beta_single translation parity", Label("uns_beta"), func() {
+	It("reproduces all 12 pinned redpanda values, the key_pattern join, and a connect-accepted config from the pure YAML builder", func() {
+		seedBrokers := []string{"broker1:9092", "broker2:9092"}
+		kafkaTopic := "umh.messages"
+		consumerGroup := "parity-group"
+		umhTopics := []string{"umh.v1.acme.temp", "umh.v1.acme.pressure"}
+
+		// Pure, broker-free access to the translated redpanda config YAML.
+		// buildUnsBetaSingleInner must delegate to this helper so the
+		// translation is inspectable without dialing a broker.
+		yaml := redpandaConfigYAML(seedBrokers, kafkaTopic, consumerGroup, umhTopics)
+
+		// "connect accepts the parsed config": parse against the forwarder's
+		// re-exported redpanda field set (connect's real schema), not a local
+		// copy. A YAML that connect's schema rejects fails here.
+		spec := service.NewConfigSpec().Fields(redpandaforward.ConfigFields()...)
+		conf, err := spec.ParseYAML(yaml, nil)
+		Expect(err).NotTo(HaveOccurred(), "translated YAML must parse against connect's redpanda field set:\n%s", yaml)
+
+		// Lean-field pass-throughs.
+		gotBrokers, err := conf.FieldStringList("seed_brokers")
+		Expect(err).NotTo(HaveOccurred(), "seed_brokers missing")
+		Expect(gotBrokers).To(Equal(seedBrokers), "seed_brokers must mirror the lean broker list")
+		gotTopics, err := conf.FieldStringList("topics")
+		Expect(err).NotTo(HaveOccurred(), "topics missing")
+		Expect(gotTopics).To(Equal([]string{kafkaTopic}), "topics must mirror the lean kafka_topic")
+		gotGroup, err := conf.FieldString("consumer_group")
+		Expect(err).NotTo(HaveOccurred(), "consumer_group missing")
+		Expect(gotGroup).To(Equal(consumerGroup), "consumer_group must mirror the lean field")
+
+		// String-valued pins: start_offset is a literal pin; the three
+		// fetch byte fields are re-derived from the Go fetch constants in
+		// uns_input_config.go (the same constants uns_beta's render test
+		// uses), so a constant retune updates production and expectation in
+		// lockstep — these pins guard format, not value. They are emitted
+		// AS STRINGS (upstream NewStringField contract).
+		Expect(conf.FieldString("start_offset")).To(Equal("earliest"), "start_offset must be pinned to earliest")
+		Expect(conf.FieldString("fetch_max_bytes")).To(Equal(strconv.FormatFloat(defaultFetchMaxBytes, 'f', -1, 64)), "fetch_max_bytes must mirror defaultFetchMaxBytes")
+		Expect(conf.FieldString("fetch_max_partition_bytes")).To(Equal(strconv.FormatFloat(defaultFetchMaxPartitionBytes, 'f', -1, 64)), "fetch_max_partition_bytes must mirror defaultFetchMaxPartitionBytes")
+		Expect(conf.FieldString("fetch_min_bytes")).To(Equal(strconv.FormatFloat(defaultFetchMinBytes, 'f', -1, 64)), "fetch_min_bytes must mirror defaultFetchMinBytes")
+
+		// Duration-valued pins: fetch_max_wait and conn_idle_timeout re-derive
+		// from the Go fetch/conn constants (guarding format, not value, since
+		// both operands derive from the same constant). commit_period is EMITTED
+		// by the translation as the literal "5s" — pinned defensively, matching
+		// uns_beta's template pin and the auto_replay_nacks treatment, so a
+		// future connect default change cannot silently alter the commit cadence.
+		Expect(conf.FieldDuration("fetch_max_wait")).To(Equal(defaultFetchMaxWaitTime), "fetch_max_wait must mirror defaultFetchMaxWaitTime")
+		Expect(conf.FieldDuration("conn_idle_timeout")).To(Equal(defaultConnIdleTimeout), "conn_idle_timeout must mirror defaultConnIdleTimeout")
+		Expect(conf.FieldDuration("commit_period")).To(Equal(5*time.Second), "commit_period must be pinned to 5s by the translation")
+
+		// auto_replay_nacks pinned true (the ENG-5094 NACK-replay guarantee),
+		// defensively, so a future connect default change cannot silently
+		// disable redelivery.
+		Expect(conf.FieldBool("auto_replay_nacks")).To(BeTrue(), "auto_replay_nacks must be pinned true")
+
+		// key_pattern must equal the Go-side betaKeyFilter combined regex for
+		// the same umh_topics — (?:p1)|(?:p2)|... — reusing the same wrap, not a
+		// raw "|"-join. The wrap prevents a pattern containing '|' from
+		// mis-grouping. Cross-check against newBetaKeyFilter's compiled source
+		// (filter.re.String()) rather than hand-rebuilding the join, so a drift
+		// between this helper's wrap convention and newBetaKeyFilter's fails
+		// here — mirroring the sibling uns_beta render test
+		// (uns_beta_input_test.go: rp["key_pattern"] == filter.re.String()).
+		filter, err := newBetaKeyFilter(umhTopics)
+		Expect(err).NotTo(HaveOccurred(), "test umh_topics must compile into a betaKeyFilter")
+		Expect(conf.FieldString("key_pattern")).To(Equal(filter.re.String()),
+			"key_pattern must equal the Go-side betaKeyFilter combined regex for umh_topics — connect's pre-filter must not drift from the Go keep set")
+	})
+
+	// Direct parity with uns_beta: render uns_beta's actual template for the
+	// same logical inputs and assert the redpanda block is field-by-field
+	// identical to the translation. The constants-based case above proves the
+	// translation is self-consistent with the shared Go constants; this case
+	// proves it matches uns_beta's rendered template, so a template edit that
+	// diverges from the translation (different fetch bytes, a dropped
+	// commit_period pin, a different key_pattern join) fails here rather than
+	// only in the sibling uns_beta render test. renderUnsBetaReader/redpandaOf
+	// are the same helpers uns_beta's own render test uses.
+	It("matches uns_beta's rendered redpanda block field-for-field for the same inputs", func() {
+		seedBrokers := []string{"broker1:9092", "broker2:9092"}
+		kafkaTopic := "umh.messages"
+		consumerGroup := "parity-group"
+		umhTopics := []string{"umh.v1.acme.temp", "umh.v1.acme.pressure"}
+
+		// uns_beta's lean surface takes broker_address as a CSV string; the
+		// template splits/trims/drops empties into seed_brokers. Render it for
+		// the same logical brokers/group/topic/topics.
+		reader := renderUnsBetaReader(fmt.Sprintf(`
+uns_beta:
+  broker_address: %q
+  consumer_group: %q
+  kafka_topic: %q
+  umh_topics: [%s]
+`, strings.Join(seedBrokers, ", "), consumerGroup, kafkaTopic, `"`+strings.Join(umhTopics, `", "`)+`"`))
+		rp := redpandaOf(reader)
+
+		// The translation's parsed config for the same inputs.
+		spec := service.NewConfigSpec().Fields(redpandaforward.ConfigFields()...)
+		conf, err := spec.ParseYAML(redpandaConfigYAML(seedBrokers, kafkaTopic, consumerGroup, umhTopics), nil)
+		Expect(err).NotTo(HaveOccurred(), "translation YAML must parse")
+
+		// List fields: the template renders []any; the parsed conf yields
+		// []string. Coerce and compare both sides to the lean inputs.
+		Expect(stringSlice(rp["seed_brokers"])).To(Equal(seedBrokers), "seed_brokers must match uns_beta's render")
+		gotBrokers, _ := conf.FieldStringList("seed_brokers")
+		Expect(gotBrokers).To(Equal(seedBrokers))
+		Expect(stringSlice(rp["topics"])).To(Equal([]string{kafkaTopic}), "topics must match uns_beta's render")
+		gotTopics, _ := conf.FieldStringList("topics")
+		Expect(gotTopics).To(Equal([]string{kafkaTopic}))
+
+		// Scalar string fields.
+		Expect(rp["consumer_group"]).To(Equal(consumerGroup))
+		Expect(conf.FieldString("consumer_group")).To(Equal(consumerGroup))
+		Expect(rp["start_offset"]).To(Equal("earliest"))
+		Expect(conf.FieldString("start_offset")).To(Equal("earliest"))
+		Expect(rp["fetch_max_bytes"]).To(Equal(strconv.FormatFloat(defaultFetchMaxBytes, 'f', -1, 64)))
+		Expect(conf.FieldString("fetch_max_bytes")).To(Equal(rp["fetch_max_bytes"]))
+		Expect(rp["fetch_max_partition_bytes"]).To(Equal(strconv.FormatFloat(defaultFetchMaxPartitionBytes, 'f', -1, 64)))
+		Expect(conf.FieldString("fetch_max_partition_bytes")).To(Equal(rp["fetch_max_partition_bytes"]))
+		Expect(rp["fetch_min_bytes"]).To(Equal(strconv.FormatFloat(defaultFetchMinBytes, 'f', -1, 64)))
+		Expect(conf.FieldString("fetch_min_bytes")).To(Equal(rp["fetch_min_bytes"]))
+
+		// Duration fields: the template renders the literal string; the parsed
+		// conf yields a time.Duration. Compare via the duration's String() form.
+		Expect(rp["fetch_max_wait"]).To(Equal(defaultFetchMaxWaitTime.String()))
+		fmw, _ := conf.FieldDuration("fetch_max_wait")
+		Expect(fmw.String()).To(Equal(rp["fetch_max_wait"]))
+		Expect(rp["conn_idle_timeout"]).To(Equal(defaultConnIdleTimeout.String()))
+		cit, _ := conf.FieldDuration("conn_idle_timeout")
+		Expect(cit.String()).To(Equal(rp["conn_idle_timeout"]))
+		Expect(rp["commit_period"]).To(Equal("5s"))
+		Expect(conf.FieldDuration("commit_period")).To(Equal(5 * time.Second))
+
+		// Bool + key_pattern. Cross-check the template's key_pattern against the
+		// Go betaKeyFilter compiled source (the canonical join), and the
+		// translation against the template.
+		filter, err := newBetaKeyFilter(umhTopics)
+		Expect(err).NotTo(HaveOccurred(), "test umh_topics must compile into a betaKeyFilter")
+		Expect(rp["auto_replay_nacks"]).To(BeTrue())
+		Expect(conf.FieldBool("auto_replay_nacks")).To(BeTrue())
+		Expect(rp["key_pattern"]).To(Equal(filter.re.String()))
+		Expect(conf.FieldString("key_pattern")).To(Equal(rp["key_pattern"]))
+	})
+})
+
+// stringSlice coerces a rendered YAML list ([]any) to []string for comparison
+// against a parsed conf's FieldStringList. Panics on non-string elements, which
+// is a test-only path for known string lists.
+func stringSlice(v any) []string {
+	in, ok := v.([]any)
+	Expect(ok).To(BeTrue(), "expected a YAML list, got %T", v)
+	out := make([]string, len(in))
+	for i, e := range in {
+		s, ok := e.(string)
+		Expect(ok).To(BeTrue(), "expected string element, got %T", e)
+		out[i] = s
+	}
+	return out
+}


### PR DESCRIPTION
## `uns_beta_single`: single-plugin candidate alongside `uns_beta` (option B, ENG-5105)

### What this is

A second, additive UNS consumer input, `uns_beta_single`, registered alongside the existing `uns_beta` (the template form from #367). Both coexist; nothing in #367 is modified or deleted. The production `uns_beta` name stays with the template form until the comparison is decided.

`uns_beta_single` does in one Go registration what `uns_beta` does in two (a template + a reader): it translates the lean 4-field user surface into a full redpanda config, builds connect's `redpanda` input itself in Go, and applies the umh_topics key filter, ack-gating, and metadata aliasing. The lean surface (`consumer_group` + `umh_topics` required; `broker_address` default `localhost:9092`; `kafka_topic` default `umh.messages`) is identical to `uns_beta` by design, so the two forms are comparable on behavior, not on config.

Note on reuse: `uns_beta_single` does not wrap the existing `newUnsBetaInputFor`/`unsBetaInput`. It reimplements the key filter, the all-filtered self-ack, and the `umh_topic`/`kafka_msg_key` aliasing inline in its own `ReadBatch` loop, because the forwarder returns a `service.BatchInput` (no `ConnectionTest`) rather than the `readBatcher` the wrapper expects. This inline reimplementation is what the parameterized suite checks against `uns_beta`.

### Why two forms exist, and what this tests

`uns_beta` is two registrations because of a Go `internal/` wall: connect's redpanda constructor (`NewFranzReaderToggledFromConfig`) and its field helpers live in `connect/v4/internal/impl/kafka`, unimportable from benthos-umh. The template form routes around it by letting benthos build the redpanda input as a managed child from a parsed config field. This PR tests the alternative: lift the wall with a **forwarder shim** (a small package patched in under `connect/v4/` that can import `internal/impl/kafka`), so a single Go input can construct the redpanda input directly.

The open question this PR exists to answer: is the single-plugin form worth it? It removes the two-registration parity-by-convention, but it pays for that with a compile-time-mandatory patch and coupling to connect's internal `init()` assembly. The decision is deferred until the two forms are compared; this PR does not replace #367.

### How it works

- **Forwarder shim** (`patches/connect-redpanda-forward.patch`): creates `connect/v4/public/components/kafka/redpandaforward/`, exporting `ConfigFields()` (delegates to a new `RedpandaInputConfigFields()` wrapper added to `internal/impl/kafka`, so a structural change in connect propagates through the shim, so no manual mirror can drift) and `NewRedpandaInput(conf, res)` (re-assembles connect's redpanda input `init()`: connection details + consumer opts + the reader + the three wrappers). Explicit-connection-only; the shared-redpanda-client fallback is omitted (unused by this caller, since no benthos-umh caller registers `SharedGlobalRedpandaClientKey`).
- **`uns_beta_single` Go input**: 4 lean fields → redpanda config YAML pinned to the same 12 values `uns_beta`'s template pins → `ParseYAML` → `NewRedpandaInput(conf, res)` with the outer stream's resources → inline filter/ack/alias loop (see reuse note above).
- **`make patch-connect`** now applies both patches (key-filter + forwarder) sequentially, each with its own `git apply --check` drift gate.

### What's proven

- **`redpanda_lag` reaches the outer stream's metrics registry** under Go-side construction (verified at runtime, not just at the source level). The gauge binds to `res.Metrics()` at `franz_reader_ordered.go:534`, regardless of construction path, so the single-plugin form keeps the metrics the two-plugin rationale feared losing.
- **Behavioral parity (parameterized suite)**: 11 behavioral scenarios run against both forms via a plugin-name parameter: delivery, metadata contract, key filter, all-filtered commit, start-from-earliest, mixed-batch NACK redelivery, gapless restart, unreachable broker, NACK capstone, plus the `dropped_keyless` and `filtered_records` counter scenarios. All green for both forms. A behavior fix to either form is checked against the other; drift between them is caught.
- **Translation parity**: all 12 pinned redpanda values reproduced exactly, asserted against the Go fetch constants (not magic strings) and cross-checked against `newBetaKeyFilter`, plus a field-for-field comparison against `uns_beta`'s rendered template.
- **Perf parity**: the E2E drain benchmark runs `select_one` (200k records, 1 kept) against `uns_beta`, `uns_beta_single`, and legacy `uns`. Both `uns_beta` forms land at ~412k allocs/op; the `key_pattern` source pre-filter omits 199,999 of 200,000 records before message construction in both. (The kfake broker can produce noisy high-alloc outliers for `uns_beta` from its eager `FieldInput` kgo client thrashing against the fake broker; the benchmark header warns kfake `uns_beta` numbers are not throughput-trustworthy. The real-broker `BenchmarkE2E_DrainRedpanda` is the throughput comparison of record.)

### How this differs from #367

| | `uns_beta` (#367, template) | `uns_beta_single` (this PR, option B) |
|---|---|---|
| Registrations | Two (template alias + Go reader) | One (Go input) |
| Config translation | Template (YAML, at config-load) | Go (at construction) |
| Inner input construction | Eager (framework `FieldInput` builds the redpanda input at config-load) | Lazy (built in `Connect`) |
| Connect coupling | Public config schema only | Internal `init()` assembly (via shim) |
| Patch | key-filter, perf-only / runtime-optional | key-filter + forwarder, compile-mandatory |
| Parity enforcement | By convention (render tests) | By Go construction + parameterized suite |
| `redpanda_lag` | Reaches outer stream (managed child) | Reaches outer stream (outer `res` passed in); confirmed at runtime |

Both forms deliver identical records, metadata, and redelivery guarantees across the 11 parameterized scenarios. Perf parity is measured, not assumed: the E2E drain benchmark runs `select_one` (200k records, 1 kept) against both, and both land at ~412k allocs/op. The `key_pattern` source pre-filter (the build-time `connect-key-filter.patch`, inherited from #367) omits non-matching records before `service.Message` construction identically in both forms; the plugin-level filter is defense-in-depth. The one known behavioral divergence is the spoofed-keyless counter (below).

### Known gap (documented, deferred)

The parameterized suite found one real divergence: `uns_beta`'s `classifyDrop` is spoof-first (a record with a foreign `kafka_key` header shadowing an empty native key is tallied as `dropped_spoofed_key`), while `uns_beta_single` lacks `hasSpoofHeader` and mis-counts such records as `dropped_keyless`. `uns_beta_single` also does not register `dropped_spoofed_key`. Spoof detection is a tracked, deferred workstream (**ENG-5125**); this PR documents the gap with a `TODO(ENG-5125)` at the divergence point rather than porting the logic separately. ENG-5125 will port `hasSpoofHeader`/`classifyDrop` to the single form (and rework it for both). Narrow exposure (mixed-producer topics with an external `kafka_key` header injector). The `dropped_spoofed_key` counter scenario is left `uns_beta`-only for that reason; the other 11 scenarios are parameterized.

### What this is NOT

- Not replacing #367. #367 stays the likely-ship; this is a comparison candidate.
- Not a clean (patch-free) form. The clean single-plugin form needs an upstream connect re-export of `NewFranzReaderToggledFromConfig` + the field helpers from `public/components/kafka`, filed as a follow-up, not as part of this PR. That re-export retires the **forwarder patch**. The **key-filter patch** retires separately, only if connect upstream adopts a `key_pattern` feature (a different upstream contribution); the two patches retire under different conditions.
- Not user-visible / no changelog. `uns_beta_single` is an internal comparison candidate behind a patched-only build; the changelog waits for the commit that picks between the two forms.
- Not porting spoof detection; deferred to ENG-5125.

### Reviewer attention

The forwarder patch is compile-mandatory for this branch (the unpatched lane doesn't have `uns_beta_single`). Local dev requires `make patch-connect` before `go test`/`go build`. The patched CI lane (`test-uns-patched`, kfake, no docker) is the green signal. The branch is 4 commits behind staging and will need a rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)