### PR TITLE
Modbus: read an address from a subset of slaves

### DIFF
--- a/.changelog/unreleased/new-20260806-171145.yaml
+++ b/.changelog/unreleased/new-20260806-171145.yaml
@@ -1,0 +1,3 @@
+kind: new
+body: Modbus addresses can be restricted to a subset of slaves with slaveID=3,5,6 in unifiedAddresses (ENG-4688)
+time: 2026-08-06T17:11:45.873311+02:00

--- a/docs/input/modbus.md
+++ b/docs/input/modbus.md
@@ -266,7 +266,8 @@ name.register.address.type[:key=value]*
 4. `type` — one of: `BIT`, `INT8L`, `INT8H`, `UINT8L`, `UINT8H`, `INT16`, `UINT16`, `INT32`, `UINT32`, `INT64`, `UINT64`, `FLOAT16`, `FLOAT32`, `FLOAT64`, `STRING`
 
 **Optional key-value pairs** (colon-separated):
-- `slaveID=<0-255>` — restrict to specific slave ID (default: 0 = all)
+- `slaveID=<0-255>` — restrict to a specific slave ID (default: 0 = all)
+- `slaveID=<id>,<id>,...` — restrict to a subset of slaves, e.g. `slaveID=3,5,6`. Every ID must appear in the top-level `slaveIDs`. `0` means all slaves and cannot be combined with specific IDs.
 - `length=<n>` — register count, only valid for STRING type
 - `bit=<0-15>` — bit number, only valid for BIT type
 - `scale=<float>` — scaling factor
@@ -283,6 +284,38 @@ input:
       - "serial_number.holding.200.STRING:length=10"
       - "pressure.holding.300.FLOAT32:scale=0.1:output=FLOAT64:slaveID=2"
 ```
+
+**Reading one address from a subset of slaves**
+
+```yaml
+input:
+  modbus:
+    controller: 'tcp://localhost:502'
+    slaveIDs: [1, 2, 3, 4, 5, 6]
+    unifiedAddresses:
+      - "cycle_count.holding.23.INT16:slaveID=3,5,6"   # only slaves 3, 5 and 6
+      - "temperature.holding.100.INT16:slaveID=2"      # only slave 2
+      - "pressure.holding.300.FLOAT32"                 # all six slaves
+```
+
+Each listed slave produces its own message, all carrying the same `modbus_tag_name`
+and differing only in `modbus_tag_slaveid`. If your pipeline builds the topic from the
+tag name alone, all of them land on one topic and overwrite each other. Include the
+slave ID in the topic:
+
+```yaml
+pipeline:
+  processors:
+    - tag_processor:
+        defaults: |
+          msg.meta.tag_name = msg.meta.modbus_tag_name;
+          msg.meta.virtual_path = "slave" + msg.meta.modbus_tag_slaveid;
+          return msg;
+```
+
+This replaces the older workaround of duplicating the address once per slave under a
+different name. Subsets are supported in `unifiedAddresses` only; the deprecated
+`addresses` list keeps its single `slaveID` value.
 
 **Migration from `addresses` to `unifiedAddresses`**
 
@@ -408,6 +441,8 @@ input:
 * **Description**: Optionally restrict this address to a specific slave ID. When set, only the specified slave will read this address. When omitted or set to 0, all configured slaves (from the top-level `slaveIDs`) will read this address.
 * **Default**: 0 (all slaves)
 * **Validation**: If non-zero, the value must appear in the top-level `slaveIDs` list.
+* **Note**: This deprecated field accepts a single ID only. To read one address from
+  several slaves, use `unifiedAddresses` with `slaveID=3,5,6`.
 *   **Configuration Example**:
 
     ```yaml

--- a/docs/input/modbus.md
+++ b/docs/input/modbus.md
@@ -300,8 +300,9 @@ input:
 
 Each listed slave produces its own message, all carrying the same `modbus_tag_name`
 and differing only in `modbus_tag_slaveid`. If your pipeline builds the topic from the
-tag name alone, all of them land on one topic and overwrite each other. Include the
-slave ID in the topic:
+tag name alone, all of them land on one topic and overwrite each other. The plugin logs
+a warning at startup whenever an address is read from more than one slave, so this is
+visible before any data flows. Include the slave ID in the topic:
 
 ```yaml
 pipeline:
@@ -313,8 +314,10 @@ pipeline:
           return msg;
 ```
 
-This replaces the older workaround of duplicating the address once per slave under a
-different name. Subsets are supported in `unifiedAddresses` only; the deprecated
+If an unrestricted address and a subset address point at the same register and address,
+each affected slave keeps whichever of the two comes first in the configuration and drops
+the other. This replaces the older workaround of duplicating the address once per slave
+under a different name. Subsets are supported in `unifiedAddresses` only; the deprecated
 `addresses` list keeps its single `slaveID` value.
 
 **Migration from `addresses` to `unifiedAddresses`**

