### PR TITLE
docs: publish the TimescaleDB Historian output reference (ENG-5400)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,4 +26,5 @@
   - [Sparkplug B (Output)](output/sparkplug-b-output.md)
   - [UNS (Output)](output/uns-output.md)
   - [OPC UA (Output)](output/opc-ua-output.md)
+  - [TimescaleDB Historian (Output)](output/historian.md)
   - [More](https://docs.redpanda.com/redpanda-connect/components/outputs/about/)


### PR DESCRIPTION
Adds the TimescaleDB Historian output to `docs/SUMMARY.md`.

The reference page (`docs/output/historian.md`) has existed since ENG-5181 and is linked from `docs/output/README.md`, but it was never listed in `SUMMARY.md`, so GitBook never published it. It is not reachable at docs.umh.app/benthos-umh/output/historian today.

Companion to the umh-core Historian docs ([ENG-5400](https://linear.app/united-manufacturing-hub/issue/ENG-5400)), whose pages deep-link to this reference for the plugin's advanced options, metrics, and the poisoned-tag runbook: united-manufacturing-hub/united-manufacturing-hub#2671

One line, no content changes.

No changelog fragment: the output itself was already announced in v0.14.0, and this only makes its reference page reachable.

## Also unpublished

`docs/output/snowflake-put.md` has the same problem, listed in `output/README.md` but missing from `SUMMARY.md`. Left out of this PR to keep it scoped to ENG-5400; happy to add the line here if you'd prefer one fix over two.
