### PR TITLE
fix: tag_processor string conversion without number

### DIFF
--- a/.changelog/unreleased/fixes-20260723-120000.yaml
+++ b/.changelog/unreleased/fixes-20260723-120000.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: The tag processor no longer converts numeric-looking string values to numbers; a string read from the source stays a string in the UNS, and msg.meta.datatype = "number" remains available for explicit coercion (ENG-5422)
+time: 2026-07-23T17:31:13+02:00

--- a/docs/processing/tag-processor.md
+++ b/docs/processing/tag-processor.md
@@ -121,6 +121,7 @@ This consistent formatting ensures that:
 - Simple types (numbers, strings, booleans) are preserved as-is
 - Complex types (arrays, objects) are converted to JSON string representations
 - Numbers are always preserved as numeric types (integers or floats)
+- Numeric-looking strings (e.g., `"2340925"`) stay strings and keep their exact digits; set `msg.meta.datatype = "number"` to convert them explicitly
 
 > **Breaking change in v4.0.0**: Arrays now serialize to JSON format `["a","b","c"]` instead of space-separated format `[a b c]`. This preserves type information and enables array parsing in downstream processors.
 
@@ -269,7 +270,7 @@ The processor uses the following metadata fields:
 **Optional Fields:**
 
 - `virtual_path`: Logical, non-physical grouping path in dot notation (e.g., "axis.x.position")
-- `datatype`: Forces the output value type (`"string"`, `"number"`, or `"bool"`) instead of auto-detection. Set to `"string"` to keep numeric-looking strings (e.g., serial codes) from being converted to lossy numbers
+- `datatype`: Forces the output value type (`"string"`, `"number"`, or `"bool"`) instead of auto-detection. Set to `"number"` to convert a numeric string (e.g., `"42"`) into a number; without it, a string value always stays a string
 
 **Generated Fields:**
 

--- a/tag_processor_plugin/conversion_test.go
+++ b/tag_processor_plugin/conversion_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tag_processor_plugin
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable("convertValue datatype handling",
+	func(input any, datatype string, want any, wantErr bool) {
+		p := &TagProcessor{}
+		got, err := p.convertValue(input, datatype)
+		if wantErr {
+			Expect(err).To(HaveOccurred())
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal(want))
+	},
+
+	// auto-detect (no msg.meta.datatype set)
+	Entry("bool passes through", true, "", true, false),
+	Entry("float to json.Number", 23.5, "", json.Number("23.5"), false),
+	Entry("int to json.Number", 42, "", json.Number("42"), false),
+	Entry("non-numeric string stays string", "hello", "", "hello", false),
+	Entry("numeric string stays string", "2340925", "", "2340925", false),
+	Entry("float-string stays string", "23.5", "", "23.5", false),
+	Entry("large-int string stays exact", "12345678901234567890", "", "12345678901234567890", false),
+	Entry("array to JSON string", []any{1, 2}, "", "[1,2]", false),
+	Entry("object to JSON string", map[string]any{"a": 1}, "", `{"a":1}`, false),
+
+	// explicit msg.meta.datatype override
+	Entry("datatype number coerces numeric string", "42", "number", json.Number("42"), false),
+	Entry("datatype number keeps digits exact", "2340925", "number", json.Number("2340925"), false),
+	Entry("datatype number rejects non-numeric string", "abc", "number", nil, true),
+	Entry("datatype string forces number to string", 42, "string", "42", false),
+	Entry("datatype string keeps numeric string", "2340925", "string", "2340925", false),
+	Entry("datatype bool coerces string", "true", "bool", true, false),
+	Entry("datatype bool rejects non-bool string", "yes", "bool", nil, true),
+)