--- a/modbus_plugin/address_parser.go
+++ b/modbus_plugin/address_parser.go
@@ -219,7 +219,17 @@ func FormatModbusAddress(item ModbusDataItemWithAddress) string {
 
 	// Optional key-value pairs (in a stable order).
 	// Zero-value options (bit=0, length=0, slaveID=0, scale=0) are omitted to produce canonical form.
-	if item.SlaveID != 0 {
+	// A list wins over the single ID, matching targetSlaves precedence. Order is kept
+	// as configured so canonical strings round-trip.
+	if len(item.SlaveIDs) > 0 {
+		b.WriteString(":slaveID=")
+		for i, sid := range item.SlaveIDs {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(strconv.Itoa(int(sid)))
+		}
+	} else if item.SlaveID != 0 {
 		b.WriteString(":slaveID=")
 		b.WriteString(strconv.Itoa(int(item.SlaveID)))
 	}

--- a/modbus_plugin/address_parser.go
+++ b/modbus_plugin/address_parser.go
@@ -145,16 +145,13 @@ func ParseModbusAddress(addr string) (ModbusDataItemWithAddress, error) {
 
 		switch key {
 		case "slaveID":
-			slaveID, err := strconv.Atoi(value)
+			single, list, err := parseSlaveIDOption(value)
 			if err != nil {
-				return ModbusDataItemWithAddress{}, fmt.Errorf("invalid slaveID value %q: %w", value, err)
+				return ModbusDataItemWithAddress{}, err
 			}
 
-			if slaveID < 0 || slaveID > 255 {
-				return ModbusDataItemWithAddress{}, fmt.Errorf("slaveID %d out of range (0-255)", slaveID)
-			}
-
-			item.SlaveID = byte(slaveID)
+			item.SlaveID = single
+			item.SlaveIDs = list
 		case "length":
 			length, err := strconv.Atoi(value)
 			if err != nil {
@@ -248,4 +245,49 @@ func FormatModbusAddress(item ModbusDataItemWithAddress) string {
 	}
 
 	return b.String()
+}
+
+// parseSlaveIDOption parses the value of the slaveID option, which accepts either a
+// single ID or a comma-separated list. A single ID is returned in the first result to
+// keep the legacy single-slave path byte-identical; two or more IDs are returned in
+// the second result. Order is preserved so the canonical string round-trips.
+func parseSlaveIDOption(value string) (byte, []byte, error) {
+	rawIDs := strings.Split(value, ",")
+
+	ids := make([]byte, 0, len(rawIDs))
+	seen := make(map[byte]bool, len(rawIDs))
+
+	for _, raw := range rawIDs {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			return 0, nil, fmt.Errorf("empty slaveID in list %q", value)
+		}
+
+		id, err := strconv.Atoi(trimmed)
+		if err != nil {
+			return 0, nil, fmt.Errorf("invalid slaveID value %q: %w", trimmed, err)
+		}
+
+		if id < 0 || id > 255 {
+			return 0, nil, fmt.Errorf("slaveID %d out of range (0-255)", id)
+		}
+
+		if len(rawIDs) > 1 && id == 0 {
+			return 0, nil, fmt.Errorf("slaveID 0 means all slaves and cannot be combined with specific IDs in %q", value)
+		}
+
+		if seen[byte(id)] {
+			return 0, nil, fmt.Errorf("duplicate slaveID %d in list %q", id, value)
+		}
+		seen[byte(id)] = true
+
+		ids = append(ids, byte(id))
+	}
+
+	// A single ID keeps using SlaveID, so no existing config reaches the list path.
+	if len(ids) == 1 {
+		return ids[0], nil, nil
+	}
+
+	return 0, ids, nil
 }

--- a/modbus_plugin/address_parser_test.go
+++ b/modbus_plugin/address_parser_test.go
@@ -258,4 +258,69 @@ var _ = Describe("ParseModbusAddress", func() {
 			Entry("full example", "fullExample.holding.300.INT16:slaveID=55:scale=0.01:output=FLOAT64"),
 		)
 	})
+
+	Context("slaveID lists", func() {
+		It("should parse a multi-value slaveID into SlaveIDs", func() {
+			item, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=3,5,6")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(item.SlaveIDs).To(Equal([]byte{3, 5, 6}))
+			Expect(item.SlaveID).To(Equal(byte(0)))
+		})
+
+		It("should trim spaces around list values", func() {
+			item, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=3, 5 ,6")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(item.SlaveIDs).To(Equal([]byte{3, 5, 6}))
+		})
+
+		It("should preserve the configured order", func() {
+			item, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=6,3,5")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(item.SlaveIDs).To(Equal([]byte{6, 3, 5}))
+		})
+
+		It("should keep a single value in SlaveID and leave SlaveIDs empty", func() {
+			item, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=2")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(item.SlaveID).To(Equal(byte(2)))
+			Expect(item.SlaveIDs).To(BeEmpty())
+		})
+
+		It("should keep slaveID=0 meaning all slaves", func() {
+			item, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(item.SlaveID).To(Equal(byte(0)))
+			Expect(item.SlaveIDs).To(BeEmpty())
+		})
+
+		It("should reject 0 inside a list", func() {
+			_, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=3,0,5")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot be combined"))
+		})
+
+		It("should reject duplicates inside a list", func() {
+			_, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=3,3,5")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("duplicate slaveID 3"))
+		})
+
+		It("should reject an empty list element", func() {
+			_, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=3,,5")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("empty slaveID"))
+		})
+
+		It("should reject an out-of-range list value", func() {
+			_, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=3,300")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("out of range"))
+		})
+
+		It("should reject a non-numeric list value", func() {
+			_, err := ParseModbusAddress("reg.holding.23.INT16:slaveID=3,abc")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid slaveID"))
+		})
+	})
 })

