### PR TITLE
fix(historian): don't warn or degrade on contract-mismatch-only batches

### DIFF
--- a/.changelog/unreleased/fixes-20260720-132909.yaml
+++ b/.changelog/unreleased/fixes-20260720-132909.yaml
@@ -1,3 +1,3 @@
 kind: fixes
-body: Historian no longer logs a warning (or reports the bridge as degraded) when a batch is dropped solely because its messages belong to a different data contract than the one the bridge stores; that expected case is now a debug-level message (ENG-5394)
+body: The TimescaleDB historian output no longer logs a warning when a batch is dropped solely because its messages belong to a data contract other than the one it stores; that expected case is now a single info-level notice per process, while genuine faults are still logged as warnings (ENG-5394)
 time: 2026-07-20T13:29:09.837735+02:00

--- a/.changelog/unreleased/fixes-20260720-132909.yaml
+++ b/.changelog/unreleased/fixes-20260720-132909.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: Historian no longer logs a warning (or reports the bridge as degraded) when a batch is dropped solely because its messages belong to a different data contract than the one the bridge stores; that expected case is now a debug-level message (ENG-5394)
+time: 2026-07-20T13:29:09.837735+02:00

--- a/.changelog/unreleased/fixes-20260720-132909.yaml
+++ b/.changelog/unreleased/fixes-20260720-132909.yaml
@@ -1,3 +1,3 @@
 kind: fixes
-body: The TimescaleDB historian output no longer logs a warning when a batch is dropped solely because its messages belong to a data contract other than the one it stores; that expected case is now a single info-level notice per process, while genuine faults are still logged as warnings (ENG-5394)
+body: The TimescaleDB historian output logs a one-time info notice confirming the first message stored for its data contract. When it is receiving data but has stored nothing for that contract, it logs a one-time notice that the messages all belong to other contracts and points at data_contract_name and the flow's topic subscription. Other-contract-only batches no longer warn once data is flowing, while genuine faults are still logged as warnings (ENG-5394)
 time: 2026-07-20T13:29:09.837735+02:00

