### PR TITLE
fix: ethernet-ip plugin appears green, but no throughput

### DIFF
--- a/.changelog/unreleased/fixes-20260804-144432.yaml
+++ b/.changelog/unreleased/fixes-20260804-144432.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: The EtherNet/IP input now reconnects after losing the connection to the controller; it previously kept reporting a healthy connection while delivering no data (ENG-5401)
+time: 2026-08-04T14:44:32.439123+02:00

--- a/.changelog/unreleased/fixes-20260804-144433.yaml
+++ b/.changelog/unreleased/fixes-20260804-144433.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: A single unreadable tag or attribute no longer stops the rest of an EtherNet/IP poll; only a poll where nothing at all can be read triggers a reconnect (ENG-5401)
+time: 2026-08-04T14:44:33.656144+02:00

--- a/.changelog/unreleased/fixes-20260804-144559.yaml
+++ b/.changelog/unreleased/fixes-20260804-144559.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: word, dword, uint8 and uint64 values from the EtherNet/IP input are now labelled eip_tag_type number instead of string, and word and dword attributes decode to a number instead of a stringified byte slice; processors that branched on either see different input (ENG-5401)
+time: 2026-08-04T14:45:59.45259+02:00

--- a/.changelog/unreleased/improvements-20260804-144525.yaml
+++ b/.changelog/unreleased/improvements-20260804-144525.yaml
@@ -1,0 +1,3 @@
+kind: improvements
+body: Stopping an EtherNet/IP input no longer waits out the current poll interval (ENG-5401)
+time: 2026-08-04T14:45:25.976637+02:00

--- a/.changelog/unreleased/improvements-20260804-144527.yaml
+++ b/.changelog/unreleased/improvements-20260804-144527.yaml
@@ -1,0 +1,3 @@
+kind: improvements
+body: Connection and session diagnostics from the EtherNet/IP protocol library now surface in the input logs, including failures it previously swallowed (ENG-5401)
+time: 2026-08-04T14:45:27.206865+02:00