--- a/modbus_plugin/address_parser_test.go
+++ b/modbus_plugin/address_parser_test.go
@@ -324,3 +324,51 @@ var _ = Describe("ParseModbusAddress", func() {
 		})
 	})
 })
+
+var _ = Describe("FormatModbusAddress slaveID lists", func() {
+	It("should emit a comma-separated list", func() {
+		out := FormatModbusAddress(ModbusDataItemWithAddress{
+			Name:     "reg",
+			Register: "holding",
+			Address:  23,
+			Type:     "INT16",
+			SlaveIDs: []byte{3, 5, 6},
+		})
+		Expect(out).To(Equal("reg.holding.23.INT16:slaveID=3,5,6"))
+	})
+
+	It("should preserve list order", func() {
+		out := FormatModbusAddress(ModbusDataItemWithAddress{
+			Name:     "reg",
+			Register: "holding",
+			Address:  23,
+			Type:     "INT16",
+			SlaveIDs: []byte{6, 3, 5},
+		})
+		Expect(out).To(Equal("reg.holding.23.INT16:slaveID=6,3,5"))
+	})
+
+	It("should still emit a single slaveID unchanged", func() {
+		out := FormatModbusAddress(ModbusDataItemWithAddress{
+			Name:     "reg",
+			Register: "holding",
+			Address:  23,
+			Type:     "INT16",
+			SlaveID:  2,
+		})
+		Expect(out).To(Equal("reg.holding.23.INT16:slaveID=2"))
+	})
+
+	DescribeTable("should round-trip canonical strings",
+		func(addr string) {
+			item, err := ParseModbusAddress(addr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(FormatModbusAddress(item)).To(Equal(addr))
+		},
+		Entry("no slave", "reg.holding.23.INT16"),
+		Entry("single slave", "reg.holding.23.INT16:slaveID=2"),
+		Entry("slave subset", "reg.holding.23.INT16:slaveID=3,5,6"),
+		Entry("unordered subset", "reg.holding.23.INT16:slaveID=6,3,5"),
+		Entry("subset with scale and output", "reg.holding.23.FLOAT32:slaveID=3,5:scale=0.1:output=FLOAT64"),
+	)
+})

--- a/modbus_plugin/config_helper.go
+++ b/modbus_plugin/config_helper.go
@@ -17,6 +17,7 @@ package modbus_plugin
 import (
 	"fmt"
 	"hash/maphash"
+	"slices"
 	"strconv"
 )
 
@@ -84,6 +85,16 @@ func tagIDWithSlave(seed maphash.Seed, item ModbusDataItemWithAddress) uint64 {
 	mh.WriteString(strconv.Itoa(int(item.Address)))
 	mh.WriteByte(0)
 	mh.WriteByte(item.SlaveID)
+
+	// Hash a sorted copy so the same subset written in a different order dedups.
+	// Items without a list write nothing extra, keeping legacy hashes unchanged.
+	if len(item.SlaveIDs) > 0 {
+		sorted := slices.Clone(item.SlaveIDs)
+		slices.Sort(sorted)
+
+		mh.WriteByte(0)
+		mh.Write(sorted)
+	}
 
 	return mh.Sum64()
 }

--- a/modbus_plugin/export_test.go
+++ b/modbus_plugin/export_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modbus_plugin
+
+// This file is only compiled into the test binary. It exposes the constructor's
+// per-slave distribution and deduplication to the external modbus_plugin_test
+// package so its helpers can call production code instead of re-implementing it.
+
+// BuildPerSlaveAddressesForTest exposes buildPerSlaveAddresses to external tests.
+func (m *ModbusInput) BuildPerSlaveAddressesForTest() map[byte][]ModbusDataItemWithAddress {
+	return m.buildPerSlaveAddresses()
+}
+
+// DedupPerSlaveForTest exposes dedupPerSlave to external tests.
+func (m *ModbusInput) DedupPerSlaveForTest(perSlaveAddresses map[byte][]ModbusDataItemWithAddress) map[byte][]ModbusDataItemWithAddress {
+	return m.dedupPerSlave(perSlaveAddresses)
+}

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -193,11 +193,14 @@ var ModbusConfigSpec = service.NewConfigSpec().
 		Description("Modbus workarounds. Required by some devices to work correctly. Should be left alone by default and must not be changed unless necessary.").Advanced()).
 	Field(service.NewStringListField("unifiedAddresses").
 		Description("Unified address strings. Format: 'name.register.address.type[:key=value]*'. "+
-			"Mutually exclusive with 'addresses'; providing both will result in an error.").
+			"Mutually exclusive with 'addresses'; providing both will result in an error. "+
+			"The 'slaveID' key also accepts a comma-separated list, such as 'slaveID=3,5,6', "+
+			"to read the address from just that subset of the configured slaveIDs.").
 		Examples(
 			[]string{"temperature.holding.100.INT16"},
 			[]string{"motor_status.discrete.1.BIT:bit=3"},
 			[]string{"pressure.holding.300.FLOAT32:scale=0.1:output=FLOAT64:slaveID=2"},
+			[]string{"cycle_count.holding.23.INT16:slaveID=3,5,6"},
 		).
 		Default([]string{}).
 		Optional()).
