### PR TITLE
fix: schema validation error is misleading, now checks on datatype

### DIFF
--- a/.changelog/unreleased/fixes-20260713-115151.yaml
+++ b/.changelog/unreleased/fixes-20260713-115151.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: UNS schema validation now reports a clear datatype mismatch (e.g. sent timeseries-number, tag registered as timeseries-string) instead of a confusing error that listed the tag as both valid and invalid (ENG-5347)
+time: 2026-07-13T11:51:51.968926+02:00

--- a/uns_plugin/schema_validation/redpanda_integration_test.go
+++ b/uns_plugin/schema_validation/redpanda_integration_test.go
@@ -706,12 +706,14 @@ var _ = Describe("Real Redpanda Integration Tests", Ordered, Label("redpanda"), 
 			Expect(result.SchemaCheckPassed).To(BeTrue())
 			Expect(result.ContractName).To(Equal("_pump_data"))
 
-			// Test that number values fail on string-only virtual paths
+			// Test that number values fail on string-only virtual paths with a clear datatype-mismatch message.
 			numberPayload := []byte(`{"timestamp_ms": 1719859200000, "value": 12345}`)
 			result = validator.Validate(serialTopic, numberPayload)
 			Expect(result.SchemaCheckPassed).To(BeFalse())
 			Expect(result.Error).To(HaveOccurred())
-			Expect(result.Error.Error()).To(ContainSubstring("schema validation failed"))
+			Expect(result.Error.Error()).To(ContainSubstring("datatype mismatch"))
+			Expect(result.Error.Error()).To(ContainSubstring("want timeseries-string"))
+			Expect(result.Error.Error()).To(ContainSubstring("got timeseries-number"))
 		})
 	})
 

--- a/uns_plugin/schema_validation/validator.go
+++ b/uns_plugin/schema_validation/validator.go
@@ -326,6 +326,21 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 		v.debugf("Validator.Validate: Schema validation failed for subject '%s': %s", subjectName, strings.Join(validationErrors, "; "))
 	}
 
+	// For existing tag, but a different type we want a datatype-mismatch error here
+	if lastError != nil {
+		mismatch := v.datatypeMismatchError(schemas, version, contractName, virtualPath, classifyPayloadType(payload))
+		if mismatch != nil {
+			v.debugf("Validator.Validate: datatype mismatch for '%s': %v", virtualPath, mismatch)
+			return &ValidationResult{
+				SchemaCheckPassed:   false,
+				SchemaCheckBypassed: false,
+				ContractName:        contractName,
+				ContractVersion:     version,
+				Error:               mismatch,
+			}
+		}
+	}
+
 	// None of the schemas matched
 	v.debugf("Validator.Validate: FAILED! No schemas matched for contract '%s' version %d. Last error: %v", contractName, version, lastError)
 	return &ValidationResult{
@@ -719,6 +734,107 @@ func (v *Validator) evictOldestEntries() {
 	}
 }
 