--- a/eip_plugin/eip_test.go
+++ b/eip_plugin/eip_test.go
@@ -17,6 +17,7 @@ package eip_plugin_test
 import (
 	"context"
 	"reflect"
+	"unsafe"
 
 	"github.com/danomagnum/gologix"
 	. "github.com/onsi/ginkgo/v2"
@@ -295,14 +296,16 @@ func GetUnderlyingEIPInputForTest(bi service.BatchInput) *EIPInput {
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
-	field := v.FieldByName("wrapped")
+	// the wrapped input sits in an unexported field, hence the unsafe read
+	field := v.FieldByName("child")
 	if !field.IsValid() {
 		return nil
 	}
-	// Assert that the underlying type is *EIPInput.
-	wrapped := field.Interface()
+
+	wrapped := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface()
 	if eip, ok := wrapped.(*EIPInput); ok {
 		return eip
 	}
+
 	return nil
 }

--- a/eip_plugin/errors.go
+++ b/eip_plugin/errors.go
@@ -16,17 +16,15 @@ package eip_plugin
 
 import (
 	"errors"
-	"io"
 	"net"
 	"os"
 	"syscall"
 )
 
-// gologix-library wraps around these errors
+// gologix-library wraps around these errors. io.EOF and io.ErrUnexpectedEOF are
+// deliberately absent: the same values come back from parsing a reply buffer.
 var transportErrors = []error{
 	os.ErrDeadlineExceeded,
-	io.EOF,
-	io.ErrUnexpectedEOF,
 	net.ErrClosed,
 	syscall.ECONNRESET,
 	syscall.ECONNREFUSED,

--- a/eip_plugin/errors.go
+++ b/eip_plugin/errors.go
@@ -14,16 +14,40 @@
 
 package eip_plugin
 
-import "github.com/danomagnum/gologix"
+import (
+	"errors"
+	"io"
+	"net"
+	"os"
+	"syscall"
+)
 
-// NOTE: Abstraction for the CIP calls so we can potentially mock them
-// possibly add some more calls here later on. The gologix.Client implements this
-// interface for our main functionality.
-type CIPReader interface {
-	Connect() error
-	Disconnect() error
-	// needed because gologix rejects calls that do not match its connection state
-	Connected() bool
-	Read(tag string, data any) error
-	GetAttrSingle(cls gologix.CIPClass, inst gologix.CIPInstance, attr gologix.CIPAttribute) (*gologix.CIPItem, error)
+// gologix-library wraps around these errors
+var transportErrors = []error{
+	os.ErrDeadlineExceeded,
+	io.EOF,
+	io.ErrUnexpectedEOF,
+	net.ErrClosed,
+	syscall.ECONNRESET,
+	syscall.ECONNREFUSED,
+	syscall.ECONNABORTED,
+	syscall.EPIPE,
+	syscall.ETIMEDOUT,
+	syscall.EHOSTUNREACH,
+	syscall.ENETUNREACH,
+}
+
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	for _, transErr := range transportErrors {
+		if errors.Is(err, transErr) {
+			return true
+		}
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }

--- a/eip_plugin/ethernetip.go
+++ b/eip_plugin/ethernetip.go
@@ -303,9 +303,14 @@ func (g *EIPInput) ReadBatch(ctx context.Context) (service.MessageBatch, service
 	failed := 0
 
 	for _, item := range g.Items {
+		err := ctx.Err()
+		if err != nil {
+			return nil, nil, err
+		}
+
 		dataAsString, err := g.readTagsOrAttributes(item)
 		if err != nil {
-			if isTransportError(err) {
+			if !g.CIP.Connected() || isTransportError(err) {
 				g.Log.Errorf("Lost connection to EIP controller: %v", err)
 				g.disconnect()
 

--- a/eip_plugin/ethernetip.go
+++ b/eip_plugin/ethernetip.go
@@ -333,18 +333,33 @@ func (g *EIPInput) ReadBatch(ctx context.Context) (service.MessageBatch, service
 		g.Log.Errorf("None of the %d configured items could be read, requesting reconnect", failed)
 		g.disconnect()
 
+		err := g.pause(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
 		return nil, nil, service.ErrNotConnected
 	}
 
-	select {
-	case <-ctx.Done():
-		return nil, nil, ctx.Err()
-	case <-time.After(g.PollRate):
+	err := g.pause(ctx)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return msgs, func(_ context.Context, _ error) error {
 		return nil
 	}, nil
+}
+
+// pause spaces out polls without holding a shutdown for the whole interval
+func (g *EIPInput) pause(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(g.PollRate):
+	}
+
+	return nil
 }
 
 func (g *EIPInput) disconnect() {

--- a/eip_plugin/ethernetip.go
+++ b/eip_plugin/ethernetip.go
@@ -17,7 +17,6 @@ package eip_plugin
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/danomagnum/gologix"
@@ -75,6 +74,15 @@ type CIPReadItem struct {
 
 	// needed to transform data into given type
 	ConverterFunc func(*gologix.CIPItem) (any, error)
+}
+
+// attributes carry no tag name, so per-item logs need this
+func (i *CIPReadItem) name() string {
+	if i.IsAttribute {
+		return i.AttributeName
+	}
+
+	return i.TagName
 }
 
 var EthernetIPConfigSpec = service.NewConfigSpec().
@@ -189,32 +197,38 @@ func init() {
 		"ethernetip", EthernetIPConfigSpec,
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
 			return NewEthernetIPInput(conf, mgr)
-		})
+		},
+	)
 	if err != nil {
 		panic(err)
 	}
 }
 
+// keep-alive stays off because the poll loop already holds the session open
+func (g *EIPInput) newCIPClient() *gologix.Client {
+	return &gologix.Client{
+		Controller:         *g.Controller,
+		VendorId:           vendorIdDefault,
+		ConnectionSize:     connSizeLargeDefault,
+		AutoConnect:        true,
+		KeepAliveAutoStart: false,
+		KeepAliveFrequency: keepAliveFreq,
+		KeepAliveProps:     []gologix.CIPAttribute{1, 2, 3, 4, 10},
+		// this is the Request Packet Interval
+		RPI:           g.PollRate,
+		SocketTimeout: socketTimeoutDefault,
+		KnownTags:     make(map[string]gologix.KnownTag),
+		Logger:        cipLogger{log: g.Log},
+	}
+}
+
 func (g *EIPInput) Connect(_ context.Context) error {
 	if g.CIP == nil {
-		g.CIP = &gologix.Client{
-			Controller:         *g.Controller,
-			VendorId:           vendorIdDefault,
-			ConnectionSize:     connSizeLargeDefault,
-			AutoConnect:        true,
-			KeepAliveAutoStart: false,
-			KeepAliveFrequency: keepAliveFreq,
-			KeepAliveProps:     []gologix.CIPAttribute{1, 2, 3, 4, 10},
-			// this is the Request Packet Interval
-			RPI:           g.PollRate,
-			SocketTimeout: socketTimeoutDefault,
-			KnownTags:     make(map[string]gologix.KnownTag),
-			// NOTE:
-			// we only want to use our logs not the gologix-logs here
-			Logger: slog.New(slog.DiscardHandler),
-			// but for now we want to see some logs here:
-			// Logger: slog.Default(),
-		}
+		g.CIP = g.newCIPClient()
+	}
+
+	if g.CIP.Connected() {
+		return nil
 	}
 
 	err := g.CIP.Connect()
@@ -272,12 +286,7 @@ func (g *EIPInput) logDeviceProperties() error {
 	if err != nil {
 		return err
 	}
-	deviceNameBytes, err := productNameAttr.Bytes()
-	if err != nil {
-		return err
-	}
-
-	deviceName := string(deviceNameBytes)
+	deviceName := decodeCIPString(attributePayload(productNameAttr))
 
 	g.Log.Infof("EIP Device Information:")
 	g.Log.Infof("    Device Name: %s", deviceName)
@@ -289,44 +298,63 @@ func (g *EIPInput) logDeviceProperties() error {
 	return nil
 }
 
-func (g *EIPInput) ReadBatch(_ context.Context) (service.MessageBatch, service.AckFunc, error) {
+func (g *EIPInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
 	var msgs service.MessageBatch
+	failed := 0
 
 	for _, item := range g.Items {
-		// read either tags or attributes
 		dataAsString, err := g.readTagsOrAttributes(item)
 		if err != nil {
-			// service.ErrNotconnected
-			return nil, nil, err
+			if isTransportError(err) {
+				g.Log.Errorf("Lost connection to EIP controller: %v", err)
+				g.disconnect()
+
+				return nil, nil, service.ErrNotConnected
+			}
+
+			g.Log.Warnf("Skipping %s: %v", item.name(), err)
+			failed++
+			continue
 		}
 
 		// convert the dataAsString into bytes
 		dataAsBytes := []byte(dataAsString)
 
-		msg, err := CreateMessageFromValue(dataAsBytes, item)
-		if err != nil {
-			// service.ErrNotconnected
-			return nil, nil, err
-		}
-
 		// append the new message to the msgs slice
-		msgs = append(msgs, msg)
+		msgs = append(msgs, CreateMessageFromValue(dataAsBytes, item))
 	}
 
-	// not sure if we could just set a global "pollRate" for the plc
-	time.Sleep(g.PollRate)
+	if len(msgs) == 0 && failed > 0 {
+		g.Log.Errorf("None of the %d configured items could be read, requesting reconnect", failed)
+		g.disconnect()
+
+		return nil, nil, service.ErrNotConnected
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case <-time.After(g.PollRate):
+	}
 
 	return msgs, func(_ context.Context, _ error) error {
-		// for now
 		return nil
 	}, nil
 }
 
-func (g *EIPInput) Close(_ context.Context) error {
+func (g *EIPInput) disconnect() {
+	if g.CIP == nil || !g.CIP.Connected() {
+		return
+	}
+
 	err := g.CIP.Disconnect()
 	if err != nil {
-		return err
+		g.Log.Debugf("Disconnect failed: %v", err)
 	}
+}
+
+func (g *EIPInput) Close(_ context.Context) error {
+	g.disconnect()
 
 	return nil
 }

--- a/eip_plugin/helper.go
+++ b/eip_plugin/helper.go
@@ -16,6 +16,7 @@ package eip_plugin
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"net"
@@ -239,6 +240,37 @@ func parseCIPTypeFromString(datatype string) (gologix.CIPType, error) {
 	}
 }
 
+// CIPItem.Bytes() marshals the item back out, header included, so it cannot read a payload.
+func attributePayload(item *gologix.CIPItem) []byte {
+	if item.Pos >= len(item.Data) {
+		return nil
+	}
+
+	return item.Data[item.Pos:]
+}
+
+// controllers disagree on string framing: a 1 byte length, a 4 byte length, or none.
+func decodeCIPString(payload []byte) string {
+	trimmed := bytes.TrimRight(payload, "\x00")
+	if len(trimmed) == 0 {
+		return ""
+	}
+
+	shortLen := int(trimmed[0])
+	if shortLen == len(trimmed)-1 {
+		return string(trimmed[1:])
+	}
+
+	if len(trimmed) > 4 {
+		longLen := int(binary.LittleEndian.Uint32(trimmed[:4]))
+		if longLen == len(trimmed)-4 {
+			return string(trimmed[4:])
+		}
+	}
+
+	return string(trimmed)
+}
+
 // buildConverterFunc is used to build the function, which is needed to convert
 // the values into the correct datatype
 // only used for attributes
@@ -264,7 +296,7 @@ func buildConverterFunc(datatype string) (func(*gologix.CIPItem) (any, error), e
 		}, nil
 	case "word":
 		return func(item *gologix.CIPItem) (any, error) {
-			val, err := item.Bytes()
+			val, err := item.Uint16()
 			if err != nil {
 				return nil, err
 			}
@@ -272,7 +304,7 @@ func buildConverterFunc(datatype string) (func(*gologix.CIPItem) (any, error), e
 		}, nil
 	case "dword":
 		return func(item *gologix.CIPItem) (any, error) {
-			val, err := item.Bytes()
+			val, err := item.Uint32()
 			if err != nil {
 				return nil, err
 			}
@@ -345,20 +377,11 @@ func buildConverterFunc(datatype string) (func(*gologix.CIPItem) (any, error), e
 		}, nil
 	case "string":
 		return func(item *gologix.CIPItem) (any, error) {
-			val, err := item.Bytes()
-			if err != nil {
-				return nil, err
-			}
-			return string(val), nil
+			return decodeCIPString(attributePayload(item)), nil
 		}, nil
 	case "array of octed":
 		return func(item *gologix.CIPItem) (any, error) {
-			val, err := item.Bytes()
-			if err != nil {
-				return nil, err
-			}
-
-			return val, nil
+			return attributePayload(item), nil
 		}, nil
 	default:
 		return nil, fmt.Errorf("Failed to build converterFunc, unsupported datatype: %s", datatype)

--- a/eip_plugin/logging.go
+++ b/eip_plugin/logging.go
@@ -1,0 +1,28 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eip_plugin
+
+import "github.com/redpanda-data/benthos/v4/public/service"
+
+// cipLogger surfaces the failures gologix logs but never returns.
+type cipLogger struct {
+	log *service.Logger
+}
+
+// demoted to warn because these errors also come back to us and are logged there
+func (l cipLogger) Error(msg string, args ...any) { l.log.Warnf("gologix: %s %v", msg, args) }
+func (l cipLogger) Warn(msg string, args ...any)  { l.log.Warnf("gologix: %s %v", msg, args) }
+func (l cipLogger) Info(msg string, args ...any)  { l.log.Debugf("gologix: %s %v", msg, args) }
+func (l cipLogger) Debug(msg string, args ...any) { l.log.Debugf("gologix: %s %v", msg, args) }

--- a/eip_plugin/mockreader_test.go
+++ b/eip_plugin/mockreader_test.go
@@ -15,6 +15,7 @@
 package eip_plugin_test
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/danomagnum/gologix"
@@ -22,21 +23,33 @@ import (
 
 // MockCIPReader implements CIPReader and stores tagName -> value
 type MockCIPReader struct {
-	Connected bool
-	Tags      map[string]any
+	IsConnected bool
+	Tags        map[string]any
 
 	// let's ignore this for now
 	Attrs map[[3]uint16]*gologix.CIPItem
 }
 
+// Connect mirrors gologix v0.35.1-beta, which rejects a connect on a client that
+// is not disconnected instead of returning nil.
 func (m *MockCIPReader) Connect() error {
-	m.Connected = true
+	if m.IsConnected {
+		return errors.New("already connected")
+	}
+	m.IsConnected = true
 	return nil
 }
 
 func (m *MockCIPReader) Disconnect() error {
-	m.Connected = false
+	if !m.IsConnected {
+		return errors.New("client is already disconnected")
+	}
+	m.IsConnected = false
 	return nil
+}
+
+func (m *MockCIPReader) Connected() bool {
+	return m.IsConnected
 }
 
 func (m *MockCIPReader) Read(tag string, data any) error {

--- a/eip_plugin/read.go
+++ b/eip_plugin/read.go
@@ -305,13 +305,14 @@ func parseTagsIntoMap(items []*CIPReadItem) (map[string]any, error) {
 
 // CreateMessageFromValue is used to set the metadata for the eip-tags and
 // create the message from the rawValue which is read from the tags/attributes
-func CreateMessageFromValue(rawValue []byte, item *CIPReadItem) (*service.Message, error) {
+func CreateMessageFromValue(rawValue []byte, item *CIPReadItem) *service.Message {
 	var tagType string
 	switch item.CIPDatatype {
 	case gologix.CIPTypeBOOL:
 		tagType = "bool"
-	case gologix.CIPTypeBYTE, gologix.CIPTypeSINT, gologix.CIPTypeUINT, gologix.CIPTypeINT,
-		gologix.CIPTypeUDINT, gologix.CIPTypeDINT, gologix.CIPTypeLWORD, gologix.CIPTypeLINT,
+	case gologix.CIPTypeBYTE, gologix.CIPTypeWORD, gologix.CIPTypeDWORD, gologix.CIPTypeLWORD,
+		gologix.CIPTypeSINT, gologix.CIPTypeINT, gologix.CIPTypeDINT, gologix.CIPTypeLINT,
+		gologix.CIPTypeUSINT, gologix.CIPTypeUINT, gologix.CIPTypeUDINT, gologix.CIPTypeULINT,
 		gologix.CIPTypeREAL, gologix.CIPTypeLREAL:
 		tagType = "number"
 	default:
@@ -319,19 +320,16 @@ func CreateMessageFromValue(rawValue []byte, item *CIPReadItem) (*service.Messag
 	}
 
 	msg := service.NewMessage(rawValue)
-	msg.MetaSetMut("eip_tag_name", item.TagName) // tag name
-	msg.MetaSetMut("eip_tag_type", tagType)      // data type - number, bool, or string
-	msg.MetaSetMut("eip_tag_path", item.TagName) // tag path - usually something like `Program:Gologix_Tests.ReadTest`
-
-	if item.IsAttribute {
-		msg.MetaSetMut("eip_tag_name", item.AttributeName) // replace tag name by attribute name
-	}
+	msg.MetaSetMut("eip_tag_name", item.name())
+	msg.MetaSetMut("eip_tag_type", tagType)
+	// the alias may rename the tag below, the path keeps where the value came from
+	msg.MetaSetMut("eip_tag_path", item.name())
 
 	if item.Alias != "" {
 		msg.MetaSet("eip_tag_name", item.Alias) // replace tag name by alias if provided
 	}
 
-	return msg, nil
+	return msg
 }
 
 // readAndConvertAttribute is used to read data from attributes and then use
@@ -339,9 +337,9 @@ func CreateMessageFromValue(rawValue []byte, item *CIPReadItem) (*service.Messag
 func (g *EIPInput) readAndConvertAttribute(item *CIPReadItem) (string, error) {
 	resp, err := g.CIP.GetAttrSingle(item.CIPClass, item.CIPInstance, item.CIPAttribute)
 	if err != nil {
-		g.Log.Errorf("failed to get attribute - class %v, instance %v, attribute %v, err: %v",
+		// %w keeps the socket error reachable for isTransportError
+		return "", fmt.Errorf("failed to get attribute - class %v, instance %v, attribute %v: %w",
 			item.CIPClass, item.CIPInstance, item.CIPAttribute, err)
-		return "", err
 	}
 
 	// convert the CIPItem into the corresponding data

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/RuneRoven/benthosSMTP v0.0.1
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cespare/xxhash/v2 v2.3.0
-	github.com/danomagnum/gologix v0.27.2-beta
+	github.com/danomagnum/gologix v0.35.1-beta
 	github.com/dop251/goja v0.0.0-20260723142020-b4aef50fa347
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/gofrs/uuid/v5 v5.4.0

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
-github.com/danomagnum/gologix v0.27.2-beta h1:j0lFcAUY70InT7u7ys91TGu96SU/gRMt2lqOD5ra390=
-github.com/danomagnum/gologix v0.27.2-beta/go.mod h1:a0mVZ0+1vBg6R56BLSk68iO9XQGHyqEkyh33OCCIr9k=
+github.com/danomagnum/gologix v0.35.1-beta h1:h5pktnSTg492N8/g3mZsAWLw51BUg32zV5J0l3VeOhs=
+github.com/danomagnum/gologix v0.35.1-beta/go.mod h1:a0mVZ0+1vBg6R56BLSk68iO9XQGHyqEkyh33OCCIr9k=
 github.com/databricks/databricks-sql-go v1.10.0 h1:U17EKVC+hLP87swFMe2N6UUVektwUgTvT2pMDaDc46g=
 github.com/databricks/databricks-sql-go v1.10.0/go.mod h1:qC010ucrtqrNXY2UOcoczbfPD4gJ1jr1y6TL7iqyxPk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
# Description

As recently found out the ethernet/ip-plugin was appearing as working correctly, but without any data throughput. There are a couple of potential reasons for this e.g. connection-loss, issues when reading data, potential deadlocks and so on.

Therefore we try to surface most of it here within benthos-umh. Meaning this here introduces:
- reconnection on read-fails
- disconnect on ctx-cancellation
- additional logging from underlying library
- updated lib-version
- fixed attribute values for `word, dword, uint8, uint64`