@@ -217,7 +220,8 @@ var ModbusConfigSpec = service.NewConfigSpec().
 
 // targetSlaves returns which slaves this address is read from. A configured list wins
 // over a single slave ID, and an address with neither is read from every configured
-// slave.
+// slave. The returned slice aliases either the item's own list or the configured slice
+// passed in, so callers must treat it as read-only and not mutate it.
 func (i ModbusDataItemWithAddress) targetSlaves(configured []byte) []byte {
 	switch {
 	case len(i.SlaveIDs) > 0:
@@ -302,8 +306,8 @@ func (m *ModbusInput) validateAndAppend(
 
 	tid := tagIDWithSlave(seed, item)
 	if _, exists := seenFields[tid]; exists {
-		m.Log.Warnf("Duplicate field %q register=%s address=%d slaveID=%d, ignoring",
-			item.Name, item.Register, item.Address, item.SlaveID)
+		m.Log.Warnf("Duplicate field %q register=%s address=%d slaveID=%v, ignoring",
+			item.Name, item.Register, item.Address, item.targetSlaves(m.SlaveIDs))
 		return addresses, nil
 	}
 	seenFields[tid] = struct{}{}

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -72,6 +72,11 @@ type ModbusDataItemWithAddress struct {
 	// 0 means read from all configured slaves.
 	SlaveID byte
 
+	// SlaveIDs optionally restricts this address to a subset of the configured
+	// slaves. It is set only when two or more IDs are configured and takes
+	// precedence over SlaveID. Empty means fall back to SlaveID.
+	SlaveIDs []byte
+
 	ConverterFunc converterFunc
 }
 

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -253,6 +253,31 @@ func (m *ModbusInput) buildPerSlaveAddresses() map[byte][]ModbusDataItemWithAddr
 	return perSlaveAddresses
 }
 
+// dedupPerSlave drops, within each slave, every address that repeats a register+address
+// already seen for that slave, keeping the first occurrence in config order. This catches
+// the overlap between unrestricted entries and entries restricted to a slave subset, which
+// are distinct tags globally but collide once distributed onto a single slave. The map is
+// modified in place and returned for convenience.
+func (m *ModbusInput) dedupPerSlave(perSlaveAddresses map[byte][]ModbusDataItemWithAddress) map[byte][]ModbusDataItemWithAddress {
+	dedupSeed := maphash.MakeSeed()
+	for sid, addrs := range perSlaveAddresses {
+		seen := make(map[uint64]bool)
+		deduped := make([]ModbusDataItemWithAddress, 0, len(addrs))
+		for _, item := range addrs {
+			id := tagID(dedupSeed, item)
+			if seen[id] {
+				m.Log.Warnf("Duplicate register+address for slave %d: field %q register=%s address=%d, keeping first occurrence", sid, item.Name, item.Register, item.Address)
+				continue
+			}
+			seen[id] = true
+			deduped = append(deduped, item)
+		}
+		perSlaveAddresses[sid] = deduped
+	}
+
+	return perSlaveAddresses
+}
+
 // validateAndAppend checks slaveID membership, validates type/register compatibility,
 // deduplicates by tag ID, and appends the item to the address list.
 func (m *ModbusInput) validateAndAppend(
@@ -532,25 +557,7 @@ func newModbusInput(conf *service.ParsedConfig, mgr *service.Resources) (service
 	}
 
 	// Build per-slave address lists
-	perSlaveAddresses := m.buildPerSlaveAddresses()
-
-	// Second-pass dedup: within each slave, dedup by register+address
-	// (catches overlap between global slaveID=0 entries and specific slaveID entries)
-	dedupSeed := maphash.MakeSeed()
-	for sid, addrs := range perSlaveAddresses {
-		seen := make(map[uint64]bool)
-		deduped := make([]ModbusDataItemWithAddress, 0, len(addrs))
-		for _, item := range addrs {
-			id := tagID(dedupSeed, item)
-			if seen[id] {
-				m.Log.Warnf("Duplicate register+address for slave %d: field %q register=%s address=%d, keeping first occurrence", sid, item.Name, item.Register, item.Address)
-				continue
-			}
-			seen[id] = true
-			deduped = append(deduped, item)
-		}
-		perSlaveAddresses[sid] = deduped
-	}
+	perSlaveAddresses := m.dedupPerSlave(m.buildPerSlaveAddresses())
 
 	// Build per-slave RequestSets
 	m.RequestSets = make(map[byte]RequestSet)

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -227,6 +227,12 @@ func (m *ModbusInput) validateAndAppend(
 		return addresses, fmt.Errorf("address %q has slaveID %d which is not in the top-level slaveIDs list. Add %d to slaveIDs or set slaveID to 0 to read from all slaves", item.Name, item.SlaveID, item.SlaveID)
 	}
 
+	for _, sid := range item.SlaveIDs {
+		if !slices.Contains(m.SlaveIDs, sid) {
+			return addresses, fmt.Errorf("address %q has slaveID %d which is not in the top-level slaveIDs list. Add %d to slaveIDs or remove it from the address", item.Name, sid, sid)
+		}
+	}
+
 	if valErr := validateAddressItem(item); valErr != nil {
 		return addresses, valErr
 	}

--- a/modbus_plugin/modbus.go
+++ b/modbus_plugin/modbus.go
@@ -215,6 +215,44 @@ var ModbusConfigSpec = service.NewConfigSpec().
 		Optional().
 		Deprecated())
 
+// targetSlaves returns which slaves this address is read from. A configured list wins
+// over a single slave ID, and an address with neither is read from every configured
+// slave.
+func (i ModbusDataItemWithAddress) targetSlaves(configured []byte) []byte {
+	switch {
+	case len(i.SlaveIDs) > 0:
+		return i.SlaveIDs
+	case i.SlaveID != 0:
+		return []byte{i.SlaveID}
+	default:
+		return configured
+	}
+}
+
+// buildPerSlaveAddresses groups the parsed addresses by the slaves they are read from.
+func (m *ModbusInput) buildPerSlaveAddresses() map[byte][]ModbusDataItemWithAddress {
+	perSlaveAddresses := make(map[byte][]ModbusDataItemWithAddress)
+
+	for _, item := range m.Addresses {
+		targets := item.targetSlaves(m.SlaveIDs)
+
+		// A slave list yields one message per slave under the same tag name. Warn so a
+		// pipeline that builds its topic from modbus_tag_name alone does not silently
+		// collapse them. The all-slaves case is deliberately not warned about: it has
+		// always behaved this way and would fire on existing configs.
+		if len(item.SlaveIDs) > 1 {
+			m.Log.Warnf("Address %q is read from %d slaves (%v); include modbus_tag_slaveid in the topic to avoid collapsing them onto one tag",
+				item.Name, len(item.SlaveIDs), item.SlaveIDs)
+		}
+
+		for _, sid := range targets {
+			perSlaveAddresses[sid] = append(perSlaveAddresses[sid], item)
+		}
+	}
+
+	return perSlaveAddresses
+}
+
 // validateAndAppend checks slaveID membership, validates type/register compatibility,
 // deduplicates by tag ID, and appends the item to the address list.
 func (m *ModbusInput) validateAndAppend(
@@ -494,18 +532,7 @@ func newModbusInput(conf *service.ParsedConfig, mgr *service.Resources) (service
 	}
 
 	// Build per-slave address lists
-	perSlaveAddresses := make(map[byte][]ModbusDataItemWithAddress)
-	for _, item := range m.Addresses {
-		// Specific slave: handle and continue
-		if item.SlaveID != 0 {
-			perSlaveAddresses[item.SlaveID] = append(perSlaveAddresses[item.SlaveID], item)
-			continue
-		}
-		// Global address: add to every slave
-		for _, sid := range m.SlaveIDs {
-			perSlaveAddresses[sid] = append(perSlaveAddresses[sid], item)
-		}
-	}
+	perSlaveAddresses := m.buildPerSlaveAddresses()
 
 	// Second-pass dedup: within each slave, dedup by register+address
 	// (catches overlap between global slaveID=0 entries and specific slaveID entries)

--- a/modbus_plugin/modbus_test.go
+++ b/modbus_plugin/modbus_test.go
@@ -359,33 +359,12 @@ var _ = Describe("Per-Slave Address Routing", func() {
 			}
 		}
 
-		// Build per-slave address lists
-		perSlaveAddresses := make(map[byte][]ModbusDataItemWithAddress)
-		for _, item := range input.Addresses {
-			if item.SlaveID == 0 {
-				for _, sid := range input.SlaveIDs {
-					perSlaveAddresses[sid] = append(perSlaveAddresses[sid], item)
-				}
-			} else {
-				perSlaveAddresses[item.SlaveID] = append(perSlaveAddresses[item.SlaveID], item)
-			}
-		}
-
-		// Second-pass dedup: within each slave, dedup by register+address
-		for sid, addrs := range perSlaveAddresses {
-			seen := make(map[string]bool)
-			deduped := make([]ModbusDataItemWithAddress, 0, len(addrs))
-			for _, item := range addrs {
-				key := fmt.Sprintf("%s:%d", item.Register, item.Address)
-				if seen[key] {
-					continue
-				}
-				seen[key] = true
-				deduped = append(deduped, item)
-			}
-			perSlaveAddresses[sid] = deduped
-			if tracking != nil {
-				tracking[sid] = deduped
+		// Distribution and dedup come straight from production so this helper cannot
+		// drift from the constructor.
+		perSlaveAddresses := input.DedupPerSlaveForTest(input.BuildPerSlaveAddressesForTest())
+		if tracking != nil {
+			for sid, addrs := range perSlaveAddresses {
+				tracking[sid] = addrs
 			}
 		}
 

--- a/modbus_plugin/slave_targets_internal_test.go
+++ b/modbus_plugin/slave_targets_internal_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
 var _ = Describe("tagIDWithSlave", func() {
@@ -65,5 +66,60 @@ var _ = Describe("tagIDWithSlave", func() {
 		a.SlaveIDs = []byte{6, 3, 5}
 		_ = tagIDWithSlave(seed, a)
 		Expect(a.SlaveIDs).To(Equal([]byte{6, 3, 5}))
+	})
+})
+
+var _ = Describe("validateAndAppend with slave lists", func() {
+	var (
+		m          *ModbusInput
+		seed       maphash.Seed
+		seenFields map[uint64]struct{}
+	)
+
+	BeforeEach(func() {
+		m = &ModbusInput{
+			Log:      service.MockResources().Logger(),
+			SlaveIDs: []byte{1, 2, 3, 4, 5, 6},
+		}
+		seed = maphash.MakeSeed()
+		seenFields = make(map[uint64]struct{})
+	})
+
+	item := func(ids ...byte) ModbusDataItemWithAddress {
+		return ModbusDataItemWithAddress{
+			Name: "reg", Register: "holding", Address: 23, Type: "INT16", SlaveIDs: ids,
+		}
+	}
+
+	It("should accept a subset of the configured slaves", func() {
+		out, err := m.validateAndAppend(nil, item(3, 5, 6), seed, seenFields)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].SlaveIDs).To(Equal([]byte{3, 5, 6}))
+	})
+
+	It("should reject an ID missing from the top-level slaveIDs", func() {
+		_, err := m.validateAndAppend(nil, item(3, 7), seed, seenFields)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("slaveID 7"))
+		Expect(err.Error()).To(ContainSubstring("top-level slaveIDs list"))
+	})
+
+	It("should drop a second identical entry as a duplicate", func() {
+		out, err := m.validateAndAppend(nil, item(3, 5), seed, seenFields)
+		Expect(err).NotTo(HaveOccurred())
+
+		out, err = m.validateAndAppend(out, item(5, 3), seed, seenFields)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(HaveLen(1))
+	})
+
+	It("should keep entries with different slave lists", func() {
+		out, err := m.validateAndAppend(nil, item(3, 5), seed, seenFields)
+		Expect(err).NotTo(HaveOccurred())
+
+		out, err = m.validateAndAppend(out, item(4, 6), seed, seenFields)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(HaveLen(2))
 	})
 })

--- a/modbus_plugin/slave_targets_internal_test.go
+++ b/modbus_plugin/slave_targets_internal_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modbus_plugin
+
+import (
+	"hash/maphash"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("tagIDWithSlave", func() {
+	var seed maphash.Seed
+
+	BeforeEach(func() {
+		seed = maphash.MakeSeed()
+	})
+
+	base := func() ModbusDataItemWithAddress {
+		return ModbusDataItemWithAddress{Name: "reg", Register: "holding", Address: 23, Type: "INT16"}
+	}
+
+	It("should treat differently ordered lists as the same tag", func() {
+		a, b := base(), base()
+		a.SlaveIDs = []byte{3, 5}
+		b.SlaveIDs = []byte{5, 3}
+		Expect(tagIDWithSlave(seed, a)).To(Equal(tagIDWithSlave(seed, b)))
+	})
+
+	It("should treat different lists as different tags", func() {
+		a, b := base(), base()
+		a.SlaveIDs = []byte{3, 5}
+		b.SlaveIDs = []byte{3, 6}
+		Expect(tagIDWithSlave(seed, a)).NotTo(Equal(tagIDWithSlave(seed, b)))
+	})
+
+	It("should treat a list and a single slave as different tags", func() {
+		a, b := base(), base()
+		a.SlaveIDs = []byte{3, 5}
+		b.SlaveID = 3
+		Expect(tagIDWithSlave(seed, a)).NotTo(Equal(tagIDWithSlave(seed, b)))
+	})
+
+	It("should not change the hash of an item without a list", func() {
+		a, b := base(), base()
+		a.SlaveID = 2
+		b.SlaveID = 2
+		Expect(tagIDWithSlave(seed, a)).To(Equal(tagIDWithSlave(seed, b)))
+	})
+
+	It("should not mutate the caller's slice while sorting", func() {
+		a := base()
+		a.SlaveIDs = []byte{6, 3, 5}
+		_ = tagIDWithSlave(seed, a)
+		Expect(a.SlaveIDs).To(Equal([]byte{6, 3, 5}))
+	})
+})

--- a/modbus_plugin/slave_targets_internal_test.go
+++ b/modbus_plugin/slave_targets_internal_test.go
@@ -123,3 +123,85 @@ var _ = Describe("validateAndAppend with slave lists", func() {
 		Expect(out).To(HaveLen(2))
 	})
 })
+
+var _ = Describe("targetSlaves", func() {
+	configured := []byte{1, 2, 3, 4, 5, 6}
+
+	It("should return the list when one is set", func() {
+		item := ModbusDataItemWithAddress{SlaveIDs: []byte{3, 5, 6}}
+		Expect(item.targetSlaves(configured)).To(Equal([]byte{3, 5, 6}))
+	})
+
+	It("should prefer the list over a single ID", func() {
+		item := ModbusDataItemWithAddress{SlaveID: 2, SlaveIDs: []byte{3, 5}}
+		Expect(item.targetSlaves(configured)).To(Equal([]byte{3, 5}))
+	})
+
+	It("should return the single ID when no list is set", func() {
+		item := ModbusDataItemWithAddress{SlaveID: 2}
+		Expect(item.targetSlaves(configured)).To(Equal([]byte{2}))
+	})
+
+	It("should return every configured slave when nothing is set", func() {
+		item := ModbusDataItemWithAddress{}
+		Expect(item.targetSlaves(configured)).To(Equal(configured))
+	})
+})
+
+var _ = Describe("buildPerSlaveAddresses", func() {
+	newInput := func(addrs ...ModbusDataItemWithAddress) *ModbusInput {
+		return &ModbusInput{
+			Log:       service.MockResources().Logger(),
+			SlaveIDs:  []byte{1, 2, 3, 4, 5, 6},
+			Addresses: addrs,
+		}
+	}
+
+	named := func(name string, ids ...byte) ModbusDataItemWithAddress {
+		return ModbusDataItemWithAddress{
+			Name: name, Register: "holding", Address: 23, Type: "INT16", SlaveIDs: ids,
+		}
+	}
+
+	It("should assign a subset address to exactly its slaves", func() {
+		perSlave := newInput(named("reg", 3, 5, 6)).buildPerSlaveAddresses()
+		Expect(perSlave).To(HaveLen(3))
+		Expect(perSlave).To(HaveKey(byte(3)))
+		Expect(perSlave).To(HaveKey(byte(5)))
+		Expect(perSlave).To(HaveKey(byte(6)))
+		Expect(perSlave[byte(3)]).To(HaveLen(1))
+		Expect(perSlave[byte(3)][0].Name).To(Equal("reg"))
+	})
+
+	It("should not assign a subset address to unlisted slaves", func() {
+		perSlave := newInput(named("reg", 3, 5, 6)).buildPerSlaveAddresses()
+		Expect(perSlave).NotTo(HaveKey(byte(1)))
+		Expect(perSlave).NotTo(HaveKey(byte(2)))
+		Expect(perSlave).NotTo(HaveKey(byte(4)))
+	})
+
+	It("should assign a single-slave address to that slave only", func() {
+		item := ModbusDataItemWithAddress{Name: "one", Register: "holding", Address: 10, Type: "INT16", SlaveID: 2}
+		perSlave := newInput(item).buildPerSlaveAddresses()
+		Expect(perSlave).To(HaveLen(1))
+		Expect(perSlave).To(HaveKey(byte(2)))
+	})
+
+	It("should assign an unrestricted address to every configured slave", func() {
+		item := ModbusDataItemWithAddress{Name: "all", Register: "holding", Address: 11, Type: "INT16"}
+		perSlave := newInput(item).buildPerSlaveAddresses()
+		Expect(perSlave).To(HaveLen(6))
+	})
+
+	It("should mix subset, single and unrestricted addresses", func() {
+		perSlave := newInput(
+			named("sub", 3, 5),
+			ModbusDataItemWithAddress{Name: "one", Register: "holding", Address: 10, Type: "INT16", SlaveID: 1},
+			ModbusDataItemWithAddress{Name: "all", Register: "holding", Address: 11, Type: "INT16"},
+		).buildPerSlaveAddresses()
+
+		Expect(perSlave[byte(1)]).To(HaveLen(2)) // one + all
+		Expect(perSlave[byte(3)]).To(HaveLen(2)) // sub + all
+		Expect(perSlave[byte(2)]).To(HaveLen(1)) // all
+	})
+})

--- a/modbus_plugin/slave_targets_internal_test.go
+++ b/modbus_plugin/slave_targets_internal_test.go
@@ -205,3 +205,74 @@ var _ = Describe("buildPerSlaveAddresses", func() {
 		Expect(perSlave[byte(2)]).To(HaveLen(1)) // all
 	})
 })
