### PR TITLE
Recognise two-part data contract version suffixes (ENG-5500)

### DIFF
--- a/.changelog/unreleased/fixes-20260805-090022.yaml
+++ b/.changelog/unreleased/fixes-20260805-090022.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: UNS schema validation now reports a two-part data contract version (e.g. v1_1) in full instead of showing only the major version in the validation failure message (ENG-5500)
+time: 2026-08-05T09:00:22.261398+02:00

--- a/.changelog/unreleased/fixes-20260805-090808.yaml
+++ b/.changelog/unreleased/fixes-20260805-090808.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: Data contracts with a two-part version suffix (_pump_v1_1) are now recognised by the Historian output and the UNS schema validator. Previously the Historian dropped every message for such a contract and the validator treated it as unversioned, skipping schema checks entirely. (ENG-5500)
+time: 2026-08-05T09:08:08.270723+02:00

--- a/.changelog/unreleased/fixes-20260805-182815.yaml
+++ b/.changelog/unreleased/fixes-20260805-182815.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: UNS output now includes the minor version in the data_contract_version metadata for a two-part data contract (e.g. 1_1 for _pump_v1_1) instead of reporting the major version alone (ENG-5500)
+time: 2026-08-05T18:28:15.772987+02:00

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -592,6 +592,41 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(ok).To(BeFalse())
 	})
 
+	It("resolves a versioned contract name to the same topic as the bare name via get_topic_id (P12: Go/SQL regex parity)", func() {
+		h := connected("pump")
+		defer h.Close(ctx)
+		Expect(h.WriteBatch(ctx, service.MessageBatch{mkMsg(1.0, 1000, "_pump_v1", "acme.line1", "t", nil)})).To(Succeed())
+
+		idBare, ok := h.GetTopicID(ctx, "acme.line1", "vibration", "pump", "t")
+		Expect(ok).To(BeTrue())
+
+		for _, versioned := range []string{"pump_v1", "pump_v1_1", "pump_v10_3"} {
+			idVersioned, ok := h.GetTopicID(ctx, "acme.line1", "vibration", versioned, "t")
+			Expect(ok).To(BeTrue(), "versioned contract %q must resolve", versioned)
+			Expect(idVersioned).To(Equal(idBare), "versioned contract %q must resolve to the same topic as the bare name", versioned)
+			Expect(tsh.NormalizeContract(versioned)).To(Equal(tsh.NormalizeContract("pump")), "Go NormalizeContract must agree with the SQL resolution for %q", versioned)
+		}
+	})
+
+	It("strips only the literal _v suffix, not a digit run in the model name (P12)", func() {
+		h := connected("line_2")
+		defer h.Close(ctx)
+		Expect(h.WriteBatch(ctx, service.MessageBatch{mkMsg(1.0, 1000, "_line_2_v1_1", "acme.line1", "t", nil)})).To(Succeed())
+
+		idBare, ok := h.GetTopicID(ctx, "acme.line1", "vibration", "line_2", "t")
+		Expect(ok).To(BeTrue())
+
+		idVersioned, ok := h.GetTopicID(ctx, "acme.line1", "vibration", "line_2_v1_1", "t")
+		Expect(ok).To(BeTrue())
+		Expect(idVersioned).To(Equal(idBare), "line_2_v1_1 must resolve to the same topic as line_2")
+		Expect(tsh.NormalizeContract("line_2_v1_1")).To(Equal(tsh.NormalizeContract("line_2")))
+
+		// A regex that latches onto any trailing digit run rather than the literal "_v" would
+		// wrongly strip "_2_v1_1" down to "line". Assert that lookup does NOT match.
+		_, ok = h.GetTopicID(ctx, "acme.line1", "vibration", "line", "t")
+		Expect(ok).To(BeFalse(), "line_2_v1_1 must not resolve against the unrelated bare name line")
+	})
+
 	It("drops a different value at the same (topic_id, ts) as poison", func() {
 		h := connected("conf")
 		defer h.Close(ctx)

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -130,7 +130,7 @@ AS $fn$
     JOIN umh.tag   g ON g.virtual_path = p_virtual_path
                 AND g.name = p_tag_name
                 AND g.data_contract_name =
-                    '_' || regexp_replace(regexp_replace(p_data_contract, '_v\d+$', ''), '^_', '')
+                    '_' || regexp_replace(regexp_replace(p_data_contract, '_v\d+(_\d+)?$', ''), '^_', '')
     JOIN umh.topic t ON t.location_id = l.location_id AND t.tag_id = g.tag_id
    WHERE l.path = umh.to_ltree_path(p_location_path);
 $fn$;

--- a/historian_plugin/transform.go
+++ b/historian_plugin/transform.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	reVersionSuffix = regexp.MustCompile(`_v\d+$`)
+	reVersionSuffix = regexp.MustCompile(`_v\d+(_\d+)?$`)
 	reContract      = regexp.MustCompile(`^[a-z0-9_]+$`)
 	reNonLtreeLabel = regexp.MustCompile(`[^A-Za-z0-9_-]`)
 )
@@ -63,13 +63,13 @@ func CanonicalLtreePath(loc string) string {
 	return strings.Join(out, ".")
 }
 
-// NormalizeContract strips a trailing _vN (all versions share one table).
+// NormalizeContract strips a trailing _vN or _vN_M (all versions share one table).
 func NormalizeContract(metaContract string) string {
 	return reVersionSuffix.ReplaceAllString(metaContract, "")
 }
 
 // ValidateContract checks that data_contract_name is a bare lowercase name (letters, digits,
-// underscores) with no leading underscore and no _vN version suffix.
+// underscores) with no leading underscore and no version suffix.
 func ValidateContract(c string) error {
 	if !reContract.MatchString(c) {
 		return fmt.Errorf("data_contract_name %q invalid: use a bare lowercase name (letters, digits, underscores), e.g. \"pump\"", c)

--- a/historian_plugin/transform_test.go
+++ b/historian_plugin/transform_test.go
@@ -26,13 +26,18 @@ import (
 )
 
 var _ = Describe("contract helpers", func() {
-	DescribeTable("NormalizeContract strips a trailing _vN",
+	DescribeTable("NormalizeContract strips a trailing _vN or _vN_M",
 		func(in, want string) { Expect(tsh.NormalizeContract(in)).To(Equal(want)) },
 		Entry("plain", "_pump", "_pump"),
 		Entry("v1", "_pump_v1", "_pump"),
 		Entry("v12", "_pump_v12", "_pump"),
 		Entry("bare with version", "pump_v1", "pump"),
 		Entry("empty", "", ""),
+		Entry("two-part", "_pump_v1_1", "_pump"),
+		Entry("two-part multi-digit", "_pump_v10_3", "_pump"),
+		Entry("two-part minor zero", "_pump_v1_0", "_pump"),
+		Entry("model name ending in digits", "_line_2_v1_1", "_line_2"),
+		Entry("idempotent", "_pump", "_pump"),
 	)
 
 	DescribeTable("ValidateContract",
@@ -50,6 +55,7 @@ var _ = Describe("contract helpers", func() {
 		Entry("leading underscore rejected", "_pump", false),
 		Entry("version suffix rejected", "pump_v1", false),
 		Entry("empty rejected", "", false),
+		Entry("two-part version suffix rejected", "pump_v1_1", false),
 	)
 })
 

--- a/uns_plugin/schema_validation/validator.go
+++ b/uns_plugin/schema_validation/validator.go
@@ -56,6 +56,10 @@ type ContractRef struct {
 	Name  string
 	Major uint64
 	Minor uint64
+	// HasMinor reports whether the contract name carried an explicit "_N"
+	// minor segment, distinguishing "_pump_v1" (false) from "_pump_v1_0"
+	// (true, Minor 0).
+	HasMinor bool
 }
 
 // ParseContractRef splits a versioned data contract name into its parts. It
@@ -77,14 +81,15 @@ func ParseContractRef(contract string) (ContractRef, error) {
 	}
 
 	var minor uint64
-	if len(matches) > 3 && matches[3] != "" {
+	hasMinor := len(matches) > 3 && matches[3] != ""
+	if hasMinor {
 		minor, err = strconv.ParseUint(matches[3], 10, 64)
 		if err != nil {
 			return ContractRef{}, fmt.Errorf("invalid version number '%s' in contract '%s': %w", matches[3], contract, err)
 		}
 	}
 
-	return ContractRef{Full: contract, Name: matches[1], Major: major, Minor: minor}, nil
+	return ContractRef{Full: contract, Name: matches[1], Major: major, Minor: minor, HasMinor: hasMinor}, nil
 }
 
 // VersionString renders the version as it appears in a two-part contract name.
@@ -102,10 +107,24 @@ type ValidationResult struct {
 	ContractName string
 	// ContractVersion is the version of the contract that was validated against
 	ContractVersion uint64
+	// ContractMinor is the contract's minor version, and is non-nil only
+	// when the contract name carried an explicit two-part version (e.g.
+	// "_pump_v1_1"). It is nil for a one-part contract like "_pump_v1".
+	ContractMinor *uint64
 	// BypassReason indicates why validation was bypassed (empty if not bypassed)
 	BypassReason string
 	// Error contains the validation error if validation failed
 	Error error
+}
+
+// contractMinorPtr reports ref's minor version for ValidationResult.ContractMinor,
+// or nil when the contract name has no explicit minor segment.
+func contractMinorPtr(ref ContractRef) *uint64 {
+	if !ref.HasMinor {
+		return nil
+	}
+	minor := ref.Minor
+	return &minor
 }
 
 // ContractCacheEntry represents a cached entry for a contract+version combination
@@ -259,6 +278,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 		}
 	}
 	contractName, version := ref.Name, ref.Major
+	minor := contractMinorPtr(ref)
 
 	v.debugf("Validator.Validate: Extracted contractName='%s', version=%s", contractName, ref.VersionString())
 
@@ -271,6 +291,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 			SchemaCheckBypassed: true,
 			ContractName:        contractName,
 			ContractVersion:     version,
+			ContractMinor:       minor,
 			BypassReason:        fmt.Sprintf("failed to fetch schemas: %v", err),
 			Error:               nil,
 		}
@@ -283,6 +304,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 			SchemaCheckBypassed: true,
 			ContractName:        contractName,
 			ContractVersion:     version,
+			ContractMinor:       minor,
 			BypassReason:        fmt.Sprintf("no schemas found for contract '%s' version %s", contractName, ref.VersionString()),
 			Error:               nil,
 		}
@@ -295,6 +317,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 			SchemaCheckBypassed: true,
 			ContractName:        contractName,
 			ContractVersion:     version,
+			ContractMinor:       minor,
 			BypassReason:        fmt.Sprintf("no schemas available for contract '%s' version %s", contractName, ref.VersionString()),
 			Error:               nil,
 		}
@@ -354,6 +377,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 				SchemaCheckBypassed: false,
 				ContractName:        contractName,
 				ContractVersion:     version,
+				ContractMinor:       minor,
 				Error:               nil,
 			}
 		}
