### PR TITLE
fix(ci): test now run if any changed file matches ALL filter rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         id: filter
         with:
           initial-fetch-depth: 30
+          predicate-quantifier: every
           filters: |
             opcua:
               - 'opcua_plugin/**'


### PR DESCRIPTION
# Description

I noticed that some tests still ran whenever nothing in the corresponding plugin changed. The reason for this was `predicate-quantifier` being by default `some`. Means If any cases matches at least one rule.

We want to put it there that if any cases match all rules, as in the past the rule for "markdown was not edited" matched the rule. So if i edited ANY file in the repo the case came true that e.g. opcua didn't have any markdown-edits, therefore it was set to true.