### PR TITLE
feat(ads): Beckhoff ADS plugin — parsing (4/6)

### DIFF
--- a/beckhoff_ads_plugin/parse.go
+++ b/beckhoff_ads_plugin/parse.go
@@ -1,0 +1,62 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beckhoff_ads_plugin
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// tagKind classifies how a decoded value is emitted, matching the opcua/modbus
+// convention: numbers/bools go unquoted on the wire, strings are JSON-quoted.
+type tagKind int
+
+const (
+	tagNumber tagKind = iota
+	tagBool
+	tagString
+)
+
+// classifyBaseType maps an ADS base/primitive type to its wire kind. go-ads has
+// already decoded the binary value; this only decides number vs bool vs string.
+func classifyBaseType(bt string) tagKind {
+	switch strings.ToUpper(strings.TrimSpace(bt)) {
+	case "BOOL":
+		return tagBool
+	case "SINT", "INT", "DINT", "LINT", "USINT", "BYTE", "UINT", "WORD",
+		"UDINT", "DWORD", "ULINT", "LWORD", "REAL", "LREAL":
+		return tagNumber
+	default: // STRING/WSTRING/TIME/TOD/DATE/DT/unknown
+		return tagString
+	}
+}
+
+// adsValueBytes turns a go-ads-decoded string into payload bytes plus a tag-type hint;
+// string-like values are JSON-quoted so a numeric-looking string isn't reparsed as a number.
+func adsValueBytes(typ string, decoded string) ([]byte, string) {
+	switch classifyBaseType(typ) {
+	case tagNumber:
+		return []byte(decoded), "number"
+	case tagBool:
+		return []byte(decoded), "bool"
+	default:
+		b, err := json.Marshal(decoded)
+		if err != nil {
+			b = []byte(strconv.Quote(decoded))
+		}
+		return b, "string"
+	}
+}

--- a/beckhoff_ads_plugin/read.go
+++ b/beckhoff_ads_plugin/read.go
@@ -39,10 +39,16 @@ func (a *AdsCommInput) closeHandler() {
 	}
 }
 
-// newSymbolMessage is the single message-build site: payload is the raw value
-// (pre-parse.go typing), metadata carries symbol/type/size/timestamp.
+// newSymbolMessage is the single message-build site: payload is typed via parse.go
+// (base type preferred, data type fallback); metadata carries symbol/type/size/timestamp.
 func (a *AdsCommInput) newSymbolMessage(sym *PlcSymbol, value string, ts time.Time) *service.Message {
-	msg := service.NewMessage([]byte(value))
+	typeName := sym.BaseType
+	if typeName == "" {
+		typeName = sym.DataType
+	}
+	payload, tagType := adsValueBytes(typeName, value)
+	msg := service.NewMessage(payload)
+	msg.MetaSet("tag_type", tagType)
 	msg.MetaSet("symbol_name", sanitize(sym.Name))
 	if sym.DataType != "" {
 		msg.MetaSet("data_type", sym.DataType)
@@ -161,6 +167,15 @@ func (a *AdsCommInput) ReadBatchPull(ctx context.Context) (service.MessageBatch,
 		val, ok := values[a.Symbols[i].Name]
 		if !ok {
 			continue
+		}
+		// Symbol type unresolved at connect (e.g. PLC not ready yet): retry here
+		// so it gets typed on a later poll instead of staying string-typed forever.
+		if a.Symbols[i].BaseType == "" && a.Symbols[i].DataType == "" {
+			if info, err := a.client.GetSymbol(ctx, a.Symbols[i].Name); err == nil {
+				a.Symbols[i].DataType = info.DataType
+				a.Symbols[i].BaseType = info.BaseType
+				a.Symbols[i].Size = info.Length
+			}
 		}
 		msgs = append(msgs, a.newSymbolMessage(&a.Symbols[i], val, now))
 	}


### PR DESCRIPTION
Type conversion / metadata (BOOL, INT, REAL, STRING, ARRAY): `data_type`/`base_type`/`data_size`, symbol-cache population, and the individual-read fallback.

---
Part of the ENG-4538 Stage-1 stack (re-cut of the old #350–#354 into the 6 ticket buckets). **Merge as one batch, bottom-up (1→6).** logLevel config removed (ADS verbosity now follows the pipeline log level); connect auto-detect dial follows targetPort. CI for the unit tests is deferred to the next stage.