@@ -386,6 +410,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 				SchemaCheckBypassed: false,
 				ContractName:        contractName,
 				ContractVersion:     version,
+				ContractMinor:       minor,
 				Error:               mismatch,
 			}
 		}
@@ -398,6 +423,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 		SchemaCheckBypassed: false,
 		ContractName:        contractName,
 		ContractVersion:     version,
+		ContractMinor:       minor,
 		Error:               fmt.Errorf("schema validation failed for contract '%s' version %s against all available schemas. Last error: %w", contractName, ref.VersionString(), lastError),
 	}
 }

--- a/uns_plugin/schema_validation/validator.go
+++ b/uns_plugin/schema_validation/validator.go
@@ -255,12 +255,12 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 	}
 	contractName, version := ref.Name, ref.Major
 
-	v.debugf("Validator.Validate: Extracted contractName='%s', version=%d", contractName, version)
+	v.debugf("Validator.Validate: Extracted contractName='%s', version=%s", contractName, ref.VersionString())
 
 	// Get schemas from cache or fetch synchronously
-	schemas, schemaExists, err := v.getSchemasWithCache(contractName, version)
+	schemas, schemaExists, err := v.getSchemasWithCache(ref)
 	if err != nil {
-		v.debugf("Validator.Validate: Failed to get schemas for %s v%d: %v", contractName, version, err)
+		v.debugf("Validator.Validate: Failed to get schemas for %s %s: %v", contractName, ref.VersionString(), err)
 		return &ValidationResult{
 			SchemaCheckPassed:   false,
 			SchemaCheckBypassed: true,
@@ -272,30 +272,30 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 	}
 
 	if !schemaExists {
-		v.debugf("Validator.Validate: No schemas found for contract '%s' version %d", contractName, version)
+		v.debugf("Validator.Validate: No schemas found for contract '%s' version %s", contractName, ref.VersionString())
 		return &ValidationResult{
 			SchemaCheckPassed:   false,
 			SchemaCheckBypassed: true,
 			ContractName:        contractName,
 			ContractVersion:     version,
-			BypassReason:        fmt.Sprintf("no schemas found for contract '%s' version %d", contractName, version),
+			BypassReason:        fmt.Sprintf("no schemas found for contract '%s' version %s", contractName, ref.VersionString()),
 			Error:               nil,
 		}
 	}
 
 	if len(schemas) == 0 {
-		v.debugf("Validator.Validate: No schemas available for contract '%s' version %d", contractName, version)
+		v.debugf("Validator.Validate: No schemas available for contract '%s' version %s", contractName, ref.VersionString())
 		return &ValidationResult{
 			SchemaCheckPassed:   false,
 			SchemaCheckBypassed: true,
 			ContractName:        contractName,
 			ContractVersion:     version,
-			BypassReason:        fmt.Sprintf("no schemas available for contract '%s' version %d", contractName, version),
+			BypassReason:        fmt.Sprintf("no schemas available for contract '%s' version %s", contractName, ref.VersionString()),
 			Error:               nil,
 		}
 	}
 
-	v.debugf("Validator.Validate: Found %d schemas for contract '%s' version %d", len(schemas), contractName, version)
+	v.debugf("Validator.Validate: Found %d schemas for contract '%s' version %s", len(schemas), contractName, ref.VersionString())
 
 	// Build the full path for validation
 	var fullPath strings.Builder
@@ -373,7 +373,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 
 	// For existing tag, but a different type we want a datatype-mismatch error here
 	if lastError != nil {
-		mismatch := v.datatypeMismatchError(schemas, version, contractName, virtualPath, classifyPayloadType(payload))
+		mismatch := v.datatypeMismatchError(schemas, version, ref.Full, virtualPath, classifyPayloadType(payload))
 		if mismatch != nil {
 			v.debugf("Validator.Validate: datatype mismatch for '%s': %v", virtualPath, mismatch)
 			return &ValidationResult{
@@ -387,7 +387,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 	}
 
 	// None of the schemas matched
-	v.debugf("Validator.Validate: FAILED! No schemas matched for contract '%s' version %d. Last error: %v", contractName, version, lastError)
+	v.debugf("Validator.Validate: FAILED! No schemas matched for contract '%s' version %s. Last error: %v", contractName, ref.VersionString(), lastError)
 	return &ValidationResult{
 		SchemaCheckPassed:   false,
 		SchemaCheckBypassed: false,
@@ -397,9 +397,20 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 	}
 }
 
+// cacheKeyFor keys the compiled-schema cache. Minor 0 reuses the legacy
+// "name-vMAJOR" key so bare "_pump_v1" and explicit "_pump_v1_0" (the same
+// version per the versionKey grammar) share one entry; any other minor gets
+// its own key so it is never served for a different minor of the same major.
+func cacheKeyFor(name string, major uint64, minor uint64) string {
+	if minor == 0 {
+		return fmt.Sprintf("%s-v%d", name, major)
+	}
+	return fmt.Sprintf("%s-v%d_%d", name, major, minor)
+}
+
 // getSchemasWithCache retrieves schemas from cache or fetches them synchronously
-func (v *Validator) getSchemasWithCache(contractName string, version uint64) (map[string]*Schema, bool, error) {
-	cacheKey := fmt.Sprintf("%s-v%d", contractName, version)
+func (v *Validator) getSchemasWithCache(ref ContractRef) (map[string]*Schema, bool, error) {
+	cacheKey := cacheKeyFor(ref.Name, ref.Major, ref.Minor)
 
 	// Check cache first
 	v.cacheMutex.RLock()
@@ -415,7 +426,7 @@ func (v *Validator) getSchemasWithCache(contractName string, version uint64) (ma
 	v.debugf("getSchemasWithCache: CACHE MISS for key='%s', fetching from registry", cacheKey)
 
 	// Cache miss or expired, fetch synchronously
-	return v.fetchSchemasSync(contractName, version)
+	return v.fetchSchemasSync(ref)
 }
 
 // fetchSchemasSync fetches all schemas matching the contract+version pattern synchronously and updates cache
@@ -423,10 +434,10 @@ func (v *Validator) getSchemasWithCache(contractName string, version uint64) (ma
 // This function always fetches the LATEST version of each schema subject rather than trying to map
 // contract versions to registry versions. This simplifies the architecture and avoids version conflicts
 // since schema registry versions are independent of UMH contract versions.
-func (v *Validator) fetchSchemasSync(contractName string, version uint64) (map[string]*Schema, bool, error) {
-	cacheKey := fmt.Sprintf("%s-v%d", contractName, version)
+func (v *Validator) fetchSchemasSync(ref ContractRef) (map[string]*Schema, bool, error) {
+	cacheKey := cacheKeyFor(ref.Name, ref.Major, ref.Minor)
 
-	v.debugf("fetchSchemasSync: Fetching schemas for contractName='%s', version=%d", contractName, version)
+	v.debugf("fetchSchemasSync: Fetching schemas for contract='%s'", ref.Full)
 
 	// Double-check locking pattern
 	v.cacheMutex.Lock()
@@ -454,8 +465,8 @@ func (v *Validator) fetchSchemasSync(contractName string, version uint64) (map[s
 
 	v.debugf("fetchSchemasSync: Found %d subjects in registry", len(subjects))
 
-	// Filter subjects that match our pattern: contractName_v{version}-*
-	schemaPrefix := fmt.Sprintf("%s_v%d-", contractName, version)
+	// Filter subjects that match our pattern: <contract>-*
+	schemaPrefix := ref.Full + "-"
 	var matchingSubjects []string
 	for _, subject := range subjects {
 		if strings.HasPrefix(subject, schemaPrefix) {
@@ -508,7 +519,7 @@ func (v *Validator) fetchSchemasSync(contractName string, version uint64) (map[s
 
 		// Compile the schema
 		schema := NewSchema(subject)
-		if err := schema.AddVersion(version, schemaBytes); err != nil {
+		if err := schema.AddVersion(ref.Major, schemaBytes); err != nil {
 			v.debugf("fetchSchemasSync: Failed to compile schema for subject='%s': %v", subject, err)
 			// Log error but continue with other schemas
 			continue
@@ -518,7 +529,7 @@ func (v *Validator) fetchSchemasSync(contractName string, version uint64) (map[s
 		v.debugf("fetchSchemasSync: Successfully compiled schema for subject='%s'", subject)
 	}
 
-	v.debugf("fetchSchemasSync: Successfully compiled %d schemas for contractName='%s' version %d", len(schemas), contractName, version)
+	v.debugf("fetchSchemasSync: Successfully compiled %d schemas for contract='%s'", len(schemas), ref.Full)
 
 	// Cache the results
 	expiresAt := time.Time{} // Zero time means never expires
@@ -654,7 +665,7 @@ func (v *Validator) LoadSchemas(contractName string, version uint64, schemas map
 		return fmt.Errorf("schemas cannot be empty for contract '%s' version %d", contractName, version)
 	}
 
-	cacheKey := fmt.Sprintf("%s-v%d", contractName, version)
+	cacheKey := cacheKeyFor(contractName, version, 0)
 
 	v.cacheMutex.Lock()
 	defer v.cacheMutex.Unlock()
@@ -695,7 +706,7 @@ func (v *Validator) LoadSchemas(contractName string, version uint64, schemas map
 
 // HasSchema checks if schemas exist for the given contract name and version.
 func (v *Validator) HasSchema(contractName string, version uint64) bool {
-	cacheKey := fmt.Sprintf("%s-v%d", contractName, version)
+	cacheKey := cacheKeyFor(contractName, version, 0)
 
 	v.cacheMutex.RLock()
 	defer v.cacheMutex.RUnlock()
@@ -840,7 +851,7 @@ func classifyPayloadType(payload []byte) string {
 }
 
 // datatypeMismatchError replaces the confusing "path is both valid and invalid" error with a clear got-vs-want line.
-func (v *Validator) datatypeMismatchError(schemas map[string]*Schema, version uint64, contractName string, virtualPath string, payloadType string) error {
+func (v *Validator) datatypeMismatchError(schemas map[string]*Schema, version uint64, contract string, virtualPath string, payloadType string) error {
 	if payloadType == "" {
 		return nil
 	}
@@ -865,8 +876,8 @@ func (v *Validator) datatypeMismatchError(schemas map[string]*Schema, version ui
 	}
 
 	sort.Strings(registered)
-	return fmt.Errorf("datatype mismatch for '%s' in %s_v%d: want %s, got %s",
-		virtualPath, contractName, version, strings.Join(registered, ", "), payloadType)
+	return fmt.Errorf("datatype mismatch for '%s' in %s: want %s, got %s",
+		virtualPath, contract, strings.Join(registered, ", "), payloadType)
 }
 
 // extractValidVirtualPaths extracts valid virtual_path enum values from a JSON schema

--- a/uns_plugin/schema_validation/validator.go
+++ b/uns_plugin/schema_validation/validator.go
@@ -393,24 +393,21 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 		SchemaCheckBypassed: false,
 		ContractName:        contractName,
 		ContractVersion:     version,
-		Error:               fmt.Errorf("schema validation failed for contract '%s' version %d against all available schemas. Last error: %w", contractName, version, lastError),
+		Error:               fmt.Errorf("schema validation failed for contract '%s' version %s against all available schemas. Last error: %w", contractName, ref.VersionString(), lastError),
 	}
 }
 
-// cacheKeyFor keys the compiled-schema cache. Minor 0 reuses the legacy
-// "name-vMAJOR" key so bare "_pump_v1" and explicit "_pump_v1_0" (the same
-// version per the versionKey grammar) share one entry; any other minor gets
-// its own key so it is never served for a different minor of the same major.
-func cacheKeyFor(name string, major uint64, minor uint64) string {
-	if minor == 0 {
-		return fmt.Sprintf("%s-v%d", name, major)
-	}
-	return fmt.Sprintf("%s-v%d_%d", name, major, minor)
+// cacheKeyFor keys the compiled-schema cache on the contract name exactly as
+// it appeared on the topic, so two contracts are never conflated just
+// because ParseContractRef reports the same Minor for both (an absent
+// minor group and an explicit "_0" both parse to Minor 0).
+func cacheKeyFor(contract string) string {
+	return contract
 }
 
 // getSchemasWithCache retrieves schemas from cache or fetches them synchronously
 func (v *Validator) getSchemasWithCache(ref ContractRef) (map[string]*Schema, bool, error) {
-	cacheKey := cacheKeyFor(ref.Name, ref.Major, ref.Minor)
+	cacheKey := cacheKeyFor(ref.Full)
 
 	// Check cache first
 	v.cacheMutex.RLock()
@@ -435,7 +432,7 @@ func (v *Validator) getSchemasWithCache(ref ContractRef) (map[string]*Schema, bo
 // contract versions to registry versions. This simplifies the architecture and avoids version conflicts
 // since schema registry versions are independent of UMH contract versions.
 func (v *Validator) fetchSchemasSync(ref ContractRef) (map[string]*Schema, bool, error) {
-	cacheKey := cacheKeyFor(ref.Name, ref.Major, ref.Minor)
+	cacheKey := cacheKeyFor(ref.Full)
 
 	v.debugf("fetchSchemasSync: Fetching schemas for contract='%s'", ref.Full)
 
@@ -665,7 +662,7 @@ func (v *Validator) LoadSchemas(contractName string, version uint64, schemas map
 		return fmt.Errorf("schemas cannot be empty for contract '%s' version %d", contractName, version)
 	}
 
-	cacheKey := cacheKeyFor(contractName, version, 0)
+	cacheKey := cacheKeyFor(fmt.Sprintf("%s_v%d", contractName, version))
 
 	v.cacheMutex.Lock()
 	defer v.cacheMutex.Unlock()
@@ -706,7 +703,7 @@ func (v *Validator) LoadSchemas(contractName string, version uint64, schemas map
 
 // HasSchema checks if schemas exist for the given contract name and version.
 func (v *Validator) HasSchema(contractName string, version uint64) bool {
-	cacheKey := cacheKeyFor(contractName, version, 0)
+	cacheKey := cacheKeyFor(fmt.Sprintf("%s_v%d", contractName, version))
 
 	v.cacheMutex.RLock()
 	defer v.cacheMutex.RUnlock()

--- a/uns_plugin/schema_validation/validator.go
+++ b/uns_plugin/schema_validation/validator.go
@@ -40,8 +40,52 @@ const (
 )
 
 // schemaVersionRegex matches data contract names with version suffixes.
-// Expected format: "contractname_v123" where 123 is the version number.
-var schemaVersionRegex = regexp.MustCompile(`^(.+)_v(\d+)$`)
+// Expected format: "contractname_v123" or "contractname_v123_4".
+var schemaVersionRegex = regexp.MustCompile(`^(.+)_v(\d+)(?:_(\d+))?$`)
+
+// ContractRef is a data contract name decomposed into its parts. Full is the
+// name as it appeared on the topic and is what keys the schema cache and
+// prefixes the registry subject lookup.
+type ContractRef struct {
+	Full  string
+	Name  string
+	Major uint64
+	Minor uint64
+}
+
+// ParseContractRef splits a versioned data contract name into its parts. It
+// returns an error for an unversioned contract, which the caller treats as
+// "no schema to check".
+func ParseContractRef(contract string) (ContractRef, error) {
+	if contract == "" {
+		return ContractRef{}, fmt.Errorf("contract string is empty")
+	}
+
+	matches := schemaVersionRegex.FindStringSubmatch(contract)
+	if len(matches) < 3 {
+		return ContractRef{}, fmt.Errorf("invalid data contract format '%s', expected 'name_v1' or 'name_v1_2'", contract)
+	}
+
+	major, err := strconv.ParseUint(matches[2], 10, 64)
+	if err != nil {
+		return ContractRef{}, fmt.Errorf("invalid version number '%s' in contract '%s': %w", matches[2], contract, err)
+	}
+
+	var minor uint64
+	if len(matches) > 3 && matches[3] != "" {
+		minor, err = strconv.ParseUint(matches[3], 10, 64)
+		if err != nil {
+			return ContractRef{}, fmt.Errorf("invalid version number '%s' in contract '%s': %w", matches[3], contract, err)
+		}
+	}
+
+	return ContractRef{Full: contract, Name: matches[1], Major: major, Minor: minor}, nil
+}
+
+// VersionString renders the version as it appears in a two-part contract name.
+func (r ContractRef) VersionString() string {
+	return fmt.Sprintf("v%d_%d", r.Major, r.Minor)
+}
 
 // ValidationResult contains information about the validation result and the contract used.
 type ValidationResult struct {
@@ -196,7 +240,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 
 	v.debugf("Validator.Validate: Starting validation for contract='%s', payload length=%d", contract, len(payload))
 
-	contractName, version, err := v.ExtractSchemaVersionFromDataContract(contract)
+	ref, err := ParseContractRef(contract)
 	if err != nil {
 		v.debugf("Validator.Validate: Unversioned contract '%s', bypassing validation", contract)
 		// For unversioned contracts, always bypass (no fetching of "latest")
@@ -209,6 +253,7 @@ func (v *Validator) Validate(unsTopic *topic.UnsTopic, payload []byte) *Validati
 			Error:               nil,
 		}
 	}
+	contractName, version := ref.Name, ref.Major
 
 	v.debugf("Validator.Validate: Extracted contractName='%s', version=%d", contractName, version)
 
@@ -583,26 +628,15 @@ func (v *Validator) fetchLatestSchemaFromRegistry(subject string) ([]byte, bool,
 	return []byte(versionResp.Schema), true, nil
 }
 
-// ExtractSchemaVersionFromDataContract parses a data contract string to extract
-// the base contract name and version number.
-// Expected format: "contractname_v123" -> ("contractname", 123, nil)
+// ExtractSchemaVersionFromDataContract reports a contract's name and major
+// version. Retained for callers that predate ParseContractRef.
 func (v *Validator) ExtractSchemaVersionFromDataContract(contract string) (string, uint64, error) {
-	if contract == "" {
-		return "", 0, fmt.Errorf("contract string is empty")
-	}
-
-	matches := schemaVersionRegex.FindStringSubmatch(contract)
-	if len(matches) != 3 {
-		return "", 0, fmt.Errorf("invalid data contract format '%s', expected format: 'name_v123'", contract)
-	}
-
-	contractName := matches[1]
-	version, err := strconv.ParseUint(matches[2], 10, 64)
+	ref, err := ParseContractRef(contract)
 	if err != nil {
-		return "", 0, fmt.Errorf("invalid version number '%s' in contract '%s': %w", matches[2], contract, err)
+		return "", 0, err
 	}
 
-	return contractName, version, nil
+	return ref.Name, ref.Major, nil
 }
 
 // LoadSchemas loads and compiles multiple schemas for the specified contract name and version.

--- a/uns_plugin/schema_validation/validator.go
+++ b/uns_plugin/schema_validation/validator.go
@@ -43,6 +43,11 @@ const (
 // Expected format: "contractname_v123" or "contractname_v123_4".
 var schemaVersionRegex = regexp.MustCompile(`^(.+)_v(\d+)(?:_(\d+))?$`)
 
+// subjectVersionPattern matches the version segment of a schema registry
+// subject name, e.g. "_v1-" or "_v1_1-", so the payload shape after it can
+// be extracted.
+var subjectVersionPattern = regexp.MustCompile(`_v\d+(_\d+)?-`)
+
 // ContractRef is a data contract name decomposed into its parts. Full is the
 // name as it appeared on the topic and is what keys the schema cache and
 // prefixes the registry subject lookup.
@@ -134,7 +139,7 @@ type SchemaRegistryVersion struct {
 
 // Validator manages schema validation for UNS topics with TTL-based caching.
 type Validator struct {
-	// Cache maps "contractName-v123" to ContractCacheEntry
+	// Cache maps the full contract name (e.g. "_pump_v1" or "_pump_v1_1") to ContractCacheEntry
 	contractCache     map[string]*ContractCacheEntry
 	cacheMutex        sync.RWMutex
 	schemaRegistryURL string
@@ -943,10 +948,7 @@ func (v *Validator) enhanceVirtualPathError(originalError error, _ string, schem
 // extractSchemaTypeFromSubject extracts the schema type from a subject name
 // e.g., "_sensor_data_v1-timeseries-number" -> "timeseries-number"
 func extractSchemaTypeFromSubject(subjectName string) string {
-	// Find the first occurrence of "-" after the version part to get the schema type
-	// Pattern: contractName_v{version}-{schemaType}
-	versionPattern := regexp.MustCompile(`_v\d+-`)
-	match := versionPattern.FindStringIndex(subjectName)
+	match := subjectVersionPattern.FindStringIndex(subjectName)
 	if match != nil && match[1] < len(subjectName) {
 		return subjectName[match[1]:]
 	}

--- a/uns_plugin/schema_validation/validator_test.go
+++ b/uns_plugin/schema_validation/validator_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Validator", func() {
 
 			// Check cache entry exists and never expires
 			validator.cacheMutex.RLock()
-			entry, exists := validator.contractCache["_sensor_data-v1"]
+			entry, exists := validator.contractCache["_sensor_data_v1"]
 			validator.cacheMutex.RUnlock()
 
 			Expect(exists).To(BeTrue())
@@ -237,7 +237,7 @@ var _ = Describe("Validator", func() {
 
 			// Check cache entry exists with 10 minute expiration
 			validator.cacheMutex.RLock()
-			entry, exists := validator.contractCache["_non_existent-v1"]
+			entry, exists := validator.contractCache["_non_existent_v1"]
 			validator.cacheMutex.RUnlock()
 
 			Expect(exists).To(BeTrue())
@@ -290,7 +290,7 @@ var _ = Describe("Validator", func() {
 
 			// Verify cache entry
 			validator.cacheMutex.RLock()
-			entry, exists := validator.contractCache["_test_contract-v1"]
+			entry, exists := validator.contractCache["_test_contract_v1"]
 			validator.cacheMutex.RUnlock()
 
 			Expect(exists).To(BeTrue())
@@ -513,7 +513,7 @@ var _ = Describe("Validator", func() {
 
 			// Now manually corrupt the cache to have nil schema
 			validator.cacheMutex.Lock()
-			entry := validator.contractCache["_test_contract-v1"]
+			entry := validator.contractCache["_test_contract_v1"]
 			entry.Schemas["_test_contract_v1-timeseries-number"] = nil
 			validator.cacheMutex.Unlock()
 
@@ -829,7 +829,7 @@ var _ = Describe("Validator", func() {
 
 			// Verify exact error message format
 			errorMsg := result.Error.Error()
-			Expect(errorMsg).To(ContainSubstring("schema validation failed for contract '_test_contract' version 1"))
+			Expect(errorMsg).To(ContainSubstring("schema validation failed for contract '_test_contract' version v1_0"))
 			Expect(errorMsg).To(ContainSubstring("schema validation failed for subject '_test_contract_v1-timeseries-number'"))
 			Expect(errorMsg).To(ContainSubstring("virtual_path"))
 			Expect(errorMsg).To(ContainSubstring("does not match"))
@@ -879,7 +879,7 @@ var _ = Describe("Validator", func() {
 
 			// Verify exact error message format
 			errorMsg := result.Error.Error()
-			Expect(errorMsg).To(ContainSubstring("schema validation failed for contract '_test_contract' version 1"))
+			Expect(errorMsg).To(ContainSubstring("schema validation failed for contract '_test_contract' version v1_0"))
 			Expect(errorMsg).To(ContainSubstring("schema validation failed for subject '_test_contract_v1-timeseries-string'"))
 			Expect(errorMsg).To(ContainSubstring("virtual_path"))
 			Expect(errorMsg).To(ContainSubstring("does not match"))
@@ -1230,29 +1230,63 @@ var _ = Describe("schema cache keying", func() {
 		Expect(resultV1.BypassReason).To(ContainSubstring("no schemas found for contract"))
 
 		freshValidator.cacheMutex.RLock()
-		_, existsV1 := freshValidator.contractCache[cacheKeyFor("_pump", 1, 0)]
-		_, existsV1_1 := freshValidator.contractCache[cacheKeyFor("_pump", 1, 1)]
+		_, existsV1 := freshValidator.contractCache[cacheKeyFor("_pump_v1")]
+		_, existsV1_1 := freshValidator.contractCache[cacheKeyFor("_pump_v1_1")]
 		freshValidator.cacheMutex.RUnlock()
 
 		Expect(existsV1).To(BeTrue())
 		Expect(existsV1_1).To(BeTrue())
-		Expect(cacheKeyFor("_pump", 1, 0)).ToNot(Equal(cacheKeyFor("_pump", 1, 1)))
 	})
 
-	It("keeps one-part contracts distinct from two-part ones", func() {
-		v := NewValidator()
+	It("keeps a bare version and its explicit two-part minor-zero form in separate entries", func() {
+		// ParseContractRef reports Minor=0 for both "_pump_v1" (no minor group)
+		// and "_pump_v1_0" (explicit zero minor), so the cache key must be the
+		// full contract string, not a reconstruction from Name/Major/Minor,
+		// or these two would collide onto one entry (ENG-5500 regression).
+		freshRegistry := NewMockSchemaRegistry()
+		defer freshRegistry.Close()
+		freshRegistry.AddSchema("_pump_v1_0-timeseries-number", 1, string(numberSchemaFor("two_part_tag")))
+
+		v := NewValidatorWithRegistry(freshRegistry.URL())
 		defer v.Close()
 
 		Expect(v.LoadSchemas("_pump", 1, map[string][]byte{
-			"_pump_v1-timeseries-number": numberSchemaFor("temperature"),
+			"_pump_v1-timeseries-number": numberSchemaFor("bare_tag"),
 		})).To(Succeed())
 
-		Expect(v.HasSchema("_pump", 1)).To(BeTrue())
+		payload := []byte(`{"timestamp_ms": 1719859200000, "value": 25.5}`)
+
+		bareTopic, err := topic.NewUnsTopic("umh.v1.enterprise.site.area._pump_v1.bare_tag")
+		Expect(err).ToNot(HaveOccurred())
+		twoPartTopic, err := topic.NewUnsTopic("umh.v1.enterprise.site.area._pump_v1_0.two_part_tag")
+		Expect(err).ToNot(HaveOccurred())
+
+		bareResult := v.Validate(bareTopic, payload)
+		Expect(bareResult.SchemaCheckPassed).To(BeTrue())
+
+		twoPartResult := v.Validate(twoPartTopic, payload)
+		Expect(twoPartResult.SchemaCheckPassed).To(BeTrue())
 
 		v.cacheMutex.RLock()
-		_, existsMinor1 := v.contractCache[cacheKeyFor("_pump", 1, 1)]
+		_, existsBare := v.contractCache[cacheKeyFor("_pump_v1")]
+		_, existsTwoPart := v.contractCache[cacheKeyFor("_pump_v1_0")]
 		v.cacheMutex.RUnlock()
-		Expect(existsMinor1).To(BeFalse())
+		Expect(existsBare).To(BeTrue())
+		Expect(existsTwoPart).To(BeTrue())
+
+		// Neither entry is served the other's schemas: a tag valid only under
+		// one contract must be rejected under the other.
+		bareToppedWithOtherTag, err := topic.NewUnsTopic("umh.v1.enterprise.site.area._pump_v1.two_part_tag")
+		Expect(err).ToNot(HaveOccurred())
+		crossResult := v.Validate(bareToppedWithOtherTag, payload)
+		Expect(crossResult.SchemaCheckPassed).To(BeFalse())
+		Expect(crossResult.SchemaCheckBypassed).To(BeFalse())
+
+		twoPartWithOtherTag, err := topic.NewUnsTopic("umh.v1.enterprise.site.area._pump_v1_0.bare_tag")
+		Expect(err).ToNot(HaveOccurred())
+		crossResult2 := v.Validate(twoPartWithOtherTag, payload)
+		Expect(crossResult2.SchemaCheckPassed).To(BeFalse())
+		Expect(crossResult2.SchemaCheckBypassed).To(BeFalse())
 	})
 
 	It("serves a cache hit without going back to the registry", func() {

--- a/uns_plugin/schema_validation/validator_test.go
+++ b/uns_plugin/schema_validation/validator_test.go
@@ -1341,3 +1341,16 @@ var _ = Describe("ParseContractRef", func() {
 		Entry("no version", "_pump"),
 	)
 })
+
+var _ = Describe("extractSchemaTypeFromSubject", func() {
+	DescribeTable("returns the payload shape after the version",
+		func(subject, want string) {
+			Expect(extractSchemaTypeFromSubject(subject)).To(Equal(want))
+		},
+		Entry("one-part", "_pump_v1-timeseries-number", "timeseries-number"),
+		Entry("two-part", "_pump_v1_1-timeseries-number", "timeseries-number"),
+		Entry("two-part string", "_pump_v10_3-timeseries-string", "timeseries-string"),
+		Entry("model name with digits", "_line_2_v1_1-timeseries-number", "timeseries-number"),
+		Entry("no version", "_pump-timeseries-number", "unknown"),
+	)
+})

--- a/uns_plugin/schema_validation/validator_test.go
+++ b/uns_plugin/schema_validation/validator_test.go
@@ -1181,3 +1181,33 @@ var _ = Describe("Validator Logger Integration", func() {
 		})
 	})
 })
+
+var _ = Describe("ParseContractRef", func() {
+	DescribeTable("parses one-part and two-part contracts",
+		func(in string, wantName string, wantMajor, wantMinor uint64) {
+			ref, err := ParseContractRef(in)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ref.Full).To(Equal(in))
+			Expect(ref.Name).To(Equal(wantName))
+			Expect(ref.Major).To(Equal(wantMajor))
+			Expect(ref.Minor).To(Equal(wantMinor))
+		},
+		Entry("one-part", "_pump_v1", "_pump", uint64(1), uint64(0)),
+		Entry("one-part multi-digit", "_pump_v12", "_pump", uint64(12), uint64(0)),
+		Entry("two-part", "_pump_v1_1", "_pump", uint64(1), uint64(1)),
+		Entry("two-part minor zero", "_pump_v1_0", "_pump", uint64(1), uint64(0)),
+		Entry("two-part multi-digit", "_pump_v10_3", "_pump", uint64(10), uint64(3)),
+		Entry("model name with digits", "_line_2_v1_1", "_line_2", uint64(1), uint64(1)),
+	)
+
+	DescribeTable("rejects unversioned contracts so they take the bypass",
+		func(in string) {
+			_, err := ParseContractRef(in)
+			Expect(err).To(HaveOccurred())
+		},
+		Entry("raw", "_raw"),
+		Entry("historian", "_historian"),
+		Entry("empty", ""),
+		Entry("no version", "_pump"),
+	)
+})

--- a/uns_plugin/schema_validation/validator_test.go
+++ b/uns_plugin/schema_validation/validator_test.go
@@ -1182,6 +1182,102 @@ var _ = Describe("Validator Logger Integration", func() {
 	})
 })
 
+func numberSchemaFor(tag string) []byte {
+	return []byte(fmt.Sprintf(`{
+		"type": "object",
+		"properties": {
+			"virtual_path": {
+				"type": "string",
+				"enum": ["%s"]
+			},
+			"fields": {
+				"type": "object",
+				"properties": {
+					"timestamp_ms": {"type": "number"},
+					"value": {"type": "number"}
+				},
+				"required": ["timestamp_ms", "value"],
+				"additionalProperties": false
+			}
+		},
+		"required": ["virtual_path", "fields"],
+		"additionalProperties": false
+	}`, tag))
+}
+
+var _ = Describe("schema cache keying", func() {
+	It("does not serve one minor's schemas for another", func() {
+		freshRegistry := NewMockSchemaRegistry()
+		defer freshRegistry.Close()
+		freshRegistry.AddSchema("_pump_v1_1-timeseries-number", 1, string(numberSchemaFor("temperature")))
+
+		freshValidator := NewValidatorWithRegistry(freshRegistry.URL())
+		defer freshValidator.Close()
+
+		payload := []byte(`{"timestamp_ms": 1719859200000, "value": 25.5}`)
+
+		v1Topic, err := topic.NewUnsTopic("umh.v1.enterprise.site.area._pump_v1.temperature")
+		Expect(err).ToNot(HaveOccurred())
+		v1_1Topic, err := topic.NewUnsTopic("umh.v1.enterprise.site.area._pump_v1_1.temperature")
+		Expect(err).ToNot(HaveOccurred())
+
+		resultV1_1 := freshValidator.Validate(v1_1Topic, payload)
+		Expect(resultV1_1.SchemaCheckPassed).To(BeTrue())
+
+		resultV1 := freshValidator.Validate(v1Topic, payload)
+		Expect(resultV1.SchemaCheckPassed).To(BeFalse())
+		Expect(resultV1.SchemaCheckBypassed).To(BeTrue())
+		Expect(resultV1.BypassReason).To(ContainSubstring("no schemas found for contract"))
+
+		freshValidator.cacheMutex.RLock()
+		_, existsV1 := freshValidator.contractCache[cacheKeyFor("_pump", 1, 0)]
+		_, existsV1_1 := freshValidator.contractCache[cacheKeyFor("_pump", 1, 1)]
+		freshValidator.cacheMutex.RUnlock()
+
+		Expect(existsV1).To(BeTrue())
+		Expect(existsV1_1).To(BeTrue())
+		Expect(cacheKeyFor("_pump", 1, 0)).ToNot(Equal(cacheKeyFor("_pump", 1, 1)))
+	})
+
+	It("keeps one-part contracts distinct from two-part ones", func() {
+		v := NewValidator()
+		defer v.Close()
+
+		Expect(v.LoadSchemas("_pump", 1, map[string][]byte{
+			"_pump_v1-timeseries-number": numberSchemaFor("temperature"),
+		})).To(Succeed())
+
+		Expect(v.HasSchema("_pump", 1)).To(BeTrue())
+
+		v.cacheMutex.RLock()
+		_, existsMinor1 := v.contractCache[cacheKeyFor("_pump", 1, 1)]
+		v.cacheMutex.RUnlock()
+		Expect(existsMinor1).To(BeFalse())
+	})
+
+	It("serves a cache hit without going back to the registry", func() {
+		freshRegistry := NewMockSchemaRegistry()
+		freshRegistry.AddSchema("_pump_v1_1-timeseries-number", 1, string(numberSchemaFor("temperature")))
+
+		freshValidator := NewValidatorWithRegistry(freshRegistry.URL())
+		defer freshValidator.Close()
+
+		unsTopic, err := topic.NewUnsTopic("umh.v1.enterprise.site.area._pump_v1_1.temperature")
+		Expect(err).ToNot(HaveOccurred())
+		payload := []byte(`{"timestamp_ms": 1719859200000, "value": 25.5}`)
+
+		first := freshValidator.Validate(unsTopic, payload)
+		Expect(first.SchemaCheckPassed).To(BeTrue())
+
+		// Registry is now gone; a second validation can only pass if it was
+		// served from cache instead of going back over the network.
+		freshRegistry.Close()
+
+		second := freshValidator.Validate(unsTopic, payload)
+		Expect(second.SchemaCheckPassed).To(BeTrue())
+	})
+})
+
 var _ = Describe("ParseContractRef", func() {
 	DescribeTable("parses one-part and two-part contracts",
 		func(in string, wantName string, wantMajor, wantMinor uint64) {

--- a/uns_plugin/uns_output.go
+++ b/uns_plugin/uns_output.go
@@ -379,8 +379,19 @@ func (o *unsOutput) validateAndEnrichMessage(msg *service.Message, unsTopic *top
 	}
 
 	msg.MetaSet("data_contract_name", result.ContractName)
-	msg.MetaSet("data_contract_version", strconv.FormatUint(result.ContractVersion, 10))
+	msg.MetaSet("data_contract_version", contractVersionMetaValue(result))
 	return nil
+}
+
+// contractVersionMetaValue renders the "data_contract_version" metadata value.
+// For a one-part contract (no minor) it is the major version alone, unchanged
+// from before minor versions existed. For a two-part contract it is
+// "major_minor".
+func contractVersionMetaValue(result *schemavalidation.ValidationResult) string {
+	if result.ContractMinor != nil {
+		return fmt.Sprintf("%d_%d", result.ContractVersion, *result.ContractMinor)
+	}
+	return strconv.FormatUint(result.ContractVersion, 10)
 }
 
 // WriteBatch implements service.BatchOutput.

--- a/uns_plugin/uns_output_test.go
+++ b/uns_plugin/uns_output_test.go
@@ -459,3 +459,28 @@ var _ = Describe("topic validation", func() {
 		})
 	})
 })
+
+var _ = Describe("contractVersionMetaValue", func() {
+	DescribeTable("renders data_contract_version exactly as the contract name carries it",
+		func(contract, want string) {
+			ref, err := schemavalidation.ParseContractRef(contract)
+			Expect(err).ToNot(HaveOccurred())
+
+			var minor *uint64
+			if ref.HasMinor {
+				m := ref.Minor
+				minor = &m
+			}
+
+			result := &schemavalidation.ValidationResult{
+				ContractVersion: ref.Major,
+				ContractMinor:   minor,
+			}
+			Expect(contractVersionMetaValue(result)).To(Equal(want))
+		},
+		Entry("one-part contract is unchanged from today", "_pump_v1", "1"),
+		Entry("two-part contract with explicit minor zero", "_pump_v1_0", "1_0"),
+		Entry("two-part contract", "_pump_v1_1", "1_1"),
+		Entry("two-part contract with multi-digit major and minor", "_pump_v10_3", "10_3"),
+	)
+})


### PR DESCRIPTION
Data model versions are gaining a minor part (ENG-5500), so a data contract name can be `_pump_v1_1` and not only `_pump_v1`. benthos-umh reads the contract off each message's topic and pattern-matches it in several places, none of which understood a two-part suffix.

**Inert until umh-core ships.** Nothing emits a two-part name yet, so this changes no behaviour for traffic that exists today. It lands first because umh-core pins `BENTHOS_UMH_VERSION`.

### What breaks without it

- **Historian writes nothing.** `NormalizeContract` leaves the suffix on, so the configured contract no longer matches and every message is dropped as a contract mismatch. Not the wrong table, no rows at all.
- **Schema validation stops applying.** The contract fails to parse, is read as unversioned, and the bypass branch accepts messages without checking them against any schema.

### Changes

- `historian_plugin`: the version-suffix regex widens to `_v\d+(_\d+)?$`, in Go and in the SQL copy inside `umh.get_topic_id`. One rule written twice, so both move in the same commit.
- `uns_plugin`: `ParseContractRef` replaces the old parser and keeps the full contract name beside the parsed parts. The compiled-schema cache and the registry subject prefix key on that full name, so `_pump_v1` and `_pump_v1_1` can no longer share an entry. With `cacheHitTTL` at zero a shared entry would have been permanent.
- Validation error text and the `data_contract_version` metadata now carry the minor. The metadata value is byte-identical for one-part contracts.

Table naming is unchanged: every version of a model still writes to `_pump`, so there is no database migration.

### Verification

- Historian integration against live TimescaleDB: **162 of 162 specs, 0 skipped.** Two are new and are the only tests in the repo that feed a versioned name through the SQL regex. Every pre-existing case passed an already-bare contract name, so the SQL half of that rule had no coverage at all.
- `uns_plugin` unit suites green. `go vet ./...` clean across the repo.
- One case checks `line_2_v1_1` resolves to `line_2` rather than `line`, which is what catches a regex anchored on digits instead of the literal `_v`.

### For the release notes

Rolling umh-core back after the feature ships is unsafe. An older umh-core cannot read a `v1_1` key, skips it, and renumbers from the remaining keys, writing a breaking major with no additive check. A guard ships separately in umh-core, and it only protects sites that already have it.