--- a/historian_plugin/export_test.go
+++ b/historian_plugin/export_test.go
@@ -199,16 +199,29 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-// msgHandler writes each record's formatted message verbatim (one per line), so a test can grep the
-// exact operator-facing text. slog's TextHandler would quote and backslash-escape the message, which
-// mangles substrings like tag="t" -- and that text is precisely what the runbook tells operators to
-// search for.
+// msgHandler writes each record as "level=<benthos-level> msg=<message>" (one per line), matching
+// benthos's own log format so a test can assert severity, not just message text. A plain
+// slog.TextHandler would quote and escape the message, mangling substrings like tag="t".
 type msgHandler struct{ w io.Writer }
 
 func (h msgHandler) Enabled(context.Context, slog.Level) bool { return true }
 func (h msgHandler) Handle(_ context.Context, r slog.Record) error {
-	_, err := io.WriteString(h.w, r.Message+"\n")
+	_, err := io.WriteString(h.w, "level="+benthosLevel(r.Level)+" msg="+r.Message+"\n")
 	return err
+}
+
+// benthosLevel formats a slog level as benthos does (benthos uses "warning", not slog's "WARN").
+func benthosLevel(l slog.Level) string {
+	switch {
+	case l >= slog.LevelError:
+		return "error"
+	case l >= slog.LevelWarn:
+		return "warning"
+	case l >= slog.LevelInfo:
+		return "info"
+	default:
+		return "debug"
+	}
 }
 func (h msgHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
 func (h msgHandler) WithGroup(string) slog.Handler      { return h }

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -43,7 +43,7 @@ func historianConfig() *service.ConfigSpec {
 		Field(service.NewStringField("database").Description("Database name.").Default("umh")).
 		Field(service.NewStringField("username").Description("Login role.").Default("umh_owner")).
 		Field(service.NewStringField("sslmode").Description("require | disable | verify-full.").Default("require").Examples("require", "disable", "verify-full")).
-		Field(service.NewStringField("sslrootcert").Description("CA cert path (inside the umh-core container).").Default("").Advanced()).
+		Field(service.NewStringField("sslrootcert").Description("CA cert path, as seen by the benthos process.").Default("").Advanced()).
 		Field(service.NewStringField("sslcert").Description("Client cert path.").Default("").Advanced()).
 		Field(service.NewStringField("sslkey").Description("Client key path.").Default("").Advanced()).
 		Field(service.NewBoolField("metadata_keys_all").Description("Store all metadata keys except blacklists.").Default(true).Examples(true, false).Advanced()).
@@ -93,6 +93,8 @@ type historianOutput struct {
 	warnedChurn map[string]struct{} // high-churn metadata keys already warned about
 
 	warnedTruncate atomic.Bool // warn-once guard for truncation
+
+	warnedContractMismatch atomic.Bool // info-once guard for contract-mismatch-only batches
 }
 
 func newHistorianOutput(conf *service.ParsedConfig, mgr *service.Resources) (*historianOutput, error) {
@@ -242,7 +244,7 @@ func (o *historianOutput) bootstrapStmt() string {
 
 // Connect opens the pool (once), verifies the server version, bootstraps the schema idempotently on
 // first call, and checks the login role can INSERT. It is the benthos output Connect hook; a
-// returned error keeps the bridge from registering as up.
+// returned error keeps the output from registering as connected.
 //
 // The login role is assumed to be able to run the (idempotent) bootstrap DDL -- the owner
 // (umh_owner) or an equivalent. Either way a role that cannot write fails Connect visibly, just at
@@ -312,8 +314,8 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 		o.bootstrapped = true
 	}
 	// Verify write permission on every Connect (a grant can be revoked between reconnects), so a
-	// permission reject fails Connect -> connection_up never registers -> the bridge fails visibly
-	// instead of stalling on an endless WriteBatch NACK.
+	// permission reject fails Connect -> the output never registers as connected -> it fails
+	// visibly instead of stalling on an endless WriteBatch NACK.
 	if err := o.probeWritable(bootCtx); err != nil {
 		return err
 	}
@@ -323,7 +325,7 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 // probeWritable verifies the login role can INSERT into this contract's tables. Connect otherwise
 // only proves the server is reachable and the schema exists -- and bootstrap runs as the owner, so
 // it passes even when a different login role lacks INSERT. Without this a permission reject shows up
-// only as an endless WriteBatch NACK and the bridge stalls "starting" instead of failing visibly.
+// only as an endless WriteBatch NACK and the output stalls instead of failing visibly.
 // Read-only catalog lookup, so it is safe on every Connect and under concurrency.
 func (o *historianOutput) probeWritable(ctx context.Context) error {
 	valueTbl := "umh.value_" + o.contract
@@ -335,7 +337,7 @@ func (o *historianOutput) probeWritable(ctx context.Context) error {
 		return fmt.Errorf("write-permission check failed for %s / %s: %w", valueTbl, attrTbl, err)
 	}
 	if !ok {
-		return fmt.Errorf("login role %q lacks INSERT on %s or %s; grant it before the bridge can write", o.username, valueTbl, attrTbl)
+		return fmt.Errorf("login role %q lacks INSERT on %s or %s; grant it before this output can write", o.username, valueTbl, attrTbl)
 	}
 	return nil
 }
@@ -371,7 +373,7 @@ func (o *historianOutput) warnPolicyDrift(ctx context.Context) {
 		retentionWant = &v
 	}
 	for _, w := range policyDriftWarnings(int64(o.compressAfter.Seconds()), appliedComp, retentionWant, appliedRet) {
-		o.logger.Warnf("TimescaleDB historian: %s. Policies are applied once at first bootstrap and not re-applied on restart, so a config change alone does not update them. Change them on the database directly with the TimescaleDB policy functions (remove_/add_compression_policy, remove_/add_retention_policy) on umh.value_%s and umh.attribute_%s, then set the same value in the bridge config to silence this warning.", w, o.contract, o.contract)
+		o.logger.Warnf("TimescaleDB historian: %s. Policies are applied once at first bootstrap and not re-applied on restart, so a config change alone does not update them. Change them on the database directly with the TimescaleDB policy functions (remove_/add_compression_policy, remove_/add_retention_policy) on umh.value_%s and umh.attribute_%s, then set the same value in this output's config to silence this warning.", w, o.contract, o.contract)
 	}
 }
 
@@ -403,7 +405,7 @@ func (o *historianOutput) WriteBatch(ctx context.Context, batch service.MessageB
 	view := o.dedup.NewBatch()
 	rows := make([]*Row, 0, len(batch))
 	churn := map[string]struct{}{} // high-churn metadata keys seen anywhere in this batch (see below)
-	contractMismatches := 0        // messages dropped solely because they belong to another data contract
+	contractMismatches := 0        // DropContractMismatch count this batch
 	for _, msg := range batch {
 		meta := map[string]string{}
 		_ = msg.MetaWalk(func(k, v string) error { meta[k] = v; return nil })
@@ -445,17 +447,15 @@ func (o *historianOutput) WriteBatch(ctx context.Context, batch service.MessageB
 	// wants them out of metadata_keys.
 	o.warnHighChurnMetadata(churn)
 	if len(rows) == 0 {
-		// A fully-dropped batch writes nothing while the connection stays up, so umh-core would
-		// see a healthy bridge silently discarding data. Warn (umh-core surfaces this as
-		// degraded); still return nil so one bad message never stalls the stream.
+		// Return nil in every branch so one fully-dropped batch never stalls the stream.
 		switch {
 		case len(batch) == 0:
-			// empty batch: nothing to say
 		case contractMismatches == len(batch):
-			// Every message simply belonged to another data contract. Expected when a bridge
-			// subscribes to more of umh.v1 than the single contract this historian stores, so
-			// it is not a fault: log at debug and leave the bridge healthy.
-			o.logger.Debugf("TimescaleDB historian: dropped all %d message(s) in the batch; all belong to other data contracts (this historian stores only _%s). This is expected when the bridge subscribes to more than _%s and is not an error.", len(batch), o.contract, o.contract)
+			// All dropped for belonging to other contracts: expected, not a fault. Info (debug is
+			// hidden at the default log level), and once since it recurs on every such batch.
+			if o.warnedContractMismatch.CompareAndSwap(false, true) {
+				o.logger.Infof("TimescaleDB historian: stores only data contract _%s; messages for other contracts are ignored.", o.contract)
+			}
 		default:
 			o.logger.Warnf("TimescaleDB historian: dropped all %d message(s) in the batch; nothing written. Check the source data and metadata configuration.", len(batch))
 		}
@@ -742,7 +742,7 @@ func describeRow(r *Row) string {
 		r.ContractName, r.RawLocation, r.VirtualPath, r.TagName, r.TS)
 }
 
-// recordDrop counts and debug-logs a discarded message, so a misconfigured bridge that
+// recordDrop counts and debug-logs a discarded message, so a misconfigured output that
 // drops everything is visible (the metric) rather than silently healthy with zero rows.
 func (o *historianOutput) recordDrop(reason string, topic string) {
 	o.dropped.Incr(1, reason)

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -449,27 +449,20 @@ func (o *historianOutput) WriteBatch(ctx context.Context, batch service.MessageB
 	// wants them out of metadata_keys.
 	o.warnHighChurnMetadata(churn)
 	if len(rows) == 0 {
-		// Return nil in every branch so one fully-dropped batch never stalls the stream.
+		// Return nil in every branch so one fully-dropped batch never stalls the stream. Cases below
+		// only reach the last two once contractMismatches == len(batch) (every drop was a mismatch).
 		switch {
-		case len(batch) == 0:
-		case contractMismatches == len(batch):
-			if o.everStored.Load() {
-				// Over-broad subscription lull: this contract is stored, this batch just had none.
-				o.logger.Debugf("TimescaleDB historian: dropped all %d message(s); all for other data contracts.", len(batch))
-			} else {
-				// Nothing stored for this contract yet while other-contract data keeps arriving --
-				// most likely a wrong contract or subscription. Info once (debug is hidden by default).
-				// Re-check everStored under logStateMu so a store landing on a concurrent batch wins
-				// and suppresses a false starving notice.
-				o.logStateMu.Lock()
-				if !o.everStored.Load() && !o.warnedStarving {
-					o.warnedStarving = true
-					o.logger.Infof("TimescaleDB historian: nothing stored for data contract _%s yet; the last %d message(s) were all for other contracts. Check data_contract_name and the topics this flow subscribes to.", o.contract, len(batch))
-				}
-				o.logStateMu.Unlock()
-			}
-		default:
+		case len(batch) == 0: // empty batch, nothing to report
+		case contractMismatches < len(batch):
+			// Some drops were not contract mismatches, so this is a genuine fault worth a warning.
 			o.logger.Warnf("TimescaleDB historian: dropped all %d message(s) in the batch; nothing written. Check the source data and metadata configuration.", len(batch))
+		case o.everStored.Load():
+			// Over-broad subscription lull: this contract is stored, this batch just had none.
+			o.logger.Debugf("TimescaleDB historian: dropped all %d message(s); all for other data contracts.", len(batch))
+		default:
+			// Nothing stored for this contract yet while other-contract data keeps arriving --
+			// most likely a wrong contract or subscription.
+			o.noteStarving(len(batch))
 		}
 		return nil
 	}
@@ -764,6 +757,18 @@ func (o *historianOutput) noteStored() {
 	if !o.everStored.Load() { // recheck under the lock; only this method writes everStored
 		o.everStored.Store(true)
 		o.logger.Infof("TimescaleDB historian: first message stored for data contract _%s.", o.contract)
+	}
+}
+
+// noteStarving logs once, at info, while nothing has ever been stored for this contract and a batch
+// was dropped entirely for other contracts -- the negative counterpart to noteStored. The everStored
+// re-check under logStateMu lets a store landing on a concurrent batch win and suppress a false notice.
+func (o *historianOutput) noteStarving(n int) {
+	o.logStateMu.Lock()
+	defer o.logStateMu.Unlock()
+	if !o.everStored.Load() && !o.warnedStarving {
+		o.warnedStarving = true
+		o.logger.Infof("TimescaleDB historian: nothing stored for data contract _%s yet; the last %d message(s) were all for other contracts. Check data_contract_name and the topics this flow subscribes to.", o.contract, n)
 	}
 }
 

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -94,7 +94,8 @@ type historianOutput struct {
 
 	warnedTruncate atomic.Bool // warn-once guard for truncation
 
-	warnedContractMismatch atomic.Bool // info-once guard for contract-mismatch-only batches
+	everStored     atomic.Bool // set once the first value row for this contract is stored
+	warnedStarving atomic.Bool // info-once guard: receiving data but nothing stored for this contract
 }
 
 func newHistorianOutput(conf *service.ParsedConfig, mgr *service.Resources) (*historianOutput, error) {
@@ -451,10 +452,13 @@ func (o *historianOutput) WriteBatch(ctx context.Context, batch service.MessageB
 		switch {
 		case len(batch) == 0:
 		case contractMismatches == len(batch):
-			// All dropped for belonging to other contracts: expected, not a fault. Info (debug is
-			// hidden at the default log level), and once since it recurs on every such batch.
-			if o.warnedContractMismatch.CompareAndSwap(false, true) {
-				o.logger.Infof("TimescaleDB historian: stores only data contract _%s; messages for other contracts are ignored.", o.contract)
+			if o.everStored.Load() {
+				// Over-broad subscription lull: this contract is stored, this batch just had none.
+				o.logger.Debugf("TimescaleDB historian: dropped all %d message(s); all for other data contracts.", len(batch))
+			} else if o.warnedStarving.CompareAndSwap(false, true) {
+				// Nothing stored for this contract yet while other-contract data keeps arriving --
+				// most likely a wrong contract or subscription. Info once (debug is hidden by default).
+				o.logger.Infof("TimescaleDB historian: nothing stored for data contract _%s yet; the last %d message(s) were all for other contracts. Check data_contract_name and the topics this flow subscribes to.", o.contract, len(batch))
 			}
 		default:
 			o.logger.Warnf("TimescaleDB historian: dropped all %d message(s) in the batch; nothing written. Check the source data and metadata configuration.", len(batch))
@@ -673,6 +677,9 @@ func (o *historianOutput) writeBatchFast(ctx context.Context, pool *pgxpool.Pool
 	o.topicCacheSize.Set(int64(o.topicCache.Len()))
 	o.valueRows.Incr(int64(len(vIDs)))
 	o.attrRows.Incr(int64(len(aIDs)))
+	if len(vIDs) > 0 {
+		o.noteStored()
+	}
 	return nil
 }
 
@@ -733,7 +740,18 @@ func (o *historianOutput) writeRowsIsolated(ctx context.Context, pool *pgxpool.P
 	o.topicCacheSize.Set(int64(o.topicCache.Len()))
 	o.valueRows.Incr(int64(written))
 	o.attrRows.Incr(int64(attrs))
+	if written > 0 {
+		o.noteStored()
+	}
 	return nil // ACK: good rows committed, poison rows dropped-with-signal
+}
+
+// noteStored logs once when the first value row for this contract lands, so an operator can confirm
+// data is being written -- the positive counterpart to the starving notice in WriteBatch.
+func (o *historianOutput) noteStored() {
+	if o.everStored.CompareAndSwap(false, true) {
+		o.logger.Infof("TimescaleDB historian: first message stored for data contract _%s.", o.contract)
+	}
 }
 
 // describeRow identifies a row for an attributable write-failure log: which tag, at which ts.

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -94,8 +94,9 @@ type historianOutput struct {
 
 	warnedTruncate atomic.Bool // warn-once guard for truncation
 
-	everStored     atomic.Bool // set once the first value row for this contract is stored
-	warnedStarving atomic.Bool // info-once guard: receiving data but nothing stored for this contract
+	logStateMu     sync.Mutex  // linearizes the everStored transition with the starving-notice decision
+	everStored     atomic.Bool // set once the first value row is stored; lock-free reads gate the hot path
+	warnedStarving bool        // info-once guard for the starving notice; guarded by logStateMu
 }
 
 func newHistorianOutput(conf *service.ParsedConfig, mgr *service.Resources) (*historianOutput, error) {
@@ -455,10 +456,17 @@ func (o *historianOutput) WriteBatch(ctx context.Context, batch service.MessageB
 			if o.everStored.Load() {
 				// Over-broad subscription lull: this contract is stored, this batch just had none.
 				o.logger.Debugf("TimescaleDB historian: dropped all %d message(s); all for other data contracts.", len(batch))
-			} else if o.warnedStarving.CompareAndSwap(false, true) {
+			} else {
 				// Nothing stored for this contract yet while other-contract data keeps arriving --
 				// most likely a wrong contract or subscription. Info once (debug is hidden by default).
-				o.logger.Infof("TimescaleDB historian: nothing stored for data contract _%s yet; the last %d message(s) were all for other contracts. Check data_contract_name and the topics this flow subscribes to.", o.contract, len(batch))
+				// Re-check everStored under logStateMu so a store landing on a concurrent batch wins
+				// and suppresses a false starving notice.
+				o.logStateMu.Lock()
+				if !o.everStored.Load() && !o.warnedStarving {
+					o.warnedStarving = true
+					o.logger.Infof("TimescaleDB historian: nothing stored for data contract _%s yet; the last %d message(s) were all for other contracts. Check data_contract_name and the topics this flow subscribes to.", o.contract, len(batch))
+				}
+				o.logStateMu.Unlock()
 			}
 		default:
 			o.logger.Warnf("TimescaleDB historian: dropped all %d message(s) in the batch; nothing written. Check the source data and metadata configuration.", len(batch))
@@ -726,6 +734,7 @@ func (o *historianOutput) writeRowsIsolated(ctx context.Context, pool *pgxpool.P
 			return err
 		}
 		written++
+		o.noteStored() // record now: a later non-poison error can return before the tail
 		if r.EmitMeta {
 			if _, err := pool.Exec(ctx, aq, id, r.TS, r.MetadataJSON); err != nil {
 				if classify(err) == dispDropPoison {
@@ -740,15 +749,18 @@ func (o *historianOutput) writeRowsIsolated(ctx context.Context, pool *pgxpool.P
 	o.topicCacheSize.Set(int64(o.topicCache.Len()))
 	o.valueRows.Incr(int64(written))
 	o.attrRows.Incr(int64(attrs))
-	if written > 0 {
-		o.noteStored()
-	}
 	return nil // ACK: good rows committed, poison rows dropped-with-signal
 }
 
 // noteStored logs once when the first value row for this contract lands, so an operator can confirm
-// data is being written -- the positive counterpart to the starving notice in WriteBatch.
+// data is being written -- the positive counterpart to the starving notice in WriteBatch. The
+// everStored fast path keeps this lock-free on every batch after the first store.
 func (o *historianOutput) noteStored() {
+	if o.everStored.Load() {
+		return
+	}
+	o.logStateMu.Lock()
+	defer o.logStateMu.Unlock()
 	if o.everStored.CompareAndSwap(false, true) {
 		o.logger.Infof("TimescaleDB historian: first message stored for data contract _%s.", o.contract)
 	}

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -403,6 +403,7 @@ func (o *historianOutput) WriteBatch(ctx context.Context, batch service.MessageB
 	view := o.dedup.NewBatch()
 	rows := make([]*Row, 0, len(batch))
 	churn := map[string]struct{}{} // high-churn metadata keys seen anywhere in this batch (see below)
+	contractMismatches := 0        // messages dropped solely because they belong to another data contract
 	for _, msg := range batch {
 		meta := map[string]string{}
 		_ = msg.MetaWalk(func(k, v string) error { meta[k] = v; return nil })
@@ -420,6 +421,9 @@ func (o *historianOutput) WriteBatch(ctx context.Context, batch service.MessageB
 		// this row also needs to write a metadata (attribute) row. A non-empty reason means drop.
 		row, reason := Transform(payload, meta, o.contract, o.metadataKeysAll, o.metadataKeys, o.metadataExclude, view)
 		if reason != DropNone {
+			if reason == DropContractMismatch {
+				contractMismatches++
+			}
 			o.recordDrop(string(reason), meta["umh_topic"])
 			continue
 		}
@@ -444,7 +448,15 @@ func (o *historianOutput) WriteBatch(ctx context.Context, batch service.MessageB
 		// A fully-dropped batch writes nothing while the connection stays up, so umh-core would
 		// see a healthy bridge silently discarding data. Warn (umh-core surfaces this as
 		// degraded); still return nil so one bad message never stalls the stream.
-		if len(batch) > 0 {
+		switch {
+		case len(batch) == 0:
+			// empty batch: nothing to say
+		case contractMismatches == len(batch):
+			// Every message simply belonged to another data contract. Expected when a bridge
+			// subscribes to more of umh.v1 than the single contract this historian stores, so
+			// it is not a fault: log at debug and leave the bridge healthy.
+			o.logger.Debugf("TimescaleDB historian: dropped all %d message(s) in the batch; all belong to other data contracts (this historian stores only _%s). This is expected when the bridge subscribes to more than _%s and is not an error.", len(batch), o.contract, o.contract)
+		default:
 			o.logger.Warnf("TimescaleDB historian: dropped all %d message(s) in the batch; nothing written. Check the source data and metadata configuration.", len(batch))
 		}
 		return nil

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -761,7 +761,8 @@ func (o *historianOutput) noteStored() {
 	}
 	o.logStateMu.Lock()
 	defer o.logStateMu.Unlock()
-	if o.everStored.CompareAndSwap(false, true) {
+	if !o.everStored.Load() { // recheck under the lock; only this method writes everStored
+		o.everStored.Store(true)
 		o.logger.Infof("TimescaleDB historian: first message stored for data contract _%s.", o.contract)
 	}
 }

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -813,19 +813,34 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 	// benthos's mock harness (it backs metrics with a no-op), so these specs pin the co-located
 	// operator-facing log lines instead -- the same signal umh-core's log regex surfaces as degraded,
 	// and the guard against a regression that stops counting/logging a drop or truncation.
-	It("logs info once (never at warning) when whole batches are dropped only for belonging to other data contracts", func() {
+	It("logs 'nothing stored yet' once at info (never warning) when data arrives but nothing matches the contract", func() {
 		h := connected("drops")
 		defer h.Close(ctx)
 		logs := h.CaptureLogs()
 		bad := mkMsg(1.0, 1000, "_other_v1", "acme.line1", "t", nil) // contract mismatch vs "drops"
 		Expect(h.WriteBatch(ctx, service.MessageBatch{bad})).To(Succeed())
-		Expect(h.WriteBatch(ctx, service.MessageBatch{bad})).To(Succeed()) // second contract-mismatch-only batch
+		Expect(h.WriteBatch(ctx, service.MessageBatch{bad})).To(Succeed()) // still nothing stored for "drops"
 		Expect(h.CountValueRows(ctx, "drops")).To(Equal(0))
 		Expect(logs()).To(ContainSubstring("reason=contract_mismatch"), "the per-drop log must name the reason")
-		Expect(logs()).To(ContainSubstring("level=info msg=TimescaleDB historian: stores only data contract _drops"), "the notice must be emitted at info, not warning")
-		Expect(strings.Count(logs(), "stores only data contract _drops")).To(Equal(1), "the notice must be logged once per process, not per batch")
+		Expect(logs()).To(ContainSubstring("level=info msg=TimescaleDB historian: nothing stored for data contract _drops yet"), "the starving notice must be info, not a warning")
+		Expect(strings.Count(logs(), "nothing stored for data contract _drops yet")).To(Equal(1), "the starving notice must be logged once per process, not per batch")
 		Expect(logs()).NotTo(ContainSubstring("level=warning"), "a contract-mismatch-only batch must not warn")
 		Expect(logs()).NotTo(ContainSubstring("level=error"), "a contract-mismatch-only batch must not error")
+	})
+
+	It("confirms the first stored message, then stays quiet on later other-contract-only batches", func() {
+		h := connected("stored") // own contract: this spec writes a row, so it must not pollute the "drops" tables
+		defer h.Close(ctx)
+		logs := h.CaptureLogs()
+		good := mkMsg(1.0, 1000, "_stored_v1", "acme.line1", "t", nil) // matches "stored"
+		Expect(h.WriteBatch(ctx, service.MessageBatch{good})).To(Succeed())
+		Expect(h.CountValueRows(ctx, "stored")).To(Equal(1))
+		Expect(logs()).To(ContainSubstring("level=info msg=TimescaleDB historian: first message stored for data contract _stored"), "a successful first store must be confirmed at info")
+		// Data has flowed, so a later all-other-contract batch is an expected lull: no starving notice, no warning.
+		other := mkMsg(2.0, 2000, "_other_v1", "acme.line1", "t", nil)
+		Expect(h.WriteBatch(ctx, service.MessageBatch{other})).To(Succeed())
+		Expect(logs()).NotTo(ContainSubstring("nothing stored for data contract _stored yet"), "once data has flowed, an other-contract batch must not read as starving")
+		Expect(logs()).NotTo(ContainSubstring("level=warning"))
 	})
 
 	It("warns when a whole batch is dropped for a real fault", func() {

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -843,6 +843,22 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(logs()).NotTo(ContainSubstring("level=warning"))
 	})
 
+	It("stores the matching messages in a mixed batch and never reads as starving", func() {
+		h := connected("overbroad") // own contract: mixed batch writes a row, must not collide with other specs
+		defer h.Close(ctx)
+		logs := h.CaptureLogs()
+		batch := service.MessageBatch{
+			mkMsg(1.0, 1000, "_overbroad_v1", "acme.line1", "t", nil), // matches "overbroad" -> stored
+			mkMsg(2.0, 2000, "_other_v1", "acme.line1", "t", nil),     // other contract -> dropped
+		}
+		Expect(h.WriteBatch(ctx, batch)).To(Succeed())
+		Expect(h.CountValueRows(ctx, "overbroad")).To(Equal(1))
+		Expect(logs()).To(ContainSubstring("reason=contract_mismatch"), "the other-contract message must be dropped by reason")
+		Expect(logs()).To(ContainSubstring("level=info msg=TimescaleDB historian: first message stored for data contract _overbroad"), "a stored row must be confirmed")
+		Expect(logs()).NotTo(ContainSubstring("nothing stored for data contract _overbroad yet"), "a mixed batch that stored a row must not read as starving")
+		Expect(logs()).NotTo(ContainSubstring("level=warning"), "a mixed batch must not warn")
+	})
+
 	It("warns when a whole batch is dropped for a real fault", func() {
 		h := connected("drops")
 		defer h.Close(ctx)

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -813,7 +813,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 	// benthos's mock harness (it backs metrics with a no-op), so these specs pin the co-located
 	// operator-facing log lines instead -- the same signal umh-core's log regex surfaces as degraded,
 	// and the guard against a regression that stops counting/logging a drop or truncation.
-	It("logs a dropped message by reason and warns when a whole batch is dropped", func() {
+	It("does not warn when a whole batch is dropped only for belonging to other data contracts", func() {
 		h := connected("drops")
 		defer h.Close(ctx)
 		logs := h.CaptureLogs()
@@ -821,7 +821,20 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(h.WriteBatch(ctx, service.MessageBatch{bad})).To(Succeed())
 		Expect(h.CountValueRows(ctx, "drops")).To(Equal(0))
 		Expect(logs()).To(ContainSubstring("reason=contract_mismatch"), "the per-drop log must name the reason")
-		Expect(logs()).To(ContainSubstring("dropped all 1 message(s)"), "a 100%-dropped non-empty batch must warn (degraded, not silent)")
+		Expect(logs()).To(ContainSubstring("all belong to other data contracts"), "a contract-mismatch-only batch must say so, not read as a fault")
+		Expect(logs()).NotTo(ContainSubstring("Check the source data and metadata configuration"), "a contract-mismatch-only batch must not warn (not degraded)")
+	})
+
+	It("warns when a whole batch is dropped for a real fault", func() {
+		h := connected("drops")
+		defer h.Close(ctx)
+		logs := h.CaptureLogs()
+		bad := mkMsg(nil, 1000, "_drops_v1", "acme.line1", "t", nil) // matching contract, missing value
+		Expect(h.WriteBatch(ctx, service.MessageBatch{bad})).To(Succeed())
+		Expect(h.CountValueRows(ctx, "drops")).To(Equal(0))
+		Expect(logs()).To(ContainSubstring("reason=missing_value_or_timestamp"), "the per-drop log must name the reason")
+		Expect(logs()).To(ContainSubstring("dropped all 1 message(s)"), "a 100%-dropped non-empty batch for a real fault must warn (degraded, not silent)")
+		Expect(logs()).To(ContainSubstring("Check the source data and metadata configuration"))
 	})
 
 	It("truncates an over-long value_text and warns exactly once", func() {

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -813,16 +813,19 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 	// benthos's mock harness (it backs metrics with a no-op), so these specs pin the co-located
 	// operator-facing log lines instead -- the same signal umh-core's log regex surfaces as degraded,
 	// and the guard against a regression that stops counting/logging a drop or truncation.
-	It("does not warn when a whole batch is dropped only for belonging to other data contracts", func() {
+	It("logs info once (never at warning) when whole batches are dropped only for belonging to other data contracts", func() {
 		h := connected("drops")
 		defer h.Close(ctx)
 		logs := h.CaptureLogs()
 		bad := mkMsg(1.0, 1000, "_other_v1", "acme.line1", "t", nil) // contract mismatch vs "drops"
 		Expect(h.WriteBatch(ctx, service.MessageBatch{bad})).To(Succeed())
+		Expect(h.WriteBatch(ctx, service.MessageBatch{bad})).To(Succeed()) // second contract-mismatch-only batch
 		Expect(h.CountValueRows(ctx, "drops")).To(Equal(0))
 		Expect(logs()).To(ContainSubstring("reason=contract_mismatch"), "the per-drop log must name the reason")
-		Expect(logs()).To(ContainSubstring("all belong to other data contracts"), "a contract-mismatch-only batch must say so, not read as a fault")
-		Expect(logs()).NotTo(ContainSubstring("Check the source data and metadata configuration"), "a contract-mismatch-only batch must not warn (not degraded)")
+		Expect(logs()).To(ContainSubstring("level=info msg=TimescaleDB historian: stores only data contract _drops"), "the notice must be emitted at info, not warning")
+		Expect(strings.Count(logs(), "stores only data contract _drops")).To(Equal(1), "the notice must be logged once per process, not per batch")
+		Expect(logs()).NotTo(ContainSubstring("level=warning"), "a contract-mismatch-only batch must not warn")
+		Expect(logs()).NotTo(ContainSubstring("level=error"), "a contract-mismatch-only batch must not error")
 	})
 
 	It("warns when a whole batch is dropped for a real fault", func() {
@@ -833,7 +836,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(h.WriteBatch(ctx, service.MessageBatch{bad})).To(Succeed())
 		Expect(h.CountValueRows(ctx, "drops")).To(Equal(0))
 		Expect(logs()).To(ContainSubstring("reason=missing_value_or_timestamp"), "the per-drop log must name the reason")
-		Expect(logs()).To(ContainSubstring("dropped all 1 message(s)"), "a 100%-dropped non-empty batch for a real fault must warn (degraded, not silent)")
+		Expect(logs()).To(ContainSubstring("level=warning msg=TimescaleDB historian: dropped all 1 message(s)"), "a 100%-dropped non-empty batch for a real fault must warn (not silent)")
 		Expect(logs()).To(ContainSubstring("Check the source data and metadata configuration"))
 	})
 

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -136,7 +136,7 @@ AS $fn$
 $fn$;
 -- ===================== MIGRATIONS =====================
 -- Forward-only, run-once steps applied after the baseline; each is ledger-gated and runs inside
--- the bootstrap advisory lock, so an older bridge sharing the database can never revert a newer one.
+-- the bootstrap advisory lock, so an older instance sharing the database can never revert a newer one.
 MIGRATIONS_SLOT
 -- ======================================================
 COMMIT;`


### PR DESCRIPTION
## What

A TimescaleDB historian stores exactly one data contract but usually reads from a broader UNS subscription, so it drops messages for other contracts by design. How those drops were logged caused two problems:

1. A fully-dropped batch was logged with `Warnf`, which umh-core can treat as unhealthy, so a historian that received an all-other-contract batch reported degraded even though nothing was wrong.
2. Even once that was quieted, the logs could not separate two very different situations:
   - Wrong `data_contract_name` or subscription: nothing is ever stored (broken).
   - Over-broad subscription: the contract is stored, alongside expected drops (fine).

"Is any data reaching the historian at all?" is a cumulative question and could not be answered from any single batch.

## Change

Logging now keys on whether a value row for the configured contract has ever been stored:

- First successful store: info, once. `first message stored for data contract _<contract>`.
- Receiving data but nothing stored yet, and a batch is entirely other-contract: info, once. `nothing stored for data contract _<contract> yet; the last N message(s) were all for other contracts. Check data_contract_name and the topics this flow subscribes to`.
- Entirely-other-contract batch after data has flowed: debug (an expected lull).
- Genuine fault (matching contract, missing or unusable value, write failure): warn, unchanged.

Every contract-mismatch path is info or debug, so the bridge stays healthy; only genuine faults warn. Messages and comments use standalone benthos-umh wording, since this output can run outside umh-core.

## Behavior for the two cases

- Wrong contract: only `nothing stored for _<contract> yet` appears. No data is landing, and the message names the two things to check.
- Over-broad subscription: `first message stored` appears once, then other-contract batches are quiet. Data is confirmed flowing.

## Tests

Integration specs against a live TimescaleDB container cover:

- never stored: `nothing stored ... yet` logged once at info, no warning or error;
- stored, then an other-contract-only batch: `first message stored` once, no starving notice, no warning;
- genuine fault: still warns.

The test log capture records benthos's `level=... msg=...` format, so the specs assert severity, not only message text.

## Note

A contract mismatch, including a `data_contract_name` typo that matches nothing, is logged at info and never marks the bridge degraded. This is deliberate: the case stays visible in the logs without turning a bridge red.

Closes ENG-5394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