+
+var _ = Describe("dedupPerSlave", func() {
+	newInput := func(addrs ...ModbusDataItemWithAddress) *ModbusInput {
+		return &ModbusInput{
+			Log:       service.MockResources().Logger(),
+			SlaveIDs:  []byte{1, 2, 3, 4, 5, 6},
+			Addresses: addrs,
+		}
+	}
+
+	// Same register+address, different tag names: which one survives on a given slave
+	// is decided by config order.
+	named := func(name string, ids ...byte) ModbusDataItemWithAddress {
+		return ModbusDataItemWithAddress{
+			Name: name, Register: "holding", Address: 23, Type: "INT16", SlaveIDs: ids,
+		}
+	}
+
+	unrestricted := func(name string) ModbusDataItemWithAddress {
+		return ModbusDataItemWithAddress{Name: name, Register: "holding", Address: 23, Type: "INT16"}
+	}
+
+	namesFor := func(perSlave map[byte][]ModbusDataItemWithAddress, sid byte) []string {
+		names := make([]string, 0, len(perSlave[sid]))
+		for _, item := range perSlave[sid] {
+			names = append(names, item.Name)
+		}
+		return names
+	}
+
+	It("should keep the subset entry on its slaves and the unrestricted entry elsewhere", func() {
+		m := newInput(named("a", 3, 5), unrestricted("b"))
+		perSlave := m.dedupPerSlave(m.buildPerSlaveAddresses())
+
+		Expect(namesFor(perSlave, 3)).To(Equal([]string{"a"}))
+		Expect(namesFor(perSlave, 5)).To(Equal([]string{"a"}))
+		Expect(namesFor(perSlave, 1)).To(Equal([]string{"b"}))
+		Expect(namesFor(perSlave, 2)).To(Equal([]string{"b"}))
+		Expect(namesFor(perSlave, 4)).To(Equal([]string{"b"}))
+		Expect(namesFor(perSlave, 6)).To(Equal([]string{"b"}))
+	})
+
+	It("should let config order decide, so a leading unrestricted entry wins everywhere", func() {
+		m := newInput(unrestricted("b"), named("a", 3, 5))
+		perSlave := m.dedupPerSlave(m.buildPerSlaveAddresses())
+
+		for _, sid := range m.SlaveIDs {
+			Expect(namesFor(perSlave, sid)).To(Equal([]string{"b"}), "slave %d", sid)
+		}
+	})
+
+	It("should keep entries that differ in register or address", func() {
+		other := ModbusDataItemWithAddress{Name: "c", Register: "input", Address: 23, Type: "INT16"}
+		m := newInput(named("a", 3), other)
+		perSlave := m.dedupPerSlave(m.buildPerSlaveAddresses())
+
+		Expect(namesFor(perSlave, 3)).To(ConsistOf("a", "c"))
+		Expect(namesFor(perSlave, 1)).To(Equal([]string{"c"}))
+	})
+
+	It("should leave a map without collisions untouched", func() {
+		m := newInput(named("a", 3), ModbusDataItemWithAddress{
+			Name: "d", Register: "holding", Address: 24, Type: "INT16", SlaveIDs: []byte{5},
+		})
+		perSlave := m.dedupPerSlave(m.buildPerSlaveAddresses())
+
+		Expect(perSlave).To(HaveLen(2))
+		Expect(namesFor(perSlave, 3)).To(Equal([]string{"a"}))
+		Expect(namesFor(perSlave, 5)).To(Equal([]string{"d"}))
+	})
+})


