### PR TITLE
docs: document engine air-gap context restore on processor outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,17 @@ output:
     key: "${! @umh_topic }"  # Use metadata as key
 ```
 
+### Output context is restored by the engine, not the plugin
+
+`service.NewMessage(nil)` in these plugins was flagged as dropping the SortGroup source tag and the OpenTelemetry trace parent from output messages. It does not. Every processor registered via `service.RegisterBatchProcessor` (all benthos-umh processors) is wrapped at runtime in `v2BatchedToV1Processor` (`internal/component/processor/auto_observed.go`), which saves and restores message contexts around the plugin call:
+
+1. Before the plugin runs, it saves each input part's `context.Context` (`origCtxs`, `auto_observed.go:242`).
+2. After the plugin returns, it restores the saved input context onto every output part (`auto_observed.go:280-294`); fan-out children (`partIdx >= len(inputs)`) fall back to input index 0.
+
+The SortGroup tag and trace parent reach the output regardless of how the plugin builds its messages. `NewMessage(nil)` is safe here, and a plugin-side `msg.Copy()` or `newMsg.WithContext(input.Context())` is a no-op (the wrapper overwrites it). Verified: a `tag_processor` 1→2 fan-out through the full `service.NewStreamBuilder` pipeline resolves `Indexer.IndexOf(output)` to the source index with no plugin-side context handling.
+
+Any context/lineage/ACK-SortGroup claim about these plugins must be verified against the full stream pipeline, not the plugin's `ProcessBatch` in isolation.
+
 ### JavaScript Engine: goja
 
 All JavaScript execution uses **goja engine** (pure Go):

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -376,7 +376,10 @@ func (u *NodeREDJSProcessor) HandleExecutionResult(result goja.Value) (*service.
 		return service.NewMessage(nil), false, fmt.Errorf("function must return a message object or null")
 	}
 
-	// Create new message with returned content
+	// Create new message with returned content.
+	// NewMessage(nil) is safe: the air-gap wrapper restores input context onto
+	// outputs in production, so Copy()/WithContext() is a no-op (see CLAUDE.md
+	// "Output context is restored by the engine, not the plugin").
 	newMsg := service.NewMessage(nil)
 	if payload, exists := returnedMsg["payload"]; exists {
 		newMsg.SetStructured(payload)

--- a/tag_processor_plugin/tag_processor_plugin.go
+++ b/tag_processor_plugin/tag_processor_plugin.go
@@ -474,6 +474,9 @@ To fix: Set required fields (msg.meta.location_path, msg.meta.data_contract, msg
 // constructFinalMessage creates the final message with proper topic and payload structure
 // and filters out internal metadata.
 func (p *TagProcessor) constructFinalMessage(msg *service.Message) (*service.Message, error) {
+	// NewMessage(nil) is safe: the air-gap wrapper restores input context onto
+	// outputs in production, so Copy()/WithContext() is a no-op (see CLAUDE.md
+	// "Output context is restored by the engine, not the plugin").
 	newMsg := service.NewMessage(nil)
 
 	// Clean up metadata values that might stringify to invalid values (e.g., virtual_path = null)
@@ -857,6 +860,10 @@ func (p *TagProcessor) processMessageBatchWithProgram(ctx context.Context, batch
 
 		// Convert results back to Benthos messages
 		for _, resultMsg := range messages {
+			// NewMessage(nil) is safe: the air-gap wrapper restores input
+			// context onto outputs in production, so Copy()/WithContext() is a
+			// no-op (see CLAUDE.md "Output context is restored by the engine,
+			// not the plugin").
 			newMsg := service.NewMessage(nil)
 			// Set metadata from the JS message
 			if meta, ok := resultMsg["meta"].(map[string]interface{}); ok {


### PR DESCRIPTION
## What

Documents that `service.NewMessage(nil)` is safe in the processor plugins (`nodered_js`, `tag_processor`, etc.): the engine already restores the input `context.Context` (SortGroup source tag + OpenTelemetry trace parent) onto every output.

## Why

`NewMessage(nil)` was flagged as dropping the SortGroup tag and trace parent from outputs. On closer inspection it does not: every `RegisterBatchProcessor` plugin is wrapped at runtime in `v2BatchedToV1Processor` (`internal/component/processor/auto_observed.go`), which saves each input part`s context before the plugin runs and restores it onto every output part afterward (`auto_observed.go:280-294`; fan-out children fall back to input index 0). A plugin-side `msg.Copy()` or `newMsg.WithContext(input.Context())` is a no-op, since the wrapper overwrites it.

Verified: a `tag_processor` 1->2 fan-out through the full `service.NewStreamBuilder` pipeline resolves `Indexer.IndexOf(output)` to the source index with no plugin-side context handling.

Documenting this so the question is not re-litigated. Adds a CLAUDE.md section and pointer comments at the three `NewMessage(nil)` emission sites (`nodered_js_plugin.go:380`, `tag_processor_plugin.go:477` and `:860`).

## Scope

No code change. No changelog entry (doc-only).

Refs: ENG-5255 (parent), ENG-5256 (the flagging analysis, closed as not-a-bug), ENG-5240 (fan-out feature, separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)