### PR TITLE
Cache retry semantics: one fix, seven failing tests, corrected docs

### DIFF
--- a/docs/processing/javascript-api.md
+++ b/docs/processing/javascript-api.md
@@ -55,6 +55,9 @@ nodered_js:
     name: shared       # sharing identifier (default: "shared"); see "Sharing across processors" below
     path: ./cache.db   # "~" expands to home; relative paths resolve from benthos start directory. Prefer absolute paths.
     ttl: 0s            # entry lifetime; 0 (default) = no expiration. Set e.g. "1h" to auto-expire.
+    dedupKey: kafka_offset # metadata field identifying a message across retries. Without it, a
+                       # redelivered message writes to the cache a second time — a count is
+                       # raised twice for one part. See "Retries and duplicate messages".
 ```
 
 ### Sharing across processors
@@ -110,123 +113,132 @@ if (cache.exists("counter")) {
 
 ### Thread safety (auto-lock)
 
-Every batch acquires a per-cache mutex for its duration. Same mutex is shared across processors with the same `backend` + `name`. Effect:
+Every batch takes a lock on the cache for its duration. The same lock is shared across processors with the same `backend` and `name`. What that gives you:
 
-- `cache.get` → compute → `cache.set` in the same message is atomic: no other message can slip in between the get and the set
-- Multiple cache operations in one message run as one uninterrupted block
-- Cross-processor read-modify-write on a shared cache is also atomic
+- `cache.get` → compute → `cache.set` in the same message runs as one unit: no other message can slip in between the get and the set
+- The lock covers the **whole batch**, not one message, so the guarantee holds across every message in it
+- The same holds when two processors share a cache: one processor's read-change-write finishes before the other's starts
 
-Plain `get` / `set` is safe for counters, buffers, alarms, and all stateful patterns below.
+This makes plain `get` / `set` safe against two **different** messages racing each other. It does not make it safe against the **same** message being handled twice — that is a separate problem, handled by [`dedupKey`](#retries-and-duplicate-messages-dedupkey).
 
-Trade-off: cache operations serialize on a shared mutex. For workloads under 100 msg/s, the cost is negligible.
+Trade-off: the lock is held for the entire batch, JavaScript execution included, not just for the cache calls. Two processors sharing a cache therefore take turns, and raising `pipeline.threads` buys a flow that uses the cache almost nothing. At the rates a bridge or stream processor produces this costs nothing you would notice — but don't expect more threads to speed up a stateful flow.
 
 The auto-lock does not guarantee message order. With `pipeline.threads > 1`, messages process out of order; message 5 may arrive before message 3. For strict message order, set `pipeline.threads: 1`.
 
-### Idempotency and monotonicity under retries (`dedupKey`)
+### Retries and duplicate messages (`dedupKey`)
 
-At-least-once inputs (Kafka, UNS input, MQTT QoS1+, AMQP, JetStream) redeliver the same message when a downstream ACK is lost. Without protection, every retry re-runs the JavaScript, so a counter kept in the cache double-counts, an alarm re-fires, and a monotonic max advances past values it has already recorded.
+UMH delivers messages at least once. When the pipeline cannot confirm that a message was handled, it delivers the same message again and your JavaScript runs again — so a count kept in the cache counts the same part twice.
 
-Both processors accept a `dedupKey` config field that names a **Benthos message metadata field** (set by the input plugin) whose value uniquely identifies the source event across retries. On the first sight of a value, cache writes run normally and the value is recorded in the cache under the reserved prefix `__dedup__:`. On later deliveries of the same value, `cache.set` and `cache.delete` are no-ops for that message, so cache state stays idempotent under retries.
+`dedupKey` is what stops that. Once you tell it how to recognize a message, **the cache is written on the first delivery and not again**, however many times that message arrives.
 
-The dedup value is pulled from message metadata via `msg.meta.<dedupKey>`. It must be attached by the input plugin (for example the Kafka input auto-tags every message with `kafka_offset`, `kafka_partition`, `kafka_topic`). If your input doesn't attach a unique identifier, compose one with an upstream `bloblang` or `mapping` processor before the JS processor runs.
+`dedupKey` names a **message metadata field** — the value you read in JavaScript as `msg.meta.<name>`, not a field of the payload.
+
+The first time a value arrives, cache writes run normally and the value is remembered. When a message arrives carrying a value that was seen before, `cache.set` and `cache.delete` do nothing for that message, a WARN line is logged, and the `cache_dedup_suppressed` counter goes up. Retries are rare in a healthy pipeline, so a steady stream of those lines means something upstream is redelivering constantly.
+
+`cache.get` and `cache.exists` still read normally — only writes are held back. The JavaScript still runs on the redelivered message, and the message still reaches the output. What `dedupKey` protects is the cache: a stored count is not raised twice, a running total does not take the same reading in twice, a key you deleted stays deleted.
+
+**Two conditions on the field you pick**
+
+Ask two things about each candidate: does the message carry a value that survives a retry, and is that value different for every message? Both have to be true.
+
+- **The same on a retry as on the first delivery.** If it changes, the retry looks like a new message and nothing is suppressed.
+- **Different for every distinct message.** If two real readings share a value, the second one's cache writes are dropped and that reading is lost from your state.
+
+A composed string works as well as a number, as long as both conditions hold.
+
+**Choosing a key**
+
+| Field | Comes from | Verdict |
+| --- | --- | --- |
+| `kafka_offset` | `uns` input | Best choice, and nothing to compose. The UNS writes everything to `umh.messages`, which always has exactly one partition, so the offset on its own identifies a message. |
+| `kafka_offset` together with `kafka_partition` | Benthos' own `kafka` and `redpanda` inputs | These can read many partitions, and an offset is unique only inside one — partition 0 offset 42 and partition 1 offset 42 are different messages. Combine the two into one value with a `mapping` step, as described under the table. |
+| `opcua_source_timestamp` | `opcua` input | Works. Watch for a device whose clock ticks coarser than it publishes: two readings then share a timestamp, and the second one's writes are dropped. |
+| `kafka_timestamp_ms` | `uns` input; Kafka inputs | Avoid. It survives a retry, but two messages written in the same millisecond share it and the second one is suppressed. |
+| `timestamp_ms` | the payload of a tag message | Unusable as it stands: it sits in the payload, not in metadata, so `dedupKey` never finds it. In a bridge it is also stamped while the message is being processed, so copying it into metadata does not help — it changes on every retry. In a stream processor it does survive a retry and you *can* copy it into metadata with a `mapping` step, but two tags read in the same millisecond then share a value and the second one's writes are dropped. Prefer `kafka_offset`. |
+| nothing usable (S7, Modbus bridges) | — | These carry no field that identifies a message across retries. Publish the raw value to the UNS and do the counting in a stream processor, where a Kafka offset exists. |
+
+The `uns` input also attaches `kafka_topic`, `kafka_msg_key` and `umh_topic`, but none of them identifies a single message — every reading from one tag carries the same values.
+
+If your input attaches the parts of a unique value but not the value itself, compose one with a `mapping` step ahead of the JS processor and write it to a fresh metadata key. Reading a multi-partition topic with Benthos' own `kafka` input, that is:
 
 ```yaml
-# nodered_js
-nodered_js:
-  cache:
-    dedupKey: kafka_offset
-
-# tag_processor
-tag_processor:
-  dedupKey: kafka_offset
+pipeline:
+  processors:
+    - mapping: |
+        meta dedup_id = meta("kafka_partition") + ":" + meta("kafka_offset")
+    - nodered_js:
+        cache:
+          dedupKey: dedup_id
+        code: ...
 ```
 
-**What it covers**
+Inside UMH you do not need this: `umh.messages` has one partition, so `dedupKey: kafka_offset` is complete on its own.
 
-- `cache.set` — no-op on retry
-- `cache.delete` — no-op on retry
-- Read-modify-write patterns become idempotent: the JS still runs and computes locally, but the retried write does not commit
-- Monotonic counters, high-water marks, alarm latches — all stay correct across retries when built on `cache.set`
+**Configuration**
 
-Every suppressed message emits a WARN log line (`"cache: suppressing writes for retried message (dedupKey=... value=...)"`) and increments the `cache_dedup_suppressed` counter. Retries should be rare, so a WARN is intentional; a sustained high rate on this counter or a flood of these log lines usually means the upstream retry source is misbehaving.
+In `nodered_js` the field sits under `cache`; in `tag_processor` it is a top-level field. Note the camelCase spelling, unlike its all-lowercase siblings.
 
-**What it does NOT cover**
+Leave it unset and nothing is suppressed: every delivery writes to the cache, and a warning is logged once at startup. The field will become required in a future release.
 
-- Side effects outside the cache — HTTP calls, external DB writes, log lines, and metrics `Incr` still run on every retry
-- Output-side deduplication — messages sent to Kafka/UNS/MQTT still leave the pipeline on every retry. If your output needs dedup, gate it separately (e.g. Kafka idempotent producer, `umh_topic`-keyed compaction, or a downstream dedup filter)
-- Messages missing the `dedupKey` meta field — a one-time warning is logged and the message is processed as fresh
-- Cross-process retries — dedup markers live in the same cache instance as your user keys. Two benthos processes must share the same persistent cache (`backend: persistent`, same `name`) to share dedup state, and bbolt's single-writer file lock still applies
+Setting it to a name your messages don't carry is the trap to watch for, because the config looks protective and isn't. Messages without the field are treated as new, and the warning is logged **once per processor** — not once per message. So a name that *no* message ever carries, which is what happens if you reach for a payload field such as `timestamp_ms`, buys you a single line at startup and no protection at all for the rest of the run. Check `cache_dedup_suppressed` after a deploy: if a pipeline that should be seeing retries never moves it off zero, suspect the field name before you suspect the retries.
 
-**How to use**
-
-1. Pick a metadata field whose value uniquely identifies the source event across retries. For Kafka this is the `topic:partition:offset` triple — `kafka_offset` alone repeats across partitions and topics.
-2. If the input doesn't already attach such a field (or attaches only its parts), compose one earlier in the pipeline with a `mapping`/`bloblang` step and write it to a fresh meta key.
-3. Set `dedupKey` to that meta key on the processor.
-4. Bound the marker lifetime with `cache.ttl`. Markers live under `__dedup__:<value>` in the same cache; a TTL matching your worst-case retry window (minutes for Kafka, hours for slow-consumer scenarios) keeps memory bounded. Without a TTL, markers accumulate for the lifetime of the process (or the persistent file).
-
-**Example — idempotent counter under Kafka at-least-once**
-
-Benthos' Kafka input auto-tags every message with `kafka_offset`, `kafka_partition`, `kafka_topic`, etc., so a single-partition consumer can point `dedupKey` straight at `kafka_offset` with no upstream step:
+Watch `cache_dedup_suppressed` (see [Metrics](#metrics)) to confirm it is working; in a healthy pipeline it stays at or near zero.
 
 ```yaml
 input:
