### PR TITLE
fix(sparkplug): use per-metric timestamp for spb_timestamp (ENG-5341)

### DIFF
--- a/.changelog/unreleased/fixes-20260714-165424.yaml
+++ b/.changelog/unreleased/fixes-20260714-165424.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: Sparkplug B input derives spb_timestamp from each metric's own timestamp when present, falling back to the payload timestamp; multi-metric NDATA/DDATA no longer collapse to one timestamp (ENG-5341)
+time: 2026-07-14T16:54:24.582426+02:00

--- a/docs/input/sparkplug-b-input.md
+++ b/docs/input/sparkplug-b-input.md
@@ -479,7 +479,7 @@ These fields provide additional Sparkplug context and are primarily for debuggin
 * `spb_device`: Same as `spb_device_id` (alternative field name)
 * `spb_sequence`: The sequence number of the Sparkplug message
 * `spb_bdseq`: The birth-death sequence number of the session
-* `spb_timestamp`: The timestamp (in epoch ms) provided with the metric
+* `spb_timestamp`: The timestamp (in epoch ms) of the metric. The per-metric timestamp is used when present, falling back to the payload-level timestamp otherwise. This preserves each sample's own capture time — important for buffered or historical metrics that share one payload but were sampled at different moments.
 * `spb_datatype`: The Sparkplug data type of the metric (e.g. "Int32", "Double", "Boolean")
 * `spb_alias`: The alias number of the metric (for debugging alias resolution)
 * `spb_is_historical`: Set to "true" if the metric was flagged as historical

--- a/sparkplug_plugin/integration_test.go
+++ b/sparkplug_plugin/integration_test.go
@@ -58,7 +58,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -673,6 +672,141 @@ logger:
 			}
 
 			fmt.Printf("✅ Integration test completed - %d messages captured and validated\n", len(messages))