+// virtualPathInfo for mismatch-check e.g. timeseries-number vs timeseries-string
+type virtualPathInfo struct {
+	path       string
+	schemaType string
+}
+
+// schemaBytesFor prefers the locally cached schema and falls back to a registry fetch.
+func (v *Validator) schemaBytesFor(schema *Schema, subjectName string, version uint64) []byte {
+	local := schema.GetRawSchemaBytes(version)
+	if local != nil {
+		return local
+	}
+
+	fetched, _, _ := v.fetchLatestSchemaFromRegistry(subjectName)
+	return fetched
+}
+
+// Used to flatten a tag into one (path, datatype) list.
+func (v *Validator) collectValidPaths(schemas map[string]*Schema, version uint64) []virtualPathInfo {
+	var allValidPaths []virtualPathInfo
+
+	for currentSubjectName, schema := range schemas {
+		if schema == nil {
+			continue
+		}
+
+		schemaBytes := v.schemaBytesFor(schema, currentSubjectName, version)
+		if schemaBytes == nil {
+			continue
+		}
+
+		validPaths := extractValidVirtualPaths(schemaBytes)
+		if len(validPaths) == 0 {
+			continue
+		}
+
+		schemaType := extractSchemaTypeFromSubject(currentSubjectName)
+		for _, path := range validPaths {
+			allValidPaths = append(allValidPaths, virtualPathInfo{path: path, schemaType: schemaType})
+		}
+	}
+
+	return allValidPaths
+}
+
+// classifyPayloadType names the datatype actually sent, so a mismatch can report got-vs-want.
+func classifyPayloadType(payload []byte) string {
+	var fields struct {
+		Value json.RawMessage `json:"value"`
+	}
+	err := json.Unmarshal(payload, &fields)
+	if err != nil || len(fields.Value) == 0 {
+		return ""
+	}
+
+	var value any
+	err = json.Unmarshal(fields.Value, &value)
+	if err != nil {
+		return ""
+	}
+
+	switch value.(type) {
+	case bool:
+		return "timeseries-boolean"
+	case float64:
+		return "timeseries-number"
+	default:
+		return "timeseries-string"
+	}
+}
+
+// datatypeMismatchError replaces the confusing "path is both valid and invalid" error with a clear got-vs-want line.
+func (v *Validator) datatypeMismatchError(schemas map[string]*Schema, version uint64, contractName string, virtualPath string, payloadType string) error {
+	if payloadType == "" {
+		return nil
+	}
+
+	var registered []string
+	seen := map[string]bool{}
+	for _, info := range v.collectValidPaths(schemas, version) {
+		if info.path != virtualPath {
+			continue
+		}
+		if info.schemaType == payloadType {
+			return nil
+		}
+		if !seen[info.schemaType] {
+			seen[info.schemaType] = true
+			registered = append(registered, info.schemaType)
+		}
+	}
+
+	if len(registered) == 0 {
+		return nil
+	}
+
+	sort.Strings(registered)
+	return fmt.Errorf("datatype mismatch for '%s' in %s_v%d: want %s, got %s",
+		virtualPath, contractName, version, strings.Join(registered, ", "), payloadType)
+}
+
 // extractValidVirtualPaths extracts valid virtual_path enum values from a JSON schema
 func extractValidVirtualPaths(schemaBytes []byte) []string {
 	var schema map[string]interface{}
@@ -753,44 +869,7 @@ func (v *Validator) enhanceVirtualPathError(originalError error, _ string, schem
 
 	// Check if the error is about virtual_path validation
 	if strings.Contains(errorMsg, "virtual_path") && (strings.Contains(errorMsg, "does not match") || strings.Contains(errorMsg, "do not match")) {
-		// Collect all valid virtual_path values from all schemas with their types
-		type virtualPathInfo struct {
-			path       string
-			schemaType string
-		}
-
-		var allValidPaths []virtualPathInfo
-
-		// Extract virtual_path values from all schemas
-		for currentSubjectName, schema := range schemas {
-			if schema == nil {
-				continue
-			}
-
-			var schemaBytes []byte
-			// First try to get schema bytes from the locally stored schema
-			if rawSchema := schema.GetRawSchemaBytes(version); rawSchema != nil {
-				schemaBytes = rawSchema
-			} else {
-				// If no local schema bytes, try to fetch from registry
-				schemaBytes, _, _ = v.fetchLatestSchemaFromRegistry(currentSubjectName)
-			}
-
-			if schemaBytes != nil {
-				validPaths := extractValidVirtualPaths(schemaBytes)
-				if len(validPaths) > 0 {
-					// Extract schema type from subject name (e.g., "timeseries-number" from "_sensor_data_v1-timeseries-number")
-					schemaType := extractSchemaTypeFromSubject(currentSubjectName)
-
-					for _, path := range validPaths {
-						allValidPaths = append(allValidPaths, virtualPathInfo{
-							path:       path,
-							schemaType: schemaType,
-						})
-					}
-				}
-			}
-		}
+		allValidPaths := v.collectValidPaths(schemas, version)
 
 		if len(allValidPaths) > 0 {
 			// Sort alphabetically by path name

--- a/uns_plugin/schema_validation/validator_test.go
+++ b/uns_plugin/schema_validation/validator_test.go
@@ -616,7 +616,7 @@ var _ = Describe("Validator", func() {
 		It("should validate against the correct schema based on payload type", func() {
 			// Load multiple schemas for the same contract+version
 			schemas := map[string][]byte{
-				"_pump_data_v1_timeseries-number": []byte(`{
+				"_pump_data_v1-timeseries-number": []byte(`{
 					"type": "object",
 					"properties": {
 						"virtual_path": {
@@ -636,7 +636,7 @@ var _ = Describe("Validator", func() {
 					"required": ["virtual_path", "fields"],
 					"additionalProperties": false
 				}`),
-				"_pump_data_v1_timeseries-string": []byte(`{
+				"_pump_data_v1-timeseries-string": []byte(`{
 					"type": "object",
 					"properties": {
 						"virtual_path": {
@@ -695,12 +695,14 @@ var _ = Describe("Validator", func() {
 			Expect(result.Error).To(HaveOccurred())
 			Expect(result.Error.Error()).To(ContainSubstring("schema validation failed"))
 
-			// Test wrong data type for number field (should fail)
+			// Test wrong data type for number field: a string sent to a number-typed tag is a datatype mismatch, not an invalid path.
 			result = validator.Validate(numberTopic, stringPayload)
 			Expect(result.SchemaCheckPassed).To(BeFalse())
 			Expect(result.SchemaCheckBypassed).To(BeFalse())
 			Expect(result.Error).To(HaveOccurred())
-			Expect(result.Error.Error()).To(ContainSubstring("schema validation failed"))
+			Expect(result.Error.Error()).To(ContainSubstring("datatype mismatch"))
+			Expect(result.Error.Error()).To(ContainSubstring("want timeseries-number"))
+			Expect(result.Error.Error()).To(ContainSubstring("got timeseries-string"))
 		})
 	})
 
@@ -974,6 +976,61 @@ var _ = Describe("Validator", func() {
 			errorMsg := result.Error.Error()
 			Expect(errorMsg).To(ContainSubstring("Valid virtual_paths is: [temperature (timeseries-number)]"))
 			Expect(errorMsg).To(ContainSubstring("Your virtual_path is: invalid_path"))
+		})
+
+		It("should report a datatype mismatch when the tag exists only under a different type", func() {
+			// Test.Temperature is registered as timeseries-string; sending a number must be reported as a
+			// datatype mismatch, not as an invalid virtual_path that is simultaneously listed as valid (ENG-5347).
+			schemas := map[string][]byte{
+				"_example_contract_v1-timeseries-string": []byte(`{
+					"type": "object",
+					"properties": {
+						"virtual_path": {"type": "string", "enum": ["Test.Temperature", "Test.Level"]},
+						"fields": {
+							"type": "object",
+							"properties": {"timestamp_ms": {"type": "number"}, "value": {"type": "string"}},
+							"required": ["timestamp_ms", "value"],
+							"additionalProperties": false
+						}
+					},
+					"required": ["virtual_path", "fields"],
+					"additionalProperties": false
+				}`),
+				"_example_contract_v1-timeseries-boolean": []byte(`{
+					"type": "object",
+					"properties": {
+						"virtual_path": {"type": "string", "enum": ["Test.Active"]},
+						"fields": {
+							"type": "object",
+							"properties": {"timestamp_ms": {"type": "number"}, "value": {"type": "boolean"}},
+							"required": ["timestamp_ms", "value"],
+							"additionalProperties": false
+						}
+					},
+					"required": ["virtual_path", "fields"],
+					"additionalProperties": false
+				}`),
+			}
+
+			err := validator.LoadSchemas("_example_contract", 1, schemas)
+			Expect(err).ToNot(HaveOccurred())
+
+			unsTopic, err := topic.NewUnsTopic("umh.v1.enterprise.site.area._example_contract_v1.Test.Temperature")
+			Expect(err).ToNot(HaveOccurred())
+
+			payload := []byte(`{"timestamp_ms": 1719859200000, "value": 25.5}`)
+
+			result := validator.Validate(unsTopic, payload)
+			Expect(result.SchemaCheckPassed).To(BeFalse())
+			Expect(result.SchemaCheckBypassed).To(BeFalse())
+			Expect(result.Error).To(HaveOccurred())
+
+			errorMsg := result.Error.Error()
+			Expect(errorMsg).To(ContainSubstring("Test.Temperature"))
+			Expect(errorMsg).To(ContainSubstring("timeseries-number"))
+			Expect(errorMsg).To(ContainSubstring("timeseries-string"))
+			Expect(errorMsg).To(ContainSubstring("datatype mismatch"))
+			Expect(errorMsg).ToNot(ContainSubstring("Valid virtual_paths"))
 		})
 	})
 })

--- a/uns_plugin/uns_output.go
+++ b/uns_plugin/uns_output.go
@@ -366,23 +366,20 @@ func (o *unsOutput) extractHeaders(msg *service.Message) (map[string][]byte, err
 
 // validateAndEnrichMessage validates the message against the schema and enriches it with contract metadata
 func (o *unsOutput) validateAndEnrichMessage(msg *service.Message, unsTopic *topic.UnsTopic, msgAsBytes []byte, messageIndex int) error {
-	// Validate the payload against the schema
-	validationResult := o.validator.Validate(unsTopic, msgAsBytes)
-	if !validationResult.SchemaCheckPassed && !validationResult.SchemaCheckBypassed {
-		return fmt.Errorf("schema validation failed for message %d with topic '%s': %w. Please check your payload format and ensure it matches the registered schema",
-			messageIndex, unsTopic.String(), validationResult.Error)
+	result := o.validator.Validate(unsTopic, msgAsBytes)
+
+	if !result.SchemaCheckPassed && !result.SchemaCheckBypassed {
+		return fmt.Errorf("message %d (topic '%s'): %w", messageIndex, unsTopic.String(), result.Error)
 	}
 
-	if validationResult.SchemaCheckPassed {
-		// Add the contract name and version to the headers
-		msg.MetaSet("data_contract_name", validationResult.ContractName)
-		msg.MetaSet("data_contract_version", strconv.FormatUint(validationResult.ContractVersion, 10))
-	} else if validationResult.SchemaCheckBypassed {
-		// Add bypass information if validation was bypassed
+	if result.SchemaCheckBypassed {
 		msg.MetaSet("data_contract_bypassed", "true")
-		msg.MetaSet("data_contract_bypass_reason", validationResult.BypassReason)
+		msg.MetaSet("data_contract_bypass_reason", result.BypassReason)
+		return nil
 	}
 
+	msg.MetaSet("data_contract_name", result.ContractName)
+	msg.MetaSet("data_contract_version", strconv.FormatUint(result.ContractVersion, 10))
 	return nil
 }
 


### PR DESCRIPTION
# Description

Whenever the user has set up a datamodel `typevalidation_v1` with e.g.:

```yaml
count:
    _payloadshape: timeseries-number
```

If he then wants to write a string into e.g. `enterprise.line.site._typevalidation_v1.count` he gets no clear guidance by the errormessage, as you could see from the ticket.
It simply lists the available tags and states that the `virtual_path` is wrong.

Therefore we want and introduce here a type-mismatch-error message, which clearly guides for this example the user to read something like: `want: timeseries-number` `got: timeseries-string`. 
With this one doesn't have to think about each individual tag, as the list of tags that get printed back from the original error-messages grows whenever the datamodel grows.

This PR introduces a clear type-mismatch-error-message.

This is tested within the [datacontract-skip-PR](https://github.com/united-manufacturing-hub/united-manufacturing-hub/pull/2642) and looks like this now:

<img width="535" height="138" alt="grafik" src="https://github.com/user-attachments/assets/b1f36c64-c69f-4efb-9e89-513fd4c0770c" />


Fixes ENG-5319