-  kafka:
-    addresses: ["broker:9092"]
-    topics: ["events"]   # single partition
+  uns:
+    umh_topic: umh\.v1\.acme\.berlin\.assembly\..+
 pipeline:
   processors:
     - nodered_js:
         cache:
           backend: persistent
           path: /var/cache/umh.db
-          ttl: 6h
           dedupKey: kafka_offset
         code: |
-          var n = cache.exists("count") ? cache.get("count") : 0;
-          cache.set("count", n + 1);
-          msg.payload = { count: n + 1 };
+          var n = cache.exists("part_count") ? cache.get("part_count") : 0;
+          n = n + 1;
+          cache.set("part_count", n);
+          msg.payload = { part_count: n };
           return msg;
 ```
 
-For **multi-partition or multi-topic** consumers, `kafka_offset` alone collides (partition 0 offset 42 ≡ partition 1 offset 42). Compose a unique key first with a `mapping` step and point `dedupKey` at that:
+In a bridge reading from OPC UA, where each message is one reading, `tag_processor` takes the field at the top level:
 
 ```yaml
-input:
-  kafka:
-    addresses: ["broker:9092"]
-    topics: ["events"]
-pipeline:
-  processors:
-    - mapping: |
-        meta dedup_id = meta("kafka_topic") + ":" + meta("kafka_partition") + ":" + meta("kafka_offset")
-    - nodered_js:
-        cache:
-          dedupKey: dedup_id
-        code: |
-          var n = cache.exists("count") ? cache.get("count") : 0;
-          cache.set("count", n + 1);
-          msg.payload = { count: n + 1 };
-          return msg;
+- tag_processor:
+    dedupKey: opcua_source_timestamp
+    defaults: |
+      msg.meta.location_path = "acme.berlin.assembly";
+      msg.meta.data_contract = "_raw";
+      msg.meta.tag_name = "temperature";
+      return msg;
 ```
 
-- First delivery of offset 42: `count` was 41. JS reads 41 and writes 42. Payload reports `42`.
-- Redelivery of offset 42 (crash before ACK): JS reads 42 and computes 43, but the `cache.set("count", 43)` call is suppressed. The cache stays at 42. The retried message still leaves the pipeline with `43` in its payload; downstream systems must dedup output separately. Nothing kept in the cache is corrupted.
+**What a retry looks like**
 
-**Example — monotonic max under retries**
+With the counter above, at `kafka_offset` `42`:
 
-```javascript
-var seen = cache.exists("max") ? cache.get("max") : null;
-if (seen === null || msg.payload.value > seen) {
-  cache.set("max", msg.payload.value);
-  seen = msg.payload.value;
-}
-msg.payload.max_so_far = seen;
-return msg;
-```
+- First delivery. `part_count` was 41. The JavaScript reads 41, writes 42, and the message leaves with `part_count: 42`.
+- Redelivery of offset `42` after a lost ACK. The JavaScript reads 42 and computes 43, but the `cache.set` is skipped, so the stored count stays at 42 — that is the guarantee. The redelivered message itself still leaves the pipeline, carrying the 43 it computed locally. **The stored value is the authoritative one.** Because delivery is at least once, a message may reach the output more than once, and a value computed on a redelivery may run ahead of what is stored.
 
-Without `dedupKey`, a redelivered sample larger than the previous high is fine on its own (max is idempotent by construction). But a redelivered smaller value combined with any read-modify-write in the same block can still corrupt paired state (for example a running sum kept in the same cache). Setting `dedupKey` gates all cache writes for that source event, so the running sum, the max, and any other paired state stay consistent as one decision per source event.
+**What `dedupKey` does not do**
+
+- **Nothing outside the cache is held back.** HTTP calls, writes to an external database, log lines and your other metrics all happen again on the retry.
+- **No value is compared against the ones before it.** Nothing checks whether an incoming reading is older or newer than what you have stored. A message that arrives late, after newer ones, counts as a new message and its writes run. If your logic needs messages in arrival order, set `pipeline.threads: 1` (see [Thread safety](#thread-safety-auto-lock)) — that orders what this processor sees. It does not order what your flow writes: the UNS output sends batches concurrently, so a flow reading them downstream can still see them out of order.
+- **Dedup does not cross process boundaries.** The markers live in one cache instance, and a cache belongs to a single benthos process (see [Sharing across processors](#sharing-across-processors)). Each process decides on its own.
+
+**Marker storage and lifetime**
+
+In `nodered_js`, dedup markers share the cache with your own keys: **one marker per message**, counted in `cache_keys` and, on the persistent backend, in the file on disk. The only thing that removes them is `cache.ttl`, which defaults to `0s` — never expire — so a long-running flow grows by one key for every message that passes through. Setting a TTL to bound them cuts both ways: `ttl` applies to your own values too, so a TTL short enough to clear markers also expires the counter you are keeping. Pick the TTL for your state and let the markers follow.
+
+`tag_processor` works differently: it keeps its own cache in memory, private to that processor, with no `cache` block and therefore no TTL. Markers there are never removed, nothing is written to disk, and the state they protect is lost on restart.
+
+Never delete `__dedup__:` keys from JavaScript; that prefix is reserved.
 
 ### Counter
+
+Counting is the pattern that most needs `dedupKey` — set it (see [Retries and duplicate messages](#retries-and-duplicate-messages-dedupkey)) before using this:
 
 ```javascript
 var count = 0;
@@ -236,6 +248,8 @@ cache.set("count", count);
 msg.payload = count;
 return msg;
 ```
+
+**Without `dedupKey` this over-counts.** A redelivered message reads the stored count and writes count+1 a second time, so one part is counted as two — and nothing warns you.
 
 ### Previous value comparison
 
@@ -253,7 +267,11 @@ msg.payload.delta = delta;
 return msg;
 ```
 
+Nothing accumulates here, so a redelivery cannot inflate the result. But if the message carrying a difference fails to send, that difference is lost: the first attempt already moved `last_value`, so the retry compares the value against itself and reports 0. `dedupKey` does not change this. Where a missing interval matters, publish the raw value and compute the difference in a stream processor instead.
+
 ### History (last N values)