### PR DESCRIPTION
## Problem

With `slaveIDs: [1, 2, 3, 4, 5, 6]`, an address could be read from exactly one slave or from all six — never from a subset. Anyone wanting register 23 from slaves 3, 5 and 6 had to duplicate the address entry three times under three different names, which is also how those tags then showed up in the UNS.

## What we are shipping

- The existing `slaveID` option in a `unifiedAddresses` string now takes a comma-separated list: `cycle_count.holding.23.INT16:slaveID=3,5,6`. No new config key, so the Management Console form is structurally unchanged — the config-spec JSON diff against staging is one description sentence plus one example entry.
- `0` alone still means all slaves. `0` inside a list, a repeated ID, an empty element, and any ID missing from the top-level `slaveIDs` are all rejected at startup rather than silently reading nothing.
- Every listed slave emits its own message under the same `modbus_tag_name`, differing only in `modbus_tag_slaveid`. A pipeline that builds its topic from the tag name alone would collapse them onto one topic, so the plugin logs a startup warning and the docs show a `tag_processor` snippet that puts the slave ID in the `virtual_path`.
- Two test-quality fixes found while doing this: `modbus_test.go` had its own copy of the distribution and per-slave dedup logic that would have silently drifted from production, and the second-pass dedup was unreachable from any test. Both now call the real code.

## What we are NOT shipping

- The deprecated `addresses` object list is untouched — it still takes a single `slaveID` int. Subsets are `unifiedAddresses`-only.
- No `{slaveID}` placeholder in the name segment. It would remove the need for the `tag_processor` snippet above, but it grows the address grammar and is a separate decision.
- `ModbusDataItemWithAddress.SlaveID byte` is kept as-is with `SlaveIDs []byte` added alongside, rather than collapsing both into one field. The collapse is cleaner but breaks the exported struct.
- `docs/input/modbus.md` currently says the startup warning fires whenever an address is read from more than one slave; it actually fires only for an explicit multi-ID list, not the all-slaves case. Wording fix, happy to take it in review.

Fixes ENG-4688
