### PR TITLE
feat(ads): Beckhoff ADS plugin — connectivity (2/6)

### DIFF
--- a/beckhoff_ads_plugin/ads.go
+++ b/beckhoff_ads_plugin/ads.go
@@ -52,7 +52,7 @@ type AdsCommInput struct {
 	client           Client
 	Log              *service.Logger
 	Symbols          []PlcSymbol
-	symbolByName     map[string]*PlcSymbol // configured symbol name → *PlcSymbol, populated in NewAdsCommInput
+	symbolByName     map[string]*PlcSymbol // configured symbol name → *PlcSymbol, populated in initSymbolIndex (Connect)
 	NotificationChan chan *Update
 	TransmissionMode int
 
@@ -217,11 +217,6 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 		mgr.Logger().Warnf("%s", w)
 	}
 
-	symbolByName := make(map[string]*PlcSymbol, len(symbolList))
-	for i := range symbolList {
-		symbolByName[symbolList[i].Name] = &symbolList[i]
-	}
-
 	m := &AdsCommInput{
 		TargetIP:         targetIP,
 		TargetAMS:        targetAMS,
@@ -233,7 +228,6 @@ func NewAdsCommInput(conf *service.ParsedConfig, mgr *service.Resources) (servic
 		MaxDelay:         maxDelay,
 		CycleTime:        cycleTime,
 		Symbols:          symbolList,
-		symbolByName:     symbolByName,
 		Log:              mgr.Logger(),
 		IntervalTime:     intervalTime,
 		RequestTimeout:   requestTimeout,
@@ -259,11 +253,97 @@ func init() {
 	}
 }
 
-// Connect, ReadBatch and Close are stubs; the go-ads adapter (Task 2) fills in
-// connection, read and shutdown behaviour behind the Client seam.
+// sessionConfig builds the library-agnostic connection spec passed to the
+// go-ads adapter.
+func (a *AdsCommInput) sessionConfig() SessionConfig {
+	return SessionConfig{
+		TargetIP:       a.TargetIP,
+		TargetAMS:      a.TargetAMS,
+		HostIP:         a.HostIP,
+		HostAMS:        a.HostAMS,
+		TargetPort:     a.TargetPort,
+		RuntimePort:    a.RuntimePort,
+		HostPort:       a.HostPort,
+		Username:       a.Username,
+		Password:       a.Password,
+		RequestTimeout: a.RequestTimeout,
+	}
+}
 
-func (a *AdsCommInput) Connect(_ context.Context) error {
-	return service.ErrNotConnected
+// targetSummary lists the PLC-side connection parameters for logging.
+func (a *AdsCommInput) targetSummary() string {
+	return fmt.Sprintf(
+		"  target IP:    %s\n"+
+			"  target port:  %d\n"+
+			"  target AMS:   %s\n"+
+			"  runtime port: %d",
+		a.TargetIP, a.TargetPort, a.TargetAMS, a.RuntimePort)
+}
+
+// hostSummary lists our own AMS identity for logging, marking the values that
+// are derived at runtime rather than configured.
+func (a *AdsCommInput) hostSummary() string {
+	hostAMS := a.HostAMS
+	if hostAMS == "auto" {
+		hostAMS = "auto (derived on connect)"
+	}
+	hostPort := fmt.Sprintf("%d", a.HostPort)
+	if a.HostPort == 0 {
+		hostPort = "random"
+	}
+	hostIP := a.HostIP
+	if hostIP == "" {
+		hostIP = "auto-detected"
+	}
+	return fmt.Sprintf(
+		"  host AMS:     %s\n"+
+			"  host port:    %s\n"+
+			"  host IP:      %s",
+		hostAMS, hostPort, hostIP)
+}
+
+// Connect establishes the ADS session, resolves symbol metadata, and (depending
+// on config) loads the full symbol table and registers notifications.
+func (a *AdsCommInput) Connect(ctx context.Context) error {
+	if a.client != nil {
+		return nil
+	}
+
+	c, err := newGoADSClient(ctx, a.sessionConfig(), a.Log)
+	if err != nil {
+		return err
+	}
+	a.client = c
+
+	if err = a.finishConnect(ctx); err != nil {
+		a.client.Close()
+		a.client = nil
+		return err
+	}
+	return nil
+}
+
+// finishConnect drives connect → symbol resolution → (optional) symbol table
+// load → (optional) notification setup; split out so Connect can clean up a.client on failure.
+func (a *AdsCommInput) finishConnect(ctx context.Context) error {
+	a.Log.Infof("Connecting to PLC:\n%s\n%s", a.targetSummary(), a.hostSummary())
+	if err := a.client.Connect(ctx); err != nil {
+		a.Log.Errorf("Connecting to PLC failed:\n%s\n  error:        %v", a.targetSummary(), err)
+		return err
+	}
+	a.Log.Infof("Connecting to PLC succeeded:\n%s", a.targetSummary())
+	a.initSymbolIndex(ctx)
+	if a.LoadSymbols {
+		if err := a.loadSymbolTable(ctx); err != nil {
+			return err
+		}
+	}
+	if a.ReadType == "notification" {
+		if err := a.setupNotifications(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a *AdsCommInput) ReadBatch(_ context.Context) (service.MessageBatch, service.AckFunc, error) {
@@ -271,5 +351,17 @@ func (a *AdsCommInput) ReadBatch(_ context.Context) (service.MessageBatch, servi
 }
 
 func (a *AdsCommInput) Close(_ context.Context) error {
+	if a.client == nil {
+		return nil
+	}
+	a.Log.Infof("Closing connection to PLC:\n%s", a.targetSummary())
+
+	err := a.client.Close()
+	a.client = nil
+	if err != nil {
+		a.Log.Errorf("Closing connection to PLC failed:\n%s\n  error:        %v", a.targetSummary(), err)
+		return err
+	}
+	a.Log.Infof("Closing connection to PLC succeeded:\n%s", a.targetSummary())
 	return nil
 }

--- a/beckhoff_ads_plugin/client_goads.go
+++ b/beckhoff_ads_plugin/client_goads.go
@@ -1,0 +1,210 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beckhoff_ads_plugin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"strconv"
+	"time"
+
+	adsLib "github.com/RuneRoven/go-ads/v2"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// goADSClient is the go-ads adapter — the ONLY file (besides client.go)
+// importing the fork. All WithRoute/NewAMSAddress/type-mapping logic lives here.
+type goADSClient struct {
+	session *adsLib.Session
+}
+
+// containerIPRanges are ranges specific to container networking. Such an address
+// is unreachable from the PLC, which breaks TwinCAT 2; TwinCAT 3 is unaffected.
+var containerIPRanges = []netip.Prefix{
+	netip.MustParsePrefix("172.17.0.0/16"), // Docker default bridge
+	netip.MustParsePrefix("172.18.0.0/15"), // Docker user-defined bridge pool (172.18–172.31)
+	netip.MustParsePrefix("172.20.0.0/14"),
+	netip.MustParsePrefix("172.24.0.0/13"),
+	netip.MustParsePrefix("100.64.0.0/10"), // CGNAT, used by some Kubernetes CNIs
+}
+
+// isLikelyContainerIP reports whether route registration would advertise an IP
+// the PLC cannot reach.
+func isLikelyContainerIP(ip string) bool {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil || !addr.Is4() {
+		return false
+	}
+	for _, r := range containerIPRanges {
+		if r.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveRouteHostIP returns the local IP for the ADS route: the configured
+// hostIP, else the source IP of a TCP dial to the ADS port (same interface).
+func resolveRouteHostIP(ctx context.Context, cfg SessionConfig, log *service.Logger) (string, error) {
+	if cfg.HostIP != "" {
+		return cfg.HostIP, nil
+	}
+	dialer := net.Dialer{Timeout: routeDialTimeout}
+	tcpConn, dialErr := dialer.DialContext(ctx, "tcp4", net.JoinHostPort(cfg.TargetIP, strconv.Itoa(cfg.TargetPort)))
+	if dialErr != nil {
+		// PLC unreachable; fall back to a UDP routing lookup (no packet sent).
+		udpConn, udpErr := net.Dial("udp4", net.JoinHostPort(cfg.TargetIP, adsDiscoveryPort))
+		if udpErr != nil {
+			log.Errorf("Failed to auto-detect local address: %v", dialErr)
+			return "", dialErr
+		}
+		defer udpConn.Close()
+		return udpConn.LocalAddr().(*net.UDPAddr).IP.String(), nil
+	}
+	defer tcpConn.Close()
+	return tcpConn.LocalAddr().(*net.TCPAddr).IP.String(), nil
+}
+
+// buildSessionOptions assembles the go-ads SessionOptions: logger bridge,
+// route registration, local AMS override, and request timeout.
+func buildSessionOptions(ctx context.Context, cfg SessionConfig, log *service.Logger) ([]adsLib.SessionOption, error) {
+	// go-ads verbosity follows the benthos pipeline log level via this bridge;
+	// no global SetDefaultLogger (last-input-wins across multiple ADS inputs).
+	opts := []adsLib.SessionOption{adsLib.WithLogger(slog.New(&benthosLogHandler{logger: log}))}
+
+	if cfg.Username != "" && cfg.Password != "" {
+		hostAddr, err := resolveRouteHostIP(ctx, cfg, log)
+		if err != nil {
+			return nil, err
+		}
+		if isLikelyContainerIP(hostAddr) {
+			log.Warnf("Auto-detected IP %s looks like a container IP, which the PLC cannot reach. "+
+				"TwinCAT 2 routes replies via this address, so reads will time out — set hostIP to the address "+
+				"the PLC can reach this client at. TwinCAT 3 answers on the existing connection and is unaffected.", hostAddr)
+		}
+		routeName := fmt.Sprintf("benthosADS-%s", hostAddr)
+		log.Infof("Route will be registered on PLC %s: name=%s, clientIP=%s", cfg.TargetIP, routeName, hostAddr)
+		opts = append(opts, adsLib.WithRoute(routeName, cfg.Username, cfg.Password), adsLib.WithHostIP(hostAddr))
+	}
+
+	// "auto" (default) lets go-ads derive local AMS from the TCP connection.
+	if cfg.HostAMS != "" && cfg.HostAMS != "auto" {
+		localAMS, err := adsLib.NewAMSAddress(cfg.HostAMS, uint16(cfg.HostPort))
+		if err != nil {
+			log.Errorf("Invalid local AMS %q: %v", cfg.HostAMS, err)
+			return nil, err
+		}
+		opts = append(opts, adsLib.WithLocalAMS(localAMS))
+	}
+	if cfg.RequestTimeout > 0 {
+		opts = append(opts, adsLib.WithRequestTimeout(cfg.RequestTimeout))
+	}
+	return opts, nil
+}
+
+// newGoADSClient builds session options and the go-ads session from
+// SessionConfig. It does not call Connect; the caller drives that.
+func newGoADSClient(ctx context.Context, cfg SessionConfig, log *service.Logger) (Client, error) {
+	opts, err := buildSessionOptions(ctx, cfg, log)
+	if err != nil {
+		return nil, err
+	}
+	targetAMS, err := adsLib.NewAMSAddress(cfg.TargetAMS, uint16(cfg.RuntimePort))
+	if err != nil {
+		log.Errorf("Invalid target AMS %q: %v", cfg.TargetAMS, err)
+		return nil, err
+	}
+	// Background ctx: session lifetime is driven by Close, not the per-call
+	// construction ctx (which would tear the session down on return).
+	sess, err := adsLib.NewSession(context.Background(), adsLib.AMSEndpoint{
+		IP: cfg.TargetIP, Port: cfg.TargetPort, AMS: targetAMS,
+	}, opts...)
+	if err != nil {
+		log.Errorf("Failed to create connection: %v", err)
+		return nil, err
+	}
+	return &goADSClient{session: sess}, nil
+}
+
+func (c *goADSClient) Connect(ctx context.Context) error     { return c.session.Connect(ctx) }
+func (c *goADSClient) Close() error                          { return c.session.Close() }
+func (c *goADSClient) IsClosed() bool                        { return c.session.IsClosed() }
+func (c *goADSClient) LoadSymbols(ctx context.Context) error { return c.session.LoadSymbols(ctx) }
+
+func (c *goADSClient) GetSymbol(ctx context.Context, name string) (SymbolInfo, error) {
+	v, err := c.session.GetSymbol(ctx, name)
+	if err != nil {
+		return SymbolInfo{}, err
+	}
+	return SymbolInfo{DataType: v.DataType, BaseType: v.BaseTypeName(), Length: v.Length}, nil
+}
+
+func (c *goADSClient) ReadMultipleSymbols(ctx context.Context, names []string) (map[string]string, error) {
+	return c.session.ReadMultipleSymbols(ctx, names)
+}
+
+func (c *goADSClient) ReadFromSymbol(ctx context.Context, name string) (string, error) {
+	return c.session.ReadFromSymbol(ctx, name)
+}
+
+// toTransMode maps the plugin's plain transmission-mode code to the go-ads
+// protocol constant (see transmissionModeValue in ads.go for the code table).
+func toTransMode(code int) adsLib.TransMode {
+	switch code {
+	case 1:
+		return adsLib.TransModeServerCycle
+	case 2:
+		return adsLib.TransModeServerOnChange2
+	case 3:
+		return adsLib.TransModeServerCycle2
+	default:
+		return adsLib.TransModeServerOnChange
+	}
+}
+
+func (c *goADSClient) AddNotifications(ctx context.Context, cfgs []NotifyConfig, ch chan *adsLib.Update) ([]NotifyResult, error) {
+	adsCfgs := make([]adsLib.NotificationConfig, len(cfgs))
+	for i, cfg := range cfgs {
+		adsCfgs[i] = adsLib.NotificationConfig{
+			SymbolName:       cfg.SymbolName,
+			MaxDelay:         cfg.MaxDelay,
+			CycleTime:        cfg.CycleTime,
+			TransmissionMode: toTransMode(cfg.TransmissionMode),
+		}
+	}
+	results, err := c.session.AddSymbolNotifications(ctx, adsCfgs, ch)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]NotifyResult, len(results))
+	for i, r := range results {
+		out[i] = NotifyResult{
+			SymbolName: cfgs[i].SymbolName,
+			Registered: r.Skipped == nil && r.Error == adsLib.ReturnCodeNoErrors,
+			Skipped:    r.Skipped != nil,
+			Code:       uint32(r.Error),
+		}
+	}
+	return out, nil
+}
+
+// Channel accessors — the one deliberate *adsLib.Update leak. go-ads Update.Value
+// is already a decoded string (see the Client value contract).
+func sampleName(u *adsLib.Update) string    { return u.Variable }
+func sampleValue(u *adsLib.Update) string   { return u.Value }
+func sampleTime(u *adsLib.Update) time.Time { return u.TimeStamp }

--- a/beckhoff_ads_plugin/client_goads.go
+++ b/beckhoff_ads_plugin/client_goads.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/netip"
 	"strconv"
 	"time"
 
@@ -31,31 +30,6 @@ import (
 // importing the fork. All WithRoute/NewAMSAddress/type-mapping logic lives here.
 type goADSClient struct {
 	session *adsLib.Session
-}
-
-// containerIPRanges are ranges specific to container networking. Such an address
-// is unreachable from the PLC, which breaks TwinCAT 2; TwinCAT 3 is unaffected.
-var containerIPRanges = []netip.Prefix{
-	netip.MustParsePrefix("172.17.0.0/16"), // Docker default bridge
-	netip.MustParsePrefix("172.18.0.0/15"), // Docker user-defined bridge pool (172.18–172.31)
-	netip.MustParsePrefix("172.20.0.0/14"),
-	netip.MustParsePrefix("172.24.0.0/13"),
-	netip.MustParsePrefix("100.64.0.0/10"), // CGNAT, used by some Kubernetes CNIs
-}
-
-// isLikelyContainerIP reports whether route registration would advertise an IP
-// the PLC cannot reach.
-func isLikelyContainerIP(ip string) bool {
-	addr, err := netip.ParseAddr(ip)
-	if err != nil || !addr.Is4() {
-		return false
-	}
-	for _, r := range containerIPRanges {
-		if r.Contains(addr) {
-			return true
-		}
-	}
-	return false
 }
 
 // resolveRouteHostIP returns the local IP for the ADS route: the configured
@@ -91,11 +65,6 @@ func buildSessionOptions(ctx context.Context, cfg SessionConfig, log *service.Lo
 		hostAddr, err := resolveRouteHostIP(ctx, cfg, log)
 		if err != nil {
 			return nil, err
-		}
-		if isLikelyContainerIP(hostAddr) {
-			log.Warnf("Auto-detected IP %s looks like a container IP, which the PLC cannot reach. "+
-				"TwinCAT 2 routes replies via this address, so reads will time out — set hostIP to the address "+
-				"the PLC can reach this client at. TwinCAT 3 answers on the existing connection and is unaffected.", hostAddr)
 		}
 		routeName := fmt.Sprintf("benthosADS-%s", hostAddr)
 		log.Infof("Route will be registered on PLC %s: name=%s, clientIP=%s", cfg.TargetIP, routeName, hostAddr)

--- a/beckhoff_ads_plugin/connect.go
+++ b/beckhoff_ads_plugin/connect.go
@@ -1,0 +1,142 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beckhoff_ads_plugin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// initSymbolIndex builds the lower-cased symbol lookup and resolves each
+// symbol's DataType/BaseType/Size via the PLC symbol table.
+func (a *AdsCommInput) initSymbolIndex(ctx context.Context) {
+	a.symbolByName = make(map[string]*PlcSymbol, len(a.Symbols))
+	for i := range a.Symbols {
+		sym := &a.Symbols[i]
+		a.symbolByName[strings.ToLower(sym.Name)] = sym
+		info, err := a.client.GetSymbol(ctx, sym.Name)
+		if err != nil {
+			a.Log.Warnf("Failed to resolve metadata for ADS symbol %q: %v", sym.Name, err)
+			continue
+		}
+		sym.DataType = info.DataType
+		sym.BaseType = info.BaseType
+		sym.Size = info.Length
+	}
+}
+
+// loadSymbolTable downloads the full symbol and datatype table from the PLC;
+// required for struct/array symbols.
+func (a *AdsCommInput) loadSymbolTable(ctx context.Context) error {
+	a.Log.Infof("Loading symbol and datatype table from PLC")
+	if err := a.client.LoadSymbols(ctx); err != nil {
+		a.Log.Errorf("Loading symbol and datatype table from PLC failed: %v", err)
+		return err
+	}
+	a.Log.Infof("Loading symbol and datatype table from PLC succeeded")
+	return nil
+}
+
+// setupNotifications registers batch notifications and waits for an initial
+// sample from each registered symbol.
+func (a *AdsCommInput) setupNotifications(ctx context.Context) error {
+	cfgs := make([]NotifyConfig, len(a.Symbols))
+	for i, sym := range a.Symbols {
+		cfgs[i] = NotifyConfig{
+			SymbolName:       sym.Name,
+			MaxDelay:         sym.MaxDelay,
+			CycleTime:        sym.CycleTime,
+			TransmissionMode: a.TransmissionMode,
+		}
+	}
+
+	// Connect() already ensures session is stable; no retry needed here.
+	// If this fails, return error and let Benthos retry Connect().
+	a.Log.Infof("Registering notifications for %d symbols", len(cfgs))
+	results, err := a.client.AddNotifications(ctx, cfgs, a.NotificationChan)
+	if err != nil {
+		a.Log.Errorf("Registering notifications for %d symbols failed: %v", len(cfgs), err)
+		return err
+	}
+
+	// AddNotifications returns nil errors even when all symbols fail to
+	// resolve (e.g. PLC not yet ready); detect that here so Benthos retries Connect().
+	registered := 0
+	var failed []NotifyResult
+	for _, r := range results {
+		if r.Registered {
+			registered++
+			continue
+		}
+		failed = append(failed, r)
+	}
+	if registered == 0 && len(cfgs) > 0 {
+		return fmt.Errorf("no symbols registered for notifications (%d symbols all failed to resolve)", len(cfgs))
+	}
+	for _, r := range failed {
+		if r.Skipped {
+			a.Log.Warnf("Notification symbol %q skipped (check symbol name)", r.SymbolName)
+			continue
+		}
+		a.Log.Warnf("Notification symbol %q rejected by PLC: ADS error 0x%X", r.SymbolName, r.Code)
+	}
+	a.Log.Infof("Registering notifications succeeded for %d/%d symbols", registered, len(cfgs))
+
+	return a.waitForInitialSamples(ctx, results)
+}
+
+// waitForInitialSamples buffers the initial sample from each registered symbol
+// into pendingInitial (readiness gate); the first ReadBatch flushes them.
+// initialSampleTimeout bounds the wait for first samples. The PLC may hold a
+// notification for up to cycleTime + maxDelay, so the wait has to exceed the
+// slowest configured symbol or it would expire before delivery is even due.
+func (a *AdsCommInput) initialSampleTimeout() time.Duration {
+	timeout := initialSampleWait
+	for _, sym := range a.Symbols {
+		if d := sym.CycleTime + sym.MaxDelay + initialSampleWait; d > timeout {
+			timeout = d
+		}
+	}
+	return timeout
+}
+
+func (a *AdsCommInput) waitForInitialSamples(ctx context.Context, results []NotifyResult) error {
+	a.pendingInitial = nil
+	needed := make(map[string]bool, len(results))
+	for _, r := range results {
+		if r.Registered {
+			needed[strings.ToLower(r.SymbolName)] = true
+		}
+	}
+	initialCtx, initialCancel := context.WithTimeout(context.Background(), a.initialSampleTimeout())
+	defer initialCancel()
+	for len(needed) > 0 {
+		select {
+		case update := <-a.NotificationChan:
+			if update != nil {
+				a.pendingInitial = append(a.pendingInitial, update)
+				delete(needed, strings.ToLower(sampleName(update)))
+			}
+		case <-initialCtx.Done():
+			a.Log.Warnf("Timed out waiting for initial samples; %d symbols not yet received: %v", len(needed), needed)
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}

--- a/beckhoff_ads_plugin/logging.go
+++ b/beckhoff_ads_plugin/logging.go
@@ -1,0 +1,69 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beckhoff_ads_plugin
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+// benthosLogHandler is a slog.Handler bridging go-ads v2 log records to a
+// Benthos service.Logger; trace records are suppressed, verbosity follows the benthos log level.
+type benthosLogHandler struct {
+	logger *service.Logger
+	attrs  []slog.Attr
+}
+
+func (h *benthosLogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	// Suppress trace (LevelTrace = -8); forward debug and above to benthos,
+	// which then applies its own configured level filter.
+	return level >= slog.LevelDebug
+}
+
+func (h *benthosLogHandler) Handle(_ context.Context, r slog.Record) error {
+	var kvs []any
+	for _, a := range h.attrs {
+		kvs = append(kvs, a.Key, a.Value.Any())
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		kvs = append(kvs, a.Key, a.Value.Any())
+		return true
+	})
+
+	l := h.logger
+	if len(kvs) > 0 {
+		l = l.With(kvs...)
+	}
+
+	switch {
+	case r.Level >= slog.LevelError:
+		l.Errorf("%s", r.Message)
+	case r.Level >= slog.LevelWarn:
+		l.Warnf("%s", r.Message)
+	case r.Level >= slog.LevelInfo:
+		l.Infof("%s", r.Message)
+	default:
+		l.Debugf("%s", r.Message)
+	}
+	return nil
+}
+
+func (h *benthosLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &benthosLogHandler{logger: h.logger, attrs: append(h.attrs, attrs...)}
+}
+
+func (h *benthosLogHandler) WithGroup(_ string) slog.Handler { return h }


### PR DESCRIPTION
Connect, route creation, reconnect, Close. Adds the go-ads→benthos slog bridge (`benthosLogHandler`): trace suppressed, severities mapped, verbosity governed solely by the pipeline log level (no global `SetDefaultLogger`). Port fix: host-IP auto-detect TCP dial follows `targetPort` (UDP discovery stays 48899).

---
Part of the ENG-4538 Stage-1 stack (re-cut of the old #350–#354 into the 6 ticket buckets). **Merge as one batch, bottom-up (1→6).** logLevel config removed (ADS verbosity now follows the pipeline log level); connect auto-detect dial follows targetPort. CI for the unit tests is deferred to the next stage.