+
+Set `dedupKey` (see [Retries and duplicate messages](#retries-and-duplicate-messages-dedupkey)) before using this:
 
 ```javascript
 var history = [];
@@ -266,54 +284,52 @@ cache.set("history", history);
 return msg;
 ```
 
+**Without `dedupKey` a redelivered message is appended twice**, so the buffer holds the same reading in two slots and anything averaged over it is wrong.
+
 ### Alarm state tracking
 
+Publish the alarm state on every message and let consumers notice when it changes. No cache needed:
+
 ```javascript
-var alarmed = false;
-if (cache.exists("alarm_active")) {
-  alarmed = cache.get("alarm_active");
-}
-if (msg.payload.value > 100 && !alarmed) {
-  cache.set("alarm_active", true);
-  msg.meta.alarm = "triggered";
-  return msg;
-}
-if (msg.payload.value <= 100 && alarmed) {
-  cache.set("alarm_active", false);
-  msg.meta.alarm = "cleared";
-  return msg;
-}
+msg.meta.alarm_active = msg.payload.value > 100;
 return msg;
 ```
 
+**Don't latch the alarm in the cache to fire only on the transition.** That pattern looks tidier but loses alarms. It decides "did this just change?" by comparing against the stored state — and if the message carrying the "triggered" annotation fails to send, the retry finds the state already changed, reports no transition, and the alarm reaches nobody. The same happens to "cleared", leaving a consumer showing an alarm that never ends. `dedupKey` does not rescue the latching version: the branch conditions have already decided there is nothing to write, so there is no write left to suppress. Publishing the state on every message has no such gap, because the value is computed from the message alone and a retry produces exactly the same result.
+
 ### Cycle time between events
+
+Measure from the timestamps carried by the messages, not from the clock:
 
 ```javascript
 var lastMs = null;
 if (cache.exists("last_event_ms")) {
   lastMs = cache.get("last_event_ms");
 }
+var thisMs = msg.payload.timestamp_ms;
 if (lastMs !== null) {
-  msg.payload.cycle_time_ms = Date.now() - lastMs;
+  msg.payload.cycle_time_ms = thisMs - lastMs;
 }
-cache.set("last_event_ms", Date.now());
+cache.set("last_event_ms", thisMs);
 return msg;
 ```
+
+**Don't reach for `Date.now()` here.** It measures when benthos handled the message, not when the event happened, so a flow that falls behind and then catches up reports cycle times that never occurred. It also makes the result unrepeatable: a redelivered message computes a different answer than the first attempt, and no `dedupKey` can fix that, because the answer depends on the clock rather than on the message. As with the previous-value pattern above, one interval is still lost if a send fails.
 
 ### Limitations
 
 - Caches don't cross benthos process boundaries; bbolt's file lock blocks a second opener. Use an external KV to share across processes. See [Sharing across processors](#sharing-across-processors).
-- The cache has no size limit and grows unboundedly if keys are never deleted. Use `cache.delete` or rely on `ttl` for expiration. A hard cap is planned.
+- The cache has no size limit and grows unboundedly if keys are never deleted. Use `cache.delete` for your own keys, or `ttl` for everything including dedup markers, which you must not delete yourself. A hard cap is planned.
 - In `tag_processor`, one cache is shared across all stages (`defaults`, `conditions`, `advancedProcessing`); a value set in `defaults` is visible in `advancedProcessing` within the same message.
-- Keys with the prefix `__dedup__:` are reserved for the `dedupKey` retry-idempotency machinery. Don't write to them from your own code.
+- Keys with the prefix `__dedup__:` are reserved for the `dedupKey` retry check. Don't write to them from your own code.
 
 ### Metrics
 
-Each processor reports these Benthos metrics for its cache (sampled every 30 s):
+Each processor reports these Benthos metrics for its cache. The two size figures are sampled on a 30-second tick, so they appear only after the first one; the suppression counter updates immediately.
 
 - `cache_keys`: number of entries currently stored
 - `cache_disk_bytes`: file size on disk (`0` for the memory backend)
-- `cache_dedup_suppressed`: total messages whose cache writes were suppressed because their `dedupKey` value was seen before (see [Idempotency and monotonicity under retries](#idempotency-and-monotonicity-under-retries-dedupkey))
+- `cache_dedup_suppressed`: total messages whose cache writes were suppressed because their `dedupKey` value was seen before (see [Retries and duplicate messages](#retries-and-duplicate-messages-dedupkey))
 
 ## protobuf
 

--- a/nodered_js_plugin/nodered_js_plugin.go
+++ b/nodered_js_plugin/nodered_js_plugin.go
@@ -774,6 +774,7 @@ msg.meta.count = (msg.meta.count || 0) + 1;
 return msg;
 
 // Example 7: Persistent counter across messages using cache
+// Set cache.dedupKey as well, or a redelivered message counts the same part twice.
 var count = 0;
 if (cache.exists("count")) { count = cache.get("count"); }
 count++;
@@ -781,18 +782,11 @@ cache.set("count", count);
 msg.payload = count;
 return msg;
 
-// Example 8: Alarm state that only fires once per active condition
-var alarmed = cache.exists("alarm_active") ? cache.get("alarm_active") : false;
-if (msg.payload.value > 100 && !alarmed) {
-  cache.set("alarm_active", true);
-  msg.meta.alarm = "triggered";
-  return msg;
-}
-if (msg.payload.value <= 100 && alarmed) {
-  cache.set("alarm_active", false);
-  msg.meta.alarm = "cleared";
-  return msg;
-}
+// Example 8: Alarm state, published on every message
+// Don't latch this in the cache to fire only on the transition: if the message
+// carrying the "triggered" annotation fails to send, the retry finds the state
+// already changed and the alarm reaches nobody.
+msg.meta.alarm_active = msg.payload.value > 100;
 return msg;`)).
 	Field(service.NewObjectField(
 		"cache",
@@ -810,7 +804,7 @@ return msg;`)).
 			Description("Time-to-live for cached entries. 0 (default) keeps entries until explicit delete or restart. Set a positive duration (e.g. '1h') to auto-expire entries N after the last write.").
 			Default("0s"),
 		service.NewStringField("dedupKey").
-			Description("Name of the message metadata field whose value identifies a message across retries (e.g. 'kafka_offset', 'opcua_source_timestamp', 'spb_sequence'). When set, the plugin remembers each seen value in the cache and skips cache writes when the same value arrives again — so retried messages don't double-write counters or state. Leave empty (default) to disable; a startup warning is logged when disabled.").
+			Description("Name of the message metadata field whose value identifies a message across retries (e.g. 'kafka_offset', 'opcua_source_timestamp', 'spb_sequence'). When set, the plugin remembers each seen value in the cache and skips cache writes when the same value arrives again — so retried messages don't double-write counters or state. Leave empty (default) to disable; a startup warning is logged when disabled. This field will become required in a future release.").
 			Default(""),
 	).
 		Description("Cache configuration for state across messages.").
@@ -867,7 +861,7 @@ func newNodeREDJSProcessor(conf *service.ParsedConfig, mgr *service.Resources) (
 	}
 	processor.dedupKey = dedupKey
 	if dedupKey == "" {
-		mgr.Logger().Warnf("cache.dedupKey not set — retried messages will re-run cache writes. Set cache.dedupKey to a per-message identifier (e.g. kafka_offset) to skip already-processed messages.")
+		mgr.Logger().Warnf("cache.dedupKey not set — retried messages will re-run cache writes. Set cache.dedupKey to a per-message identifier (e.g. kafka_offset) to skip already-processed messages. This field will become required in a future release.")
 	}
 	return processor, nil
 }

--- a/nodered_js_plugin/nodered_js_plugin_test.go
+++ b/nodered_js_plugin/nodered_js_plugin_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 
 	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin"
+	"github.com/united-manufacturing-hub/benthos-umh/nodered_js_plugin/cache"
 )
 
 var _ = Describe("NodeREDJS Processor", func() {
@@ -2251,6 +2252,38 @@ return msg;
 			return handler, &msgs, cancel
 		}
 
+		// Same shape as buildStreamDedup, emitting cache.monotonicKey instead. The
+		// key is an interpolated string, so the same syntax reaches metadata
+		// ('${! meta("kafka_offset") }') or payload ('${! this.timestamp_ms }').
+		buildStreamMonotonic := func(monotonicKey, code string) (service.MessageHandlerFunc, *[]*service.Message, context.CancelFunc) {
+			builder := service.NewStreamBuilder()
+			handler, err := builder.AddProducerFunc()
+			Expect(err).NotTo(HaveOccurred())
+
+			yaml := fmt.Sprintf("nodered_js:\n  cache:\n    name: %q\n    monotonicKey: %q\n  code: |\n%s",
+				fmt.Sprintf("test-%d", time.Now().UnixNano()),
+				monotonicKey,
+				indentLines(code, "    "))
+			err = builder.AddProcessorYAML(yaml)
+			Expect(err).NotTo(HaveOccurred(),
+				"cache.monotonicKey does not exist yet — this is the field the design settled on 2026-08-07, "+
+					"and until it is implemented this test is red at config parse rather than at an assertion")
+
+			var msgs []*service.Message
+			err = builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+				msgs = append(msgs, m)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			stream, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			go func() { _ = stream.Run(ctx) }()
+			return handler, &msgs, cancel
+		}
+
 		It("suppresses cache writes when dedupKey value was seen before", func() {
 			handler, msgs, cancel := buildStreamDedup("kafka_offset", `
 var n = cache.exists("n") ? cache.get("n") : 0;
@@ -2336,6 +2369,692 @@ return msg;
 			Expect(payloadString(*msgs, 1)).To(Equal("gone"))
 		})
 
+		// RED, and it has to go green before this PR merges.
+		//
+		// dedupKey keeps the cache correct but not the message that leaves the
+		// processor. That was previously written up as an accepted trade-off, with
+		// the docs telling readers to dedup the output downstream themselves. That
+		// framing has been rejected, because it is not actionable here: the UNS
+		// writes every message to one compacted topic keyed by umh_topic, and
+		// compaction keeps the LAST value per key, so it preserves the wrong count
+		// rather than dropping it. Anything reading the stream live — the historian
+		// writing time series, for instance — records a wrong value at a real
+		// timestamp, and no downstream filter can recover it.
+		//
+		// The summary claim that counters "stay correct across retries" has already
+		// been narrowed in javascript-api.md to cover what is stored rather than
+		// what is published. What still describes today's behaviour, and becomes
+		// wrong the moment this test goes green, is the walkthrough under "What a
+		// retry looks like": it says the redelivered message leaves carrying the 43
+		// it computed locally and that the stored value is the authoritative one.
+		// Edit that in the same commit, and state whichever remedy was chosen next
+		// to the guarantee at the top of the section.
+		//
+		// The plugin-level options are genuinely constrained, which is why the
+		// choice belongs to the review rather than to whoever implements it: (a) is
+		// one field inside a counter()-style helper that owns the operation, but at
+		// plugin level needs a copy of the whole outgoing message, because the
+		// plugin cannot know which field is "the result"; (b) does not do what it
+		// looks like, because a processor cannot refuse a message — see the note on
+		// candidate (b) below.
+		//
+		// Invariant under test: a message may only carry a counter value that is
+		// actually committed. A consumer cannot distinguish a committed value from
+		// one that was computed and then discarded.
+		//
+		// The root cause is where the guard sits. DDIA 2nd ed, Ch. 12 "Stream
+		// Processing" -> Processing Streams -> Fault Tolerance -> "Idempotence"
+		// (this edition has no page numbers; cite by section):
+		//
+		//   "Even if an operation is not naturally idempotent, it can often be
+		//    made idempotent with a bit of extra metadata. For example, when
+		//    consuming messages from Kafka, every message has a persistent,
+		//    monotonically increasing offset. When writing a value to an external
+		//    database, you can include the offset of the message that triggered
+		//    the last write with the value. Thus, you can tell whether an update
+		//    has already been applied and avoid performing the same update again."
+		//
+		// "...with the value" is the whole design: one record, two fields, one
+		// write. Read {value, offset}, compare, and on a replay you already hold
+		// the committed value — so re-emitting it costs nothing. This PR stores
+		// the guard in a separate namespace (__dedup__:<v>) from the value, which
+		// is why the emitted message can diverge from committed state at all.
+		//
+		// The separate-marker-table shape is also blessed by the book, in a
+		// section new to the 2nd edition (Ch. 8 "Transactions" -> Distributed
+		// Transactions -> "Exactly-Once Message Processing Revisited"): keep "a
+		// table of message IDs that have been processed". But there it is one
+		// transaction with the processing, and it assumes the ID is deleted once
+		// the broker is acknowledged — "you will have an old message ID lying
+		// around, which doesn't do any harm besides taking up a little bit of
+		// storage space". A Benthos processor cannot observe the broker ack, so
+		// that cleanup is not implementable here. Which argues for the Ch. 12
+		// shape.
+		//
+		// The assertion pins the invariant, not a mechanism. Four candidates for
+		// the design discussion; this test takes no position between them:
+		//
+		//   a) Store the offset with the value (the Ch. 12 shape) and re-emit the
+		//      committed result when the write is suppressed. One extra field —
+		//      NOT a second copy of the message, so not the "rebuild the prior
+		//      message from cache" idea rejected in July. Cheap inside a counter()
+		//      helper; expensive at plugin level, because the plugin cannot know
+		//      which part of the message is "the result".
+		//   b) Error the replayed message instead of forwarding it. ⚠️ This does NOT
+		//      hold the message back: a processor cannot nack. On a non-nil return
+		//      the engine flags every part and appends the original batch to the
+		//      output anyway, logging at DEBUG level
+		//      (benthos internal/component/processor/auto_observed.go:261-269), so
+		//      the uncommitted value still reaches the output. Making the flag
+		//      actually stop the message needs error handling configured on the
+		//      pipeline, which is outside this plugin — realistically a umh-core
+		//      template concern, alongside the threads and dedupKey injection.
+		//   c) Keep the behaviour and put the guard in user code instead —
+		//      if (offset > last_offset) { ... } — where the branch is skipped
+		//      before the arithmetic rather than after it. Correct, but it means
+		//      documenting the pattern rather than fixing the plugin, so this test
+		//      would be deleted rather than made green.
+		//   d) Publish a correction afterwards, and optionally retract the earlier
+		//      value. This is the standard answer for an aggregate that has already
+		//      been published, and it needs nothing stored in advance — but the
+		//      wrong value still leaves first, and the consumer has to understand a
+		//      second message.
+		//
+		// Be precise about what satisfies the assertion, because only one of these
+		// does. The invariant is that no message carries a counter value that was
+		// never stored, and that can only be met by PREVENTING the wrong value:
+		//   - (a) meets it.
+		//   - (b) does not, on its own — the flagged message still reaches the
+		//     output unless the pipeline is configured to drop errored messages.
+		//   - (c) meets it only by changing the user's code, so the test goes away
+		//     rather than passing.
+		//   - (d) repairs rather than prevents, so the assertion still fails.
+		// The test is neutral about the mechanism that makes published == committed
+		// (helper, plugin-level snapshot, or userspace guard all qualify). It is not
+		// neutral between preventing the wrong value and correcting it afterwards.
+		It("never publishes a counter value that is not committed in the cache", func() {
+			handler, msgs, cancel := buildStreamDedup("kafka_offset", `
+var n = cache.exists("n") ? cache.get("n") : 0;
+n = n + 1;
+cache.set("n", n);
+// Re-reading after the write yields what is actually committed: on a suppressed
+// message the set was a no-op, so this is the value the consumer must agree with.
+msg.payload = { published: n, committed: cache.get("n") };
+return msg;
+`)
+			defer cancel()
+
+			ctx := context.Background()
+			// Three distinct source events, then a redelivery of the last one.
+			for _, offset := range []string{"42", "43", "44", "44"} {
+				Expect(handler(ctx, msgWithMeta("tick", "kafka_offset", offset))).To(Succeed())
+			}
+			// All four are forwarded today. Remedy (b) drops the replay instead, and
+			// would change this expectation deliberately.
+			Eventually(func() int { return len(*msgs) }).Should(Equal(4))
+
+			for i := range *msgs {
+				published := payloadMapFloat(*msgs, i, "published")
+				committed := payloadMapFloat(*msgs, i, "committed")
+				Expect(published).To(Equal(committed),
+					"message %d published counter %v, but the cache committed %v", i, published, committed)
+			}
+		})
+
+		// RED, and it has to go green before this PR merges.
+		//
+		// Unlike the counter case above, this one has a clean answer at plugin
+		// level, and it pays for itself twice: remember the highest dedupKey value
+		// seen instead of remembering every value. "Already processed" then becomes
+		// a comparison rather than a set lookup, which detects a straggler for free
+		// AND replaces the unbounded __dedup__: namespace with one entry — see the
+		// Limitations note about the cache growing without bound, which the user
+		// cannot mitigate for these keys because the docs reserve the prefix.
+		//
+		// Nothing checks that dedupKey values arrive in order.
+		//
+		// The docs section used to be titled "Idempotency and monotonicity under
+		// retries" while only idempotency was implemented; it has since been renamed
+		// to "Retries and duplicate messages" for exactly that reason, and it now
+		// states plainly that no value is compared against the ones before it. That
+		// sentence is what this test forbids, so it goes when this goes green.
+		// checkDedup asks "have I seen this exact value?" (a set-membership test
+		// against __dedup__:<v>); it never compares the incoming value with the
+		// highest one seen. Grep confirms it: no occurrence of out-of-order /
+		// monotonic / watermark / straggler anywhere in nodered_js_plugin or
+		// tag_processor_plugin. The old heading's word "monotonicity" in
+		// the heading is doing no work.
+		//
+		// Consequence: a straggler — an older event arriving after a newer one —
+		// looks brand new, so its write is applied on top of state derived from a
+		// later event. A membership test cannot detect this; a high-water mark
+		// would, for free.
+		//
+		// The downsampler is the one component in this repo that does compare
+		// timestamps — but check what it actually does before treating it as
+		// precedent. Its `late_policy` defaults to `passthrough`, so a late sample is
+		// forwarded unchanged rather than dropped. docs/processing/downsampler.md:124
+		// says it is "flagging it with meta:late_oos=true", and nothing in the code
+		// sets that flag — zero non-test occurrences of `late_oos`. The drop path
+		// logs at Debug only, and none of its eight metrics counts late arrivals.
+		// So in the default configuration a late sample passes through silently: no
+		// marker, no counter, nothing above debug.
+		//
+		// Two plugins, two answers, and neither is observable. The 2026-07-16
+		// proposal asked for one ordered-stream check and one warning shape across
+		// stateful components, naming the downsampler as the next adopter; it got
+		// there first, independently, and without the instrumentation.
+		//
+		// DDIA 2nd ed gives exactly two options, and names dropping first — Ch. 12
+		// "Stream Processing" -> Processing Streams -> Reasoning About Time ->
+		// "Handling straggler events" (no page numbers in this edition):
+		//
+		//   "You need to be able to handle such straggler events that arrive after
+		//    the window has already been declared complete. Broadly, you have two
+		//    options:
+		//      - Ignore the straggler events, as they are probably a small
+		//        percentage of events in normal circumstances. You can track the
+		//        number of dropped events as a metric and alert if you start
+		//        dropping a significant amount of data.
+		//      - Publish a correction, an updated value for the window with
+		//        stragglers included. You may also need to retract the previous
+		//        output."
+		//
+		// Note the instrumentation is the book's advice, not ours — and neither
+		// plugin follows it. The downsampler's default is neither of the two options
+		// above: it forwards the late sample unchanged, with the marker its own docs
+		// promise never actually set, no counter, and only a Debug line. The cache
+		// path does not detect the case at all.
+		//
+		// The book also draws the line we already drew by operation, Ch. 12 ->
+		// Transmitting Event Streams -> "Messaging Systems":
+		//
+		//   "with sensor readings and metrics that are transmitted periodically, an
+		//    occasional missing data point is perhaps not important, since an
+		//    updated value will be sent a short time later anyway. However, beware
+		//    that if a large number of messages are dropped, it may not be
+		//    immediately apparent that the metrics are incorrect. If you are
+		//    counting events, it is more important that they are delivered
+		//    reliably, since every lost message means incorrect counters."
+		//
+		// So: dropping is defensible for a gauge or a delta, and not for a count —
+		// the same split as idempotent-vs-accumulate. Whatever we choose has to be
+		// stated per operation, not once for the whole cache.
+		//
+		// One vocabulary caution: "watermark" is NOT this book's term. It appears
+		// twice in the whole 2nd edition, both about Netflix's DBLog CDC snapshot
+		// algorithm. The concept is there unnamed — "a special message to indicate
+		// that 'from now on, there will be no more messages with a timestamp
+		// earlier than t'" (attributed to MillWheel) — with the caveat that it gets
+		// hard when several producers each have their own threshold. Our single
+		// partition is what makes it tractable here. Don't cite DDIA for the word.
+		//
+		// Note what suppression alone cannot fix. For a retry, skipping the write
+		// protects the cache. For a straggler it does not: if the write is skipped
+		// but the message is still forwarded and the JS still runs, the arithmetic
+		// has already read newer state and will publish a garbage difference. So
+		// "warn and forward unchanged" is not a sufficient remedy here, whereas
+		// dropping the straggler, rejecting it, or guarding in user code all are.
+		// That asymmetry is worth an explicit decision.
+		//
+		// The assertion: no message may be processed whose ordering key is older
+		// than the state already in the cache. Sequence 1000, 3000, 2000, 4000 —
+		// 2000 is the straggler. Today it sails through and clobbers "last" back
+		// to an older value, so the 4000 message then computes its difference from
+		// 2000 instead of 3000.
+		It("does not process a dedupKey value older than the state already committed", func() {
+			handler, msgs, cancel := buildStreamDedup("event_ts", `
+var last = cache.exists("last") ? cache.get("last") : 0;
+var ts = Number(msg.meta.event_ts);
+cache.set("last", ts);
+msg.payload = { ts: ts, last_before: last };
+return msg;
+`)
+			defer cancel()
+
+			ctx := context.Background()
+			for _, ts := range []string{"1000", "3000", "2000", "4000"} {
+				Expect(handler(ctx, msgWithMeta("sample", "event_ts", ts))).To(Succeed())
+			}
+			Eventually(func() int { return len(*msgs) }).Should(Equal(4))
+
+			for i := range *msgs {
+				ts := payloadMapFloat(*msgs, i, "ts")
+				lastBefore := payloadMapFloat(*msgs, i, "last_before")
+				Expect(ts).To(BeNumerically(">=", lastBefore),
+					"message %d carries ordering key %v but the cache already reflected %v — a straggler was processed as if fresh",
+					i, ts, lastBefore)
+			}
+		})
+
+		When("specifying monotonicKey, the field that REPLACES dedupKey (not implemented yet)", func() {
+
+			// `monotonicKey` REPLACES `dedupKey`. It is not a second field to build
+			// alongside it, and nothing should ever accept both.
+			//
+			// | | `dedupKey` (ships today) | `monotonicKey` (this block) |
+			// |---|---|---|
+			// | reads | metadata only, via `msg.MetaGet` | metadata OR payload, one interpolated syntax |
+			// | compares | set membership on `__dedup__:<v>` | strictly `>` a stored mark |
+			// | stores | one entry per message, forever | one mark per cache key |
+			// | catches | a redelivery | a redelivery, a straggler, AND a non-monotonic key |
+			// | misses | anything about order | tells the three cases apart (it cannot) |
+			//
+			// So when `monotonicKey` lands, `dedupKey` is REMOVED, not deprecated next to
+			// it. The five tests above still use `dedupKey` only because it is what ships
+			// in this PR; they get renamed by the change that implements this block, and
+			// the config parser should reject `dedupKey` at that point rather than quietly
+			// honouring both. That rejection cannot be tested here — it would contradict
+			// the five tests above — so it belongs to the implementation, and it is named
+			// here so it is not forgotten.
+			//
+			// The two tests below fail at config parse, not at an assertion, until
+			// `cache.monotonicKey` exists. That is deliberate: they are the design decided
+			// on 2026-08-07, written in the one form that cannot be misread. Classify them
+			// as a follow-up ticket, NOT as a merge gate — a red test for an unbuilt API
+			// must not block this PR, only the rollout.
+			//
+			// Why a rename rather than teaching `dedupKey` to read the payload:
+			// `dedupKey` is set membership on a value (`__dedup__:<v>`), and set
+			// membership on a timestamp silently drops a second genuine sample that lands
+			// in the same millisecond. The two mechanisms want different comparisons, so
+			// they get different names. `monotonicKey` also states its own precondition,
+			// which `dedupKey` does not.
+			//
+			// The shape:
+			//
+			//   cache:
+			//     monotonicKey: '${! meta("kafka_offset") }'   # or '${! this.timestamp_ms }'
+			//
+			// An interpolated string reaches metadata or payload with one syntax, so no
+			// new lookup logic is needed — `service.NewInterpolatedStringField` is already
+			// used in this repo (uns_output.go:97, opcua_plugin/write.go:57). This is what
+			// makes `timestamp_ms` usable at all: it lives in the payload, and `dedupKey`
+			// resolves through `msg.MetaGet`, so today it can never be found.
+			//
+			// Both candidate values are already monotonic — a `kafka_offset` because
+			// `umh.messages` is hard-enforced single-partition (uns_output.go:43,326), a
+			// `timestamp_ms` within one series — so ONE comparison covers both, and it
+			// does three jobs at once: it spots a retry, it spots a straggler, and it is
+			// itself the check that the key is monotonic.
+			//
+			// Accept a write when the key is strictly greater than the mark. Not-greater
+			// means one of retry, genuinely-late, or a key that was never monotonic; the
+			// comparison cannot tell them apart and should not pretend to (Flink's
+			// late-data counter has the same limitation). Document it, don't design
+			// around it.
+			//
+			// This test takes no position on where the mark is stored, only on what must
+			// hold. The recommendation is with the value, per cache key — DDIA Ch. 12,
+			// "Idempotence": "you can include the offset of the message that triggered the
+			// last write with the value". That bounds the state at one mark per key
+			// instead of one `__dedup__:` entry per message forever, which is the same
+			// fix the straggler gate above needs. The second test below is what rules out
+			// the tempting shortcut of a single global mark.
+
+			// The payload-reading counterpart to the straggler gate above. Same invariant,
+			// reached through the proposed field and an ordering value that lives in the
+			// payload — which is the case `dedupKey` structurally cannot serve.
+			It("catches the straggler that dedupKey structurally cannot, because the value is in the payload", func() {
+				handler, msgs, cancel := buildStreamMonotonic(`${! this.timestamp_ms }`, `
+var last = cache.exists("last") ? cache.get("last") : 0;
+var ts = msg.payload.timestamp_ms;
+cache.set("last", ts);
+msg.payload = { ts: ts, last_before: last };
+return msg;
+`)
+				defer cancel()
+
+				ctx := context.Background()
+				for _, ts := range []int{1000, 3000, 2000, 4000} {
+					payload := fmt.Sprintf(`{"timestamp_ms":%d,"value":1}`, ts)
+					Expect(handler(ctx, service.NewMessage([]byte(payload)))).To(Succeed())
+				}
+				Eventually(func() int { return len(*msgs) }).Should(Equal(4))
+
+				for i := range *msgs {
+					ts := payloadMapFloat(*msgs, i, "ts")
+					lastBefore := payloadMapFloat(*msgs, i, "last_before")
+					Expect(ts).To(BeNumerically(">=", lastBefore),
+						"message %d carries monotonicKey %v but the cache already reflected %v — the straggler was written as if fresh",
+						i, ts, lastBefore)
+				}
+			})
+
+			// The implementation detail that a passing first test does not prove. One
+			// global high-water mark satisfies the test above and is still wrong: two
+			// tags have unrelated clocks and rates, so the fastest series would suppress
+			// every slower one, permanently and silently.
+			//
+			// Interleaved so that a global mark is fatal: series A runs at 5000/6000
+			// while series B runs at 1000/2000. Under a global mark, B's first write is
+			// below A's mark and is suppressed, so B's second message reads 0 for its
+			// previous value instead of 1000 — a whole series of state quietly lost.
+			It("keeps a separate mark per cache key so one series cannot suppress another", func() {
+				handler, msgs, cancel := buildStreamMonotonic(`${! this.timestamp_ms }`, `
+var key = "last_" + msg.meta.series;
+var last = cache.exists(key) ? cache.get(key) : 0;
+var ts = msg.payload.timestamp_ms;
+cache.set(key, ts);
+msg.payload = { ts: ts, last_before: last };
+return msg;
+`)
+				defer cancel()
+
+				ctx := context.Background()
+				samples := []struct {
+					series string
+					ts     int
+				}{
+					{"a", 5000},
+					{"b", 1000},
+					{"a", 6000},
+					{"b", 2000},
+				}
+				for _, s := range samples {
+					msg := service.NewMessage([]byte(fmt.Sprintf(`{"timestamp_ms":%d,"value":1}`, s.ts)))
+					msg.MetaSet("series", s.series)
+					Expect(handler(ctx, msg)).To(Succeed())
+				}
+				Eventually(func() int { return len(*msgs) }).Should(Equal(4))
+
+				// Series B's second sample must see B's own first sample, not zero.
+				Expect(payloadMapFloat(*msgs, 3, "last_before")).To(BeNumerically("==", 1000),
+					"series b saw %v as its previous value instead of 1000 — series a's higher mark suppressed b's write, so the mark is global rather than per cache key",
+					payloadMapFloat(*msgs, 3, "last_before"))
+
+				// And series A must be unaffected, which rules out the mirror error.
+				Expect(payloadMapFloat(*msgs, 2, "last_before")).To(BeNumerically("==", 5000),
+					"series a saw %v as its previous value instead of 5000",
+					payloadMapFloat(*msgs, 2, "last_before"))
+			})
+
+		})
+
+		// The alarm case: the counter's mirror image. There the retry publishes a
+		// value that is too high; here it publishes nothing at all.
+		//
+		// The JS below is the shipped "Alarm state tracking" example from
+		// javascript-api.md, unchanged. It is a latch: the state lives in the cache
+		// (alarm_active) and the event lives on the message (meta.alarm), and the
+		// event is only stamped on the transition. Run 1 sets the state and stamps
+		// "triggered", then its output fails. The redelivery finds the state already
+		// set, so neither branch fires, and the message leaves with no annotation —
+		// the transition is never published to anyone. The clear side loses
+		// "cleared" the same way, which leaves a consumer showing an alarm that
+		// never ends while the cache says it ended.
+		//
+		// dedupKey neither causes nor fixes this: the branch conditions have already
+		// evaluated false, so there was no write to suppress. It is what at-least-
+		// once does to any level-to-edge conversion, and the 2026-07-16 proposal
+		// recorded the same failure for delta()/changed().
+		//
+		// Two remedies, and the choice is open:
+		//   - Store the result the first run produced and re-emit it when the write
+		//     is suppressed. Note this is the ONLY remedy that works here — erroring
+		//     the replay instead (an option for the counter) does not help, because
+		//     every retry recomputes an empty annotation, so the alarm can never be
+		//     delivered at all.
+		//   - Change the pattern: publish the state on every message and let
+		//     consumers derive the transition. If that is the answer, this test is
+		//     deleted along with the example rather than made green.
+		It("re-publishes the alarm edge when the first attempt's output failed", func() {
+			// This builds its own stream rather than using buildStreamDedup, because
+			// the whole point is an output that FAILS on the first attempt. Sending
+			// the same message twice through a succeeding output proves nothing: the
+			// first delivery would carry the annotation and the duplicate lacking it
+			// is harmless under at-least-once.
+			builder := service.NewStreamBuilder()
+			handler, err := builder.AddProducerFunc()
+			Expect(err).NotTo(HaveOccurred())
+
+			yaml := fmt.Sprintf("nodered_js:\n  cache:\n    name: %q\n    dedupKey: \"kafka_offset\"\n  code: |\n%s",
+				fmt.Sprintf("test-alarm-%d", time.Now().UnixNano()),
+				indentLines(`
+var alarmed = false;
+if (cache.exists("alarm_active")) { alarmed = cache.get("alarm_active"); }
+if (msg.payload.value > 100 && !alarmed) {
+  cache.set("alarm_active", true);
+  msg.meta.alarm = "triggered";
+  return msg;
+}
+if (msg.payload.value <= 100 && alarmed) {
+  cache.set("alarm_active", false);
+  msg.meta.alarm = "cleared";
+  return msg;
+}
+return msg;
+`, "    "))
+			Expect(builder.AddProcessorYAML(yaml)).To(Succeed())
+
+			// The output rejects exactly once, then accepts. Only messages the output
+			// accepted are recorded — those are the ones that actually reached the UNS.
+			var delivered []*service.Message
+			var rejectOnce atomic.Bool
+			rejectOnce.Store(true)
+			Expect(builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+				if rejectOnce.CompareAndSwap(true, false) {
+					return fmt.Errorf("simulated output failure")
+				}
+				delivered = append(delivered, m)
+				return nil
+			})).To(Succeed())
+
+			stream, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			go func() { _ = stream.Run(ctx) }()
+
+			newSample := func() *service.Message {
+				m := service.NewMessage([]byte(`{"value": 150}`))
+				m.MetaSet("kafka_offset", "42")
+				return m
+			}
+
+			// Attempt 1: JS stamps "triggered" and commits alarm_active, then the
+			// output rejects — nothing reaches the UNS.
+			_ = handler(ctx, newSample())
+			// At-least-once: the same record is redelivered.
+			Expect(handler(ctx, newSample())).To(Succeed())
+
+			Eventually(func() int { return len(delivered) }).Should(Equal(1))
+
+			alarm, ok := delivered[0].MetaGet("alarm")
+			Expect(ok).To(BeTrue(),
+				"the only message that reached the output carries no alarm annotation, so the transition was published to nobody")
+			Expect(alarm).To(Equal("triggered"))
+		})
+
+		// RED — and unlike the three above, this one is a defect in this PR's own
+		// code rather than a hazard inherited from at-least-once delivery.
+		//
+		// checkDedup builds the marker key from the dedup value alone —
+		// DedupCacheKeyPrefix + v — with nothing recording which processor wrote it.
+		// Cache instances are shared by backend+name, and name DEFAULTS to "shared",
+		// so two nodered_js processors in one pipeline share a cache unless someone
+		// deliberately opts out. Processor 1 records __dedup__:<v>; processor 2 then
+		// finds it on the FIRST delivery of that message and suppresses its writes.
+		// Its state is never written at all, and every message logs a spurious retry
+		// WARN pointing at an upstream that is behaving perfectly.
+		//
+		// This is reachable by doing nothing unusual: the "Sharing across processors"
+		// section of javascript-api.md shows exactly this shape, two nodered_js stages
+		// on implicit defaults. Set dedupKey on both and the second silently stops
+		// keeping state.
+		//
+		// Fix direction: scope the marker to whichever processor wrote it, so two
+		// processors guarding on the same value cannot collide. That also decides
+		// ENG-5051 (sharing a cache across nodered_js processors) — sharing and
+		// dedupKey cannot both work until this is fixed.
+		It("lets two processors sharing a cache dedup independently", func() {
+			builder := service.NewStreamBuilder()
+			handler, err := builder.AddProducerFunc()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Both stages name the same cache. The default name is "shared", so this
+			// is the arrangement a user gets by configuring nothing at all.
+			cacheName := fmt.Sprintf("test-shared-%d", time.Now().UnixNano())
+			stages := []string{`
+var a = cache.exists("a") ? cache.get("a") : 0;
+a = a + 1;
+cache.set("a", a);
+msg.payload = { a: a };
+return msg;
+`, `
+var b = cache.exists("b") ? cache.get("b") : 0;
+b = b + 1;
+cache.set("b", b);
+msg.payload.b = b;
+return msg;
+`}
+			for _, code := range stages {
+				yaml := fmt.Sprintf("nodered_js:\n  cache:\n    name: %q\n    dedupKey: \"kafka_offset\"\n  code: |\n%s",
+					cacheName, indentLines(code, "    "))
+				Expect(builder.AddProcessorYAML(yaml)).To(Succeed())
+			}
+
+			var msgs []*service.Message
+			Expect(builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+				msgs = append(msgs, m)
+				return nil
+			})).To(Succeed())
+
+			stream, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			go func() { _ = stream.Run(ctx) }()
+
+			// Three distinct messages — no retries anywhere in this test.
+			for _, offset := range []string{"1", "2", "3"} {
+				Expect(handler(ctx, msgWithMeta("tick", "kafka_offset", offset))).To(Succeed())
+			}
+			Eventually(func() int { return len(msgs) }).Should(Equal(3))
+
+			for i := range msgs {
+				want := float64(i + 1)
+				Expect(payloadMapFloat(msgs, i, "a")).To(Equal(want),
+					"the first processor should have counted %v distinct messages", want)
+				Expect(payloadMapFloat(msgs, i, "b")).To(Equal(want),
+					"the second processor's counter stalled at 1: the first processor had already written the marker for this message, so the second one's own writes never commit")
+			}
+		})
+
+		// RED, and it has to go green before this PR merges.
+		//
+		// ProcessBatch opens a cache transaction, buffers every write the batch
+		// makes, and closes it with `defer u.cacheCommit(ctx)`. cacheCommit logs a
+		// failed Commit and returns nothing, so ProcessBatch still reports success.
+		// The pipeline then acknowledges the batch: the messages go to the output
+		// and the input is told it may forget them, while the state they were
+		// supposed to produce went away with the transaction. Nothing is left to
+		// redeliver, so the loss is permanent, and the only trace is one log line
+		// in a stream where every other signal says the batch succeeded.
+		//
+		// The discard is real, not hypothetical. Under the persistent backend
+		// BboltStore.Set writes into the bolt tx that Begin opened, and a failed
+		// tx.Commit throws that tx away with every write in it. There is no
+		// Rollback on the Cache interface and nothing reconciles afterwards, so a
+		// batch that failed to commit leaves no record of what it meant to write.
+		// The store injected below models that: buffered between Begin and Commit,
+		// visible to reads inside the transaction, dropped when the Commit fails.
+		//
+		// Invariant under test: committed state must account for every message the
+		// processor hands on as good. A batch whose writes did not persist may not
+		// leave looking like a batch that succeeded, because the acknowledgement
+		// that follows is what makes the loss unrecoverable.
+		//
+		// "As good" and not "acknowledged", because a Benthos processor cannot stop
+		// an acknowledgement, and this was checked rather than assumed: with
+		// cacheCommit's error plumbed through to ProcessBatch's return, all three
+		// messages below were still acknowledged. The engine wrapper around every
+		// registered processor discards the returned error — it stamps each part
+		// via MarkErr and forwards the original batch (auto_observed.go, the
+		// `if err != nil` branch of v2BatchedToV1Processor.ProcessBatch, which then
+		// returns a nil error). What a processor controls is whether the message
+		// carries an error, and an errored message is one an error-handling output
+		// can reject; a clean one is a claim that the batch worked.
+		//
+		// Fix direction: cacheCommit has to be able to fail the batch, so the
+		// commit error reaches ProcessBatch's return instead of only the log. What
+		// happens around that is open — whether the commit is retried before giving
+		// up, whether the error is returned once for the batch or attached per
+		// message, whether a failed commit should also tear the store down, and
+		// what a pipeline is then expected to configure downstream so the flagged
+		// messages are actually rejected rather than written. The assertion pins
+		// the invariant, not any of those: it compares messages certified against
+		// increments committed, so returning the error and making the commit
+		// durable enough not to lose the writes satisfy it equally. Doing nothing
+		// does not.
+		It("does not report success for a batch whose cache commit failed", func() {
+			// Attach a store whose second commit fails by pre-seeding it in the
+			// registry under the key openCacheStore computes for this cache.name;
+			// Acquire then hands the processor this instance instead of building a
+			// MemoryStore, whose no-op Commit could never fail.
+			cacheName := fmt.Sprintf("test-commit-fail-%d", time.Now().UnixNano())
+			store := newCommitFailingStore(2)
+			seeded, err := cache.Acquire("mem:"+cacheName, func() (cache.Cache, error) { return store, nil })
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = seeded.Close() }()
+
+			builder := service.NewStreamBuilder()
+			handler, err := builder.AddProducerFunc()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(builder.AddProcessorYAML(fmt.Sprintf("nodered_js:\n  cache:\n    name: %q\n  code: |\n%s",
+				cacheName, indentLines(`
+var n = cache.exists("n") ? cache.get("n") : 0;
+n = n + 1;
+cache.set("n", n);
+msg.payload = n;
+return msg;
+`, "    ")))).To(Succeed())
+
+			// certified counts the messages that reached the output carrying no
+			// error — the ones the processor vouched for. flagged counts the rest.
+			var certified, flagged atomic.Int64
+			Expect(builder.AddConsumerFunc(func(_ context.Context, m *service.Message) error {
+				if m.GetError() != nil {
+					flagged.Add(1)
+				} else {
+					certified.Add(1)
+				}
+				return nil
+			})).To(Succeed())
+
+			stream, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			go func() { _ = stream.Run(ctx) }()
+
+			// One message per batch, sent one at a time. A nil return from handler
+			// is the acknowledgement: the input may forget that message.
+			acknowledged := 0
+			for i := range 3 {
+				if handler(ctx, newMsg(fmt.Sprintf("tick-%d", i))) == nil {
+					acknowledged++
+				}
+			}
+			Eventually(func() int64 { return certified.Load() + flagged.Load() }).
+				Should(Equal(int64(acknowledged)), "the pipeline never settled")
+
+			// Positive control. Without a commit that actually failed and actually
+			// discarded its writes, the assertion below would prove nothing.
+			Eventually(store.failedCommits).Should(Equal(1),
+				"the injected commit failure never fired, so this spec is not exercising the case it claims to")
+
+			committed, found := store.committedValue("n")
+			Expect(found).To(BeTrue(), "no counter value was ever committed")
+			Expect(float64(certified.Load())).To(BeNumerically("<=", committed),
+				"%d of the %d acknowledged messages left the processor as successes, but the counter committed to the cache is only %v: a failed commit discarded a batch's writes, was logged and dropped, and the batch went out indistinguishable from one that worked — nothing will redeliver it",
+				certified.Load(), acknowledged, committed)
+		})
+
 		It("plain get+set counter is atomic across concurrent messages (auto-lock)", func() {
 			handler, msgs, cancel := buildStream(`
 var n = cache.exists("counter") ? cache.get("counter") : 0;
@@ -2395,6 +3114,27 @@ func payloadString(msgs []*service.Message, i int) string {
 	str, ok := s.(string)
 	Expect(ok).To(BeTrue(), "expected string payload, got %T: %v", s, s)
 	return str
+}
+
+// payloadMapFloat extracts a numeric field from an object payload in messages[i].
+func payloadMapFloat(msgs []*service.Message, i int, key string) float64 {
+	s, err := msgs[i].AsStructured()
+	Expect(err).NotTo(HaveOccurred())
+	m, ok := s.(map[string]any)
+	Expect(ok).To(BeTrue(), "expected object payload, got %T: %v", s, s)
+	v, present := m[key]
+	Expect(present).To(BeTrue(), "payload has no %q field: %v", key, m)
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int64:
+		return float64(n)
+	case int:
+		return float64(n)
+	default:
+		Fail(fmt.Sprintf("expected numeric %q, got %T: %v", key, v, v))
+		return 0
+	}
 }
 
 // payloadFloat extracts a numeric payload as float64 (goja may return int64 for whole numbers).
@@ -2526,6 +3266,157 @@ func (noopTimer) Timing(int64) {}
 type noopGauge struct{}
 
 func (noopGauge) Set(int64) {}
+
+// commitFailingStore is a cache.Cache that fails one Commit on demand.
+//
+// It reproduces the persistent backend's transaction semantics rather than the
+// memory backend's: writes made between Begin and Commit are buffered, reads
+// inside the transaction see them, and they only reach the underlying store
+// when the Commit succeeds. That is BboltStore's shape — Set and Delete write
+// into the bolt tx opened by Begin, and a failed tx.Commit throws the tx away
+// with everything in it. MemoryStore, whose Begin and Commit are both no-ops,
+// cannot express the case at all.
+//
+// A test attaches one of these to a processor by pre-seeding it in the cache
+// registry under the key the processor will compute for its cache.name, so
+// cache.Acquire hands the processor this store instead of building a new one.
+type commitFailingStore struct {
+	inner *cache.MemoryStore
+
+	mu      sync.Mutex
+	pending map[string]pendingWrite
+	inTx    bool
+	begun   int
+	failOn  int // 1-based index of the batch whose Commit fails
+	failed  int
+}
+
+// pendingWrite is one buffered mutation: a value to store, or a tombstone.
+type pendingWrite struct {
+	value   any
+	deleted bool
+}
+
+var _ cache.Cache = (*commitFailingStore)(nil)
+
+// newCommitFailingStore returns a store whose failOn'th Commit (counting from
+// the first Begin) fails and discards that batch's buffered writes.
+func newCommitFailingStore(failOn int) *commitFailingStore {
+	return &commitFailingStore{inner: cache.NewMemoryStore(0), failOn: failOn}
+}
+
+func (s *commitFailingStore) Set(ctx context.Context, key string, value any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.inTx {
+		return s.inner.Set(ctx, key, value)
+	}
+	s.pending[key] = pendingWrite{value: value}
+	return nil
+}
+
+func (s *commitFailingStore) Get(ctx context.Context, key string) (any, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inTx {
+		w, buffered := s.pending[key]
+		if buffered {
+			if w.deleted {
+				return nil, false
+			}
+			return w.value, true
+		}
+	}
+	return s.inner.Get(ctx, key)
+}
+
+func (s *commitFailingStore) Delete(ctx context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.inTx {
+		return s.inner.Delete(ctx, key)
+	}
+	s.pending[key] = pendingWrite{deleted: true}
+	return nil
+}
+
+func (s *commitFailingStore) Lock() { s.inner.Lock() }
+
+func (s *commitFailingStore) Unlock() { s.inner.Unlock() }
+
+func (s *commitFailingStore) Begin(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inTx {
+		return fmt.Errorf("commitFailingStore: begin called with an active batch")
+	}
+	s.inTx = true
+	s.begun++
+	s.pending = make(map[string]pendingWrite)
+	return nil
+}
+
+func (s *commitFailingStore) Commit(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.inTx {
+		return nil
+	}
+	s.inTx = false
+	pending := s.pending
+	s.pending = nil
+
+	if s.begun == s.failOn {
+		s.failed++
+		return fmt.Errorf("commitFailingStore: injected commit failure on batch %d (%d buffered writes discarded)", s.begun, len(pending))
+	}
+
+	for key, w := range pending {
+		var err error
+		if w.deleted {
+			err = s.inner.Delete(ctx, key)
+		} else {
+			err = s.inner.Set(ctx, key, w.value)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *commitFailingStore) Stats(ctx context.Context) (cache.Stats, error) {
+	return s.inner.Stats(ctx)
+}
+
+func (s *commitFailingStore) Close() error { return s.inner.Close() }
+
+// failedCommits reports how many Commits were failed by injection.
+func (s *commitFailingStore) failedCommits() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.failed
+}
+
+// committedValue returns the numeric value the underlying store actually holds
+// for key. found is false when nothing was ever committed under that key.
+func (s *commitFailingStore) committedValue(key string) (float64, bool) {
+	v, ok := s.inner.Get(context.Background(), key)
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int64:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	default:
+		Fail(fmt.Sprintf("expected numeric committed value for %q, got %T: %v", key, v, v))
+		return 0, false
+	}
+}
 
 var _ = Describe("js logmessage", func() {
 	DescribeTable(

--- a/tag_processor_plugin/tag_processor_plugin.go
+++ b/tag_processor_plugin/tag_processor_plugin.go
@@ -82,7 +82,7 @@ Empty or undefined fields will be omitted from the topic.`).
 			Default("").
 			Optional()).
 		Field(service.NewStringField("dedupKey").
-			Description("Name of the message metadata field whose value identifies a message across retries (for example `kafka_offset`). When set, cache.set/delete calls from JavaScript are silently skipped for a message whose value has already been processed once, so the cache state stays idempotent under at-least-once retries. Leave empty to disable — a startup warning is logged if unset.").
+			Description("Name of the message metadata field whose value identifies a message across retries (for example `kafka_offset`). When set, cache.set/delete calls from JavaScript are silently skipped for a message whose value has already been processed once, so the cache state stays idempotent under at-least-once retries. Leave empty to disable — a startup warning is logged if unset. This field will become required in a future release.").
 			Default("").
 			Advanced())
 
@@ -132,7 +132,7 @@ Empty or undefined fields will be omitted from the topic.`).
 				return nil, err
 			}
 			if dedupKey == "" {
-				mgr.Logger().Warnf("tag_processor.dedupKey not set — retried messages will re-run cache writes. Set dedupKey to a per-message identifier (e.g. kafka_offset) to skip already-processed messages.")
+				mgr.Logger().Warnf("tag_processor.dedupKey not set — retried messages will re-run cache writes. Set dedupKey to a per-message identifier (e.g. kafka_offset) to skip already-processed messages. This field will become required in a future release.")
 			}
 
 			config := TagProcessorConfig{

--- a/uns_plugin/uns_input_processor.go
+++ b/uns_plugin/uns_input_processor.go
@@ -97,6 +97,14 @@ func (p *MessageProcessor) ProcessRecord(record *kgo.Record) *service.Message {
 	// Add Kafka timestamp (when the record was written to Kafka) - this is used by the topic browser for ProducedAtMs
 	msg.MetaSetMut("kafka_timestamp_ms", fmt.Sprintf("%d", record.Timestamp.UnixMilli()))
 
+	// Partition and offset identify a record uniquely and survive redelivery, so downstream
+	// processors can tell a retried message from a new one (nodered_js/tag_processor dedupKey).
+	// An offset is only unique within its partition, so both are needed to compose a key.
+	// Types match Redpanda Connect's own redpanda/kafka_franz reader, which the uns_beta input
+	// delegates to, so a config written against either input behaves identically after a switch.
+	msg.MetaSetMut("kafka_partition", int(record.Partition))
+	msg.MetaSetMut("kafka_offset", int(record.Offset))
+
 	return msg
 }
 

--- a/uns_plugin/uns_input_test.go
+++ b/uns_plugin/uns_input_test.go
@@ -717,6 +717,39 @@ var _ = Describe("MessageProcessor metadata format conversion", Label("message_p
 		})
 	})
 
+	Context("when a record carries a partition and an offset", func() {
+		// The nodered_js and tag_processor dedupKey feature identifies a retried message
+		// by a metadata field, read with MetaGet. Without these two fields the documented
+		// example (dedupKey: kafka_offset) matches nothing and dedup silently does not run.
+		It("exposes them as metadata so they can be used as a dedup key", func() {
+			processor, err := NewMessageProcessor([]string{".*"}, metrics, MetadataFormatString)
+			Expect(err).ToNot(HaveOccurred())
+
+			record := &kgo.Record{
+				Key:       []byte("umh.v1.enterprise.site.area.line._raw.temperature"),
+				Value:     []byte(`{"value": 42}`),
+				Topic:     "umh.messages",
+				Partition: 3,
+				Offset:    4242,
+			}
+
+			msg := processor.ProcessRecord(record)
+			Expect(msg).NotTo(BeNil())
+
+			// Stored as strings so MetaGet — the accessor the dedup path uses — returns
+			// the value directly.
+			offset, exists := msg.MetaGet("kafka_offset")
+			Expect(exists).To(BeTrue(), "kafka_offset must be present for dedupKey to work")
+			Expect(offset).To(Equal("4242"))
+
+			// An offset is only unique within its partition, so a correct dedup key
+			// composes both.
+			partition, exists := msg.MetaGet("kafka_partition")
+			Expect(exists).To(BeTrue(), "kafka_partition must be present to disambiguate offsets")
+			Expect(partition).To(Equal("3"))
+		})
+	})
+
 	Context("when metadataFormat is 'bytes'", func() {
 		It("should keep Kafka headers as byte arrays", func() {
 			processor, err := NewMessageProcessor([]string{".*"}, metrics, MetadataFormatBytes)


### PR DESCRIPTION
# Cache retry semantics: one fix, seven failing tests, corrected docs

> **This branch fails CI on purpose.** Seven of its tests do not pass. Five write down what the cache should do
> and does not do today — those are the definition of done for this work, not a mistake. The other two suggest
> how one of the five could be fixed; they are not a gate and nothing here has to make them pass.

## Problem

UMH delivers at least once, so we expect the same message to arrive more than once. `dedupKey` stops a repeat
from writing to the cache twice. That part works.

The rest splits into two groups.

**One case was already known and written up as a limitation.** On a retry the cache is not updated, but the
message still goes out with an invalid counter — one higher than what is stored. The docs say to handle those
duplicates downstream. That does not work. The message that goes out is not a duplicate of anything — it is a
single message carrying a wrong number, so there is nothing for a filter to match on. For a customer counting
products, it reads as one more product than they made.

**Four cases were not known.**

- Two processors sharing one cache stop deduplicating properly.
- A batch is reported as a success even when its cache write failed.
- A latched alarm is lost if the first send fails.
- Nothing checks whether a message arrived out of order.

Separately, the setup the docs recommend does not work at all: they tell you to use `kafka_offset`, and the
`uns` input never sets it. That one is fixed here.

## Shipping

**A fix so `dedupKey` can be used at all.** The `uns` input now sets `kafka_offset` and `kafka_partition`. The
types match Redpanda Connect's own Kafka reader, so a config written against `uns` keeps working if you move to
`uns_beta`.

**Five failing tests, one per case above.** They do not pass. Each one writes down what the cache should do.
None of them picks a fix — that part is still open.

Two should block the merge:

- Two processors sharing one cache stop deduplicating properly.
- Nothing checks whether a message arrived out of order. Today every value is stored — one `__dedup__:` key per
  message, kept until a TTL removes it — and "have I seen this before?" is a lookup in that set. If we require
  the value to increase instead, we only have to remember the highest one. Then deduplication is a `>`
  comparison against a single number, out-of-order arrivals become visible for free, and the keys stop growing
  without limit.

  This is the standard approach, from *Designing Data-Intensive Applications* (2nd edition, Chapter 12,
  "Idempotence"):

  > "For example, when consuming messages from Kafka, every message has a persistent, monotonically increasing
  > offset. When writing a value to an external database, you can include the offset of the message that
  > triggered the last write with the value. Thus, you can tell whether an update has already been applied and
  > avoid performing the same update again."

  Two more tests in this branch write that down as a config field, `monotonicKey`. They fail at config parse
  because the field does not exist yet, and nothing here has to make them pass — they are a suggestion, and a
  test makes one more precisely than a review thread does.

  It would replace `dedupKey` rather than join it. The value it names is the same value; only the comparison
  changes. Worth settling early, because two fields that both identify a message is the confusing outcome.
  `kafka_offset` is already monotonic — `umh.messages` has one partition — so one field covers time-series and
  relational data alike. Letting it read the payload as well as metadata is what would make `timestamp_ms`
  usable at all: today `dedupKey` only looks in metadata, so a payload field name is never found and the config
  quietly does nothing.

  The second of the two tests is about one detail: the highest value is remembered per cache key, not as one
  number for the whole processor. Two tags have unrelated clocks, so a single number would let the fastest tag
  suppress every slower one.

Two should block the rollout rather than the merge. Both need the processor to remember what the first run
produced, and that belongs in a helper that owns the operation, not in this plugin:

- A retry publishes an invalid counter.
- A latched alarm is lost when the first send fails.

One needs a decision. A batch is reported as a success even when its cache write failed. The failure is logged
at error level, so the flow goes Degraded and the deploy probe trips — loud for an operator, silent for the
message.

**Docs and examples.** Every example on the JavaScript API page wrote to the cache, and none of them mentioned
retries. People copy examples, so the page taught the unsafe way whatever the text above it said — in blind
tests, five out of five attempts wrote the over-counting counter. Every example now either sets `dedupKey` or
says why it does not need to.

Two examples were wrong in themselves. The alarm one turned a state into an event, and an event cannot survive
a retry, so it now publishes the state on every message and lets consumers spot the change. The cycle-time one
used `Date.now()`, which measures when the pipeline handled the message rather than when the event happened,
and gives a different answer on a retry; it now reads the timestamp from the message.

Both of those were also in the `code` field's own examples, which is what the Management Console shows you
while you write a flow. Fixed there too.

Three statements in the `dedupKey` section were not true of the code, so they are corrected. The section now
says what the guarantee is before listing what it does not cover.

The recommended setup also lost a step. It told you to compose `kafka_partition` and `kafka_offset` into one
value with a `mapping` processor. Inside UMH that is unnecessary, because `umh.messages` always has one
partition, so it is now `dedupKey: kafka_offset` and one processor instead of two. The composition stays where
it applies, on Benthos' own `kafka` input.

## Not shipping

*(not yet reviewed)*

- No fix for any of the five tests. They are the specification, deliberately unimplemented.
- No `monotonicKey` field. Two of the failing tests describe one; they are a proposal, not a gate.
- No change to the cache implementation, the storage backend, or the transaction scope.
- `dedupKey` stays optional. The field description and startup warning now say it will become required, but
  making it so needs the config injected upstream first, or existing deployments fail to parse on upgrade.
- No ordering or monotonicity enforcement.
- No size cap or eviction for dedup markers beyond the existing `ttl`.
- No helper API. That is where the last two tests' remedy belongs and it needs its own proposal.

## Before the rollout can complete

*(not yet reviewed)*

1. The two merge-blocking tests above, green.
2. The two rollout-blocking tests, which need the helper layer.
3. In umh-core, three related config injections: pin `pipeline.threads: 1` for flows that use the cache,
   inject `dedupKey`, and decide how messages flagged with an error are handled. Today `threads` is unset, so
   every deployed flow runs one worker per core.
4. `dedupKey` made required — depends on 3.
5. The memory safeguard already listed as a stability criterion (ENG-4829), still unstarted.