--- a/tag_processor_plugin/tag_processor_plugin.go
+++ b/tag_processor_plugin/tag_processor_plugin.go
@@ -606,10 +606,6 @@ func (p *TagProcessor) autoConvertValue(v any) any {
 	case bool:
 		return val
 	case string:
-		num, err := strconv.ParseFloat(val, 64)
-		if err == nil {
-			return json.Number(fmt.Sprintf("%v", num))
-		}
 		return val
 	case float64, float32, int, int32, int64, uint, uint32, uint64:
 		return json.Number(fmt.Sprintf("%v", val))
@@ -627,9 +623,9 @@ func (p *TagProcessor) autoConvertValue(v any) any {
 		return string(jsonBytes)
 	default:
 		str := fmt.Sprintf("%v", val)
-		num, err := strconv.ParseFloat(str, 64)
+		_, err := strconv.ParseFloat(str, 64)
 		if err == nil {
-			return json.Number(fmt.Sprintf("%v", num))
+			return json.Number(str)
 		}
 		return str
 	}

--- a/tag_processor_plugin/tag_processor_plugin.go
+++ b/tag_processor_plugin/tag_processor_plugin.go
@@ -70,7 +70,8 @@ Empty or undefined fields will be omitted from the topic.`).
 		Field(service.NewStringField("defaults").
 			Description("JavaScript code to set initial metadata values").
 			Default("")).
-		Field(service.NewObjectListField("conditions",
+		Field(service.NewObjectListField(
+			"conditions",
 			service.NewStringField("if").Description("JavaScript condition expression"),
 			service.NewStringField("then").Description("JavaScript code to execute if condition is true"),
 		).Description("List of conditions to evaluate").
@@ -123,7 +124,8 @@ Empty or undefined fields will be omitted from the topic.`).
 			}
 
 			return newTagProcessor(config, mgr.Logger(), mgr.Metrics())
-		})
+		},
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -624,10 +626,10 @@ func (p *TagProcessor) autoConvertValue(v any) any {
 	default:
 		str := fmt.Sprintf("%v", val)
 		_, err := strconv.ParseFloat(str, 64)
-		if err == nil {
-			return json.Number(str)
+		if err != nil {
+			return str
 		}
-		return str
+		return json.Number(str)
 	}
 }
 
@@ -727,7 +729,8 @@ func (p *TagProcessor) compilePrograms() error {
 		p.conditionPrograms[i], err = goja.Compile(
 			fmt.Sprintf("condition-%d-if.js", i),
 			condition.If,
-			false)
+			false,
+		)
 		if err != nil {
 			return fmt.Errorf("failed to compile condition %d 'if' code: %w", i, err)
 		}
@@ -738,7 +741,8 @@ func (p *TagProcessor) compilePrograms() error {
 		p.conditionThenPrograms[i], err = goja.Compile(
 			fmt.Sprintf("condition-%d-then.js", i),
 			wrappedThenCode,
-			false)
+			false,
+		)
 		if err != nil {
 			return fmt.Errorf("failed to compile condition %d 'then' code: %w", i, err)
 		}
@@ -918,7 +922,8 @@ func (p *TagProcessor) processConditionForMessageWithProgram(ctx context.Context
 			ctx,
 			service.MessageBatch{msg},
 			p.conditionThenPrograms[conditionIndex],
-			"condition-then")
+			"condition-then",
+		)
 		// Return all messages produced by the condition action (could be 0, 1, or multiple)
 		return conditionBatch, "", "", nil
 	}

--- a/tag_processor_plugin/tag_processor_plugin_test.go
+++ b/tag_processor_plugin/tag_processor_plugin_test.go
@@ -1403,7 +1403,8 @@ tag_processor:
 			Expect(err).NotTo(HaveOccurred())
 			Expect(floatValue).To(BeNumerically("==", 23.5))
 
-			// Check float value of string encoded float
+			// Check string encoded float stays a string (no auto-conversion;
+			// use msg.meta.datatype = "number" for explicit coercion)
 			messagesMutex.Lock()
 			msg = messages[4]
 			messagesMutex.Unlock()
@@ -1413,11 +1414,9 @@ tag_processor:
 			Expect(ok).To(BeTrue())
 			value, ok = payload["value"]
 			Expect(ok).To(BeTrue())
-			numValue, ok = value.(json.Number)
+			strValue, ok = value.(string)
 			Expect(ok).To(BeTrue())
-			floatValue, err = numValue.Float64()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(floatValue).To(BeNumerically("==", 23.5))
+			Expect(strValue).To(Equal("23.5"))
 
 			// Check string array value (should be JSON serialized)
 			messagesMutex.Lock()


### PR DESCRIPTION
# Description

When reading data with e.g. `opcua_plugin` via bridges it occured, that without setting `msg.meta.datatype = string` that a number in a string got autoconverted to a number. When in fact this has been a string originally and should end up as a string.

Therefore this PR should fix this issue and not convert any numbers in strings anymore. This way it should then also get rid of the scientific annotation.

As follow-ups we should ensure that our input-plugins also directly support this. Meaning they parse it from the beginning in the correct format. Currently this does not happen for e.g. `s7comm`, `modbus`, `ethernetip`, `sensorconnect`. 

This then is more about aligning, that each plugin works the same.