+		})
+
+		It("should surface per-metric timestamps as spb_timestamp end-to-end (ENG-5341)", func() {
+			By("Creating a primary-host stream capturing messages")
+
+			uniqueGroupID := fmt.Sprintf("TSTest-%d-%s", GinkgoParallelProcess(), uuid.New().String()[:8])
+
+			streamBuilder := service.NewStreamBuilder()
+			err := streamBuilder.SetYAML(fmt.Sprintf(`
+input:
+  sparkplug_b:
+    mqtt:
+      urls: ["%s"]
+      client_id: "test-ts-host-%d-%s"
+      qos: 1
+    identity:
+      group_id: "%s"
+      edge_node_id: "CentralHost"
+    role: "primary"
+    subscription:
+      groups: ["%s"]
+
+output:
+  message_capture: {}
+
+logger:
+  level: INFO
+`, brokerURL, GinkgoParallelProcess(), uuid.New().String()[:8], uniqueGroupID, uniqueGroupID))
+			Expect(err).NotTo(HaveOccurred(), "Failed to parse stream configuration")
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			stream, err := streamBuilder.Build()
+			Expect(err).NotTo(HaveOccurred(), "Failed to build stream")
+
+			streamDone := make(chan error, 1)
+			go func() {
+				streamDone <- stream.Run(ctx)
+			}()
+
+			time.Sleep(3 * time.Second)
+
+			// Distinct per-metric timestamps, all different from the payload-level timestamp.
+			payloadTS := uint64(time.Now().UnixMilli())
+			tempTS := payloadTS + 111
+			pressureTS := payloadTS + 222
+
+			By("Publishing NBIRTH declaring Temperature (alias 100) and Pressure (alias 101)")
+			nbirth := &sparkplugb.Payload{
+				Timestamp: uint64Ptr(payloadTS),
+				Seq:       uint64Ptr(0),
+				Metrics: []*sparkplugb.Payload_Metric{
+					{Name: stringPtr("bdSeq"), Alias: uint64Ptr(0), Datatype: uint32Ptr(7), Value: &sparkplugb.Payload_Metric_LongValue{LongValue: 12345}},
+					{Name: stringPtr("Temperature"), Alias: uint64Ptr(100), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 25.5}},
+					{Name: stringPtr("Pressure"), Alias: uint64Ptr(101), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 1013.25}},
+				},
+			}
+			birthBytes, err := proto.Marshal(nbirth)
+			Expect(err).NotTo(HaveOccurred())
+			token := mqttClient.Publish(fmt.Sprintf("spBv1.0/%s/NBIRTH/Line1", uniqueGroupID), 1, false, birthBytes)
+			Expect(token.Wait()).To(BeTrue())
+			Expect(token.Error()).NotTo(HaveOccurred())
+
+			time.Sleep(2 * time.Second)
+
+			By("Publishing NDATA with two metrics carrying distinct per-metric timestamps")
+			ndata := &sparkplugb.Payload{
+				Timestamp: uint64Ptr(payloadTS),
+				Seq:       uint64Ptr(1),
+				Metrics: []*sparkplugb.Payload_Metric{
+					{Alias: uint64Ptr(100), Timestamp: uint64Ptr(tempTS), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 26.8}},
+					{Alias: uint64Ptr(101), Timestamp: uint64Ptr(pressureTS), Datatype: uint32Ptr(10), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 1015.5}},
+				},
+			}
+			dataBytes, err := proto.Marshal(ndata)
+			Expect(err).NotTo(HaveOccurred())
+			token = mqttClient.Publish(fmt.Sprintf("spBv1.0/%s/NDATA/Line1", uniqueGroupID), 1, false, dataBytes)
+			Expect(token.Wait()).To(BeTrue())
+			Expect(token.Error()).NotTo(HaveOccurred())
+
+			time.Sleep(2 * time.Second)
+			cancel()
+
+			select {
+			case <-streamDone:
+			case <-time.After(5 * time.Second):
+			}
+
+			By("Collecting captured messages")
+			messageCapture := getCurrentTestCapture()
+			Expect(messageCapture).NotTo(BeNil(), "MessageCapture should be available")
+
+			var messages []*service.Message
+			timeout := time.After(2 * time.Second)
+		collectTS:
+			for {
+				select {
+				case msg := <-messageCapture.messages:
+					if msg != nil {
+						messages = append(messages, msg)
+					}
+				case <-timeout:
+					break collectTS
+				default:
+					if len(messages) > 0 {
+						time.Sleep(500 * time.Millisecond)
+						break collectTS
+					}
+					time.Sleep(200 * time.Millisecond)
+				}
+			}
+
+			By("Verifying each NDATA metric kept its own timestamp")
+			tsByMetric := map[string]string{}
+			for _, msg := range messages {
+				msgType, _ := msg.MetaGet("spb_message_type")
+				if msgType != "NDATA" {
+					continue
+				}
+				name, ok := msg.MetaGet("spb_metric_name")
+				Expect(ok).To(BeTrue())
+				ts, ok := msg.MetaGet("spb_timestamp")
+				Expect(ok).To(BeTrue(), "NDATA metric %q should carry spb_timestamp", name)
+				tsByMetric[name] = ts
+			}
+
+			Expect(tsByMetric).To(HaveKeyWithValue("Temperature", fmt.Sprintf("%d", tempTS)),
+				"Temperature must use its own metric timestamp, not the payload timestamp")
+			Expect(tsByMetric).To(HaveKeyWithValue("Pressure", fmt.Sprintf("%d", pressureTS)),
+				"Pressure must use its own metric timestamp, not the payload timestamp")
+			Expect(tsByMetric["Temperature"]).NotTo(Equal(tsByMetric["Pressure"]),
+				"the two metrics must not collapse to a single timestamp")
+
+			fmt.Printf("✅ ENG-5341 end-to-end timestamps: %+v\n", tsByMetric)
 		})
 
 		It("should handle broker disconnection gracefully", func() {

--- a/sparkplug_plugin/sparkplug_b_core.go
+++ b/sparkplug_plugin/sparkplug_b_core.go
@@ -523,8 +523,8 @@ func (mp *MessageProcessor) extractMetricValue(metric *sparkplugb.Payload_Metric
 		result["quality"] = "UNCERTAIN"
 	}
 
-	// Note: Timestamp is at payload level in Sparkplug B, not metric level
-	// Individual metrics don't have timestamps
+	// Note: the timestamp (per-metric when present, else payload-level) is handled by
+	// the caller and not embedded in the value JSON here.
 
 	jsonBytes, err := json.Marshal(result)
 	if err != nil {

--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -1138,8 +1138,14 @@ func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metr
 	msg.MetaSet("spb_metric_index", fmt.Sprintf("%d", metricIndex))
 	msg.MetaSet("spb_metrics_in_payload", fmt.Sprintf("%d", totalMetrics))
 
-	if payload.Timestamp != nil {
-		msg.MetaSet("spb_timestamp", fmt.Sprintf("%d", *payload.Timestamp))
+	// ENG-5341: prefer the per-metric timestamp (Sparkplug proto field 3) so each metric
+	// keeps its own sample time; fall back to the payload-level timestamp when absent.
+	ts := payload.Timestamp
+	if metric.Timestamp != nil {
+		ts = metric.Timestamp
+	}
+	if ts != nil {
+		msg.MetaSet("spb_timestamp", fmt.Sprintf("%d", *ts))
 	}
 
 	// Add metric-specific metadata
@@ -1276,8 +1282,8 @@ func (s *sparkplugInput) extractMetricValue(metric *sparkplugb.Payload_Metric) [
 		}
 	}
 
-	// Note: Individual metrics don't have timestamps in Sparkplug B
-	// Timestamp is at the payload level
+	// Note: the metric timestamp is surfaced as spb_timestamp metadata (see
+	// createMessageFromMetric), not embedded in the value JSON here.
 
 	jsonBytes, err := json.Marshal(result)
 	if err != nil {
@@ -1605,8 +1611,10 @@ func (s *sparkplugInput) tryAddUMHMetadata(msg *service.Message, metric *sparkpl
 		sparkplugMsg.MetricName = "unknown_metric"
 	}
 
-	// Set timestamp from payload if available
-	if payload.Timestamp != nil {
+	// ENG-5341: prefer the per-metric timestamp, falling back to the payload-level one.
+	if metric.Timestamp != nil {
+		sparkplugMsg.Timestamp = time.UnixMilli(int64(*metric.Timestamp))
+	} else if payload.Timestamp != nil {
 		sparkplugMsg.Timestamp = time.UnixMilli(int64(*payload.Timestamp))
 	}
 

--- a/sparkplug_plugin/sparkplug_b_input.go
+++ b/sparkplug_plugin/sparkplug_b_input.go
@@ -1089,6 +1089,16 @@ func (s *sparkplugInput) createSplitMessages(payload *sparkplugb.Payload, msgTyp
 	return batch
 }
 
+// ENG-5341: resolveMetricTimestamp returns the per-metric timestamp (Sparkplug
+// proto field 3) when set so each metric keeps its own sample time, falling back
+// to the payload-level timestamp. It returns nil when neither is present.
+func resolveMetricTimestamp(metric *sparkplugb.Payload_Metric, payload *sparkplugb.Payload) *uint64 {
+	if metric.Timestamp != nil {
+		return metric.Timestamp
+	}
+	return payload.Timestamp
+}
+
 func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metric, payload *sparkplugb.Payload, msgType MessageType, topicInfo *TopicInfo, originalTopic string, metricIndex int, totalMetrics int) *service.Message {
 	// Extract metric value as JSON (always preserve Sparkplug B format)
 	value := s.extractMetricValue(metric)
@@ -1138,13 +1148,7 @@ func (s *sparkplugInput) createMessageFromMetric(metric *sparkplugb.Payload_Metr
 	msg.MetaSet("spb_metric_index", fmt.Sprintf("%d", metricIndex))
 	msg.MetaSet("spb_metrics_in_payload", fmt.Sprintf("%d", totalMetrics))
 
-	// ENG-5341: prefer the per-metric timestamp (Sparkplug proto field 3) so each metric
-	// keeps its own sample time; fall back to the payload-level timestamp when absent.
-	ts := payload.Timestamp
-	if metric.Timestamp != nil {
-		ts = metric.Timestamp
-	}
-	if ts != nil {
+	if ts := resolveMetricTimestamp(metric, payload); ts != nil {
 		msg.MetaSet("spb_timestamp", fmt.Sprintf("%d", *ts))
 	}
 
@@ -1611,11 +1615,8 @@ func (s *sparkplugInput) tryAddUMHMetadata(msg *service.Message, metric *sparkpl
 		sparkplugMsg.MetricName = "unknown_metric"
 	}
 
-	// ENG-5341: prefer the per-metric timestamp, falling back to the payload-level one.
-	if metric.Timestamp != nil {
-		sparkplugMsg.Timestamp = time.UnixMilli(int64(*metric.Timestamp))
-	} else if payload.Timestamp != nil {
-		sparkplugMsg.Timestamp = time.UnixMilli(int64(*payload.Timestamp))
+	if ts := resolveMetricTimestamp(metric, payload); ts != nil {
+		sparkplugMsg.Timestamp = time.UnixMilli(int64(*ts))
 	}
 
 	// Store original values before any sanitization

--- a/sparkplug_plugin/sparkplug_b_metric_timestamp_test.go
+++ b/sparkplug_plugin/sparkplug_b_metric_timestamp_test.go
@@ -1,0 +1,96 @@
+//go:build !integration
+
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sparkplug_plugin_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sparkplugplugin "github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin"
+	"github.com/united-manufacturing-hub/benthos-umh/sparkplug_plugin/sparkplugb"
+)
+
+// ENG-5341: spb_timestamp must reflect each metric's own timestamp (metric.Timestamp,
+// proto field 3) when present, falling back to the payload-level timestamp only when a
+// metric carries none. Previously every metric in an NDATA/DDATA inherited the single
+// payload.Timestamp, losing per-metric sample time and colliding downstream dedup keys.
+var _ = Describe("Per-metric timestamp extraction (ENG-5341)", func() {
+	var (
+		input     *sparkplugplugin.SparkplugInputTestWrapper
+		topicInfo *sparkplugplugin.TopicInfo
+	)
+
+	BeforeEach(func() {
+		input = createMockSparkplugInput()
+		topicInfo = &sparkplugplugin.TopicInfo{
+			Group:    "test",
+			EdgeNode: "edge1",
+			Device:   "device1",
+		}
+	})
+
+	Context("when metrics carry their own timestamps", func() {
+		It("uses each metric's timestamp for spb_timestamp", func() {
+			payloadTS := uint64(1730986400000)
+			tempTS := uint64(1730986400111)
+			pressureTS := uint64(1730986400222)
+			seq := uint64(42)
+
+			payload := &sparkplugb.Payload{
+				Seq:       &seq,
+				Timestamp: &payloadTS,
+				Metrics: []*sparkplugb.Payload_Metric{
+					{Name: stringPtr("temperature"), Timestamp: &tempTS, Datatype: uint32Ptr(SparkplugDataTypeDouble), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 100.5}},
+					{Name: stringPtr("pressure"), Timestamp: &pressureTS, Datatype: uint32Ptr(SparkplugDataTypeDouble), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 50.2}},
+				},
+			}
+
+			batch := input.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
+			Expect(batch).To(HaveLen(2))
+
+			ts0, ok := batch[0].MetaGet("spb_timestamp")
+			Expect(ok).To(BeTrue())
+			Expect(ts0).To(Equal("1730986400111"), "temperature should use its own metric timestamp")
+
+			ts1, ok := batch[1].MetaGet("spb_timestamp")
+			Expect(ok).To(BeTrue())
+			Expect(ts1).To(Equal("1730986400222"), "pressure should use its own metric timestamp")
+		})
+	})
+
+	Context("when a metric has no timestamp", func() {
+		It("falls back to the payload-level timestamp", func() {
+			payloadTS := uint64(1730986400000)
+			seq := uint64(43)
+
+			payload := &sparkplugb.Payload{
+				Seq:       &seq,
+				Timestamp: &payloadTS,
+				Metrics: []*sparkplugb.Payload_Metric{
+					{Name: stringPtr("temperature"), Datatype: uint32Ptr(SparkplugDataTypeDouble), Value: &sparkplugb.Payload_Metric_DoubleValue{DoubleValue: 100.5}},
+				},
+			}
+
+			batch := input.CreateSplitMessages(payload, "NDATA", topicInfo, "spBv1.0/test/NDATA/edge1/device1")
+			Expect(batch).To(HaveLen(1))
+
+			ts, ok := batch[0].MetaGet("spb_timestamp")
+			Expect(ok).To(BeTrue())
+			Expect(ts).To(Equal("1730986400000"), "should fall back to payload timestamp when metric has none")
+		})
+	})
+})


### PR DESCRIPTION
## Customer problem

A customer saw Sparkplug metrics go missing between the device and the UNS. Values published at the edge never arrived downstream.

## Background

The `sparkplug_b` input splits each Sparkplug payload into one message per metric and gives each message a timestamp. Sparkplug carries two timestamps: one on the payload for when the message was sent, and one on each metric for when that value was sampled. The input used the payload timestamp for every metric and ignored the per-metric one.

When a device sends the same tag more than once in a payload, for example buffered samples flushed after a reconnect, every copy got the same timestamp. The downsampler drops a sample whose timestamp matches the last one it kept for that tag, so the copies collapsed to a single point and the rest were dropped.

## Fix

Use the metric's own timestamp when it is set, and fall back to the payload timestamp only when it is missing (in `createMessageFromMetric` and the UMH-conversion path). Each sample now carries the time it was captured, which is what the Sparkplug B spec defines the per-metric timestamp to mean, so the downsampler keeps samples whose timestamps differ.

Testing: a unit test covers distinct and fallback timestamps; an integration test publishes a two-metric NDATA through a real broker and checks the timestamps stay distinct.

Fixes [ENG-5341](https://linear.app/united-manufacturing-hub/issue/ENG-5341/sparkplug-b-input-use-per-metric-timestamp-metrictimestamp-instead-of)

🤖 Generated with [Claude Code](https://claude.com/claude-code)