### PR TITLE
feat(historian): keep the data contract version in the stored metadata

### DIFF
--- a/.changelog/unreleased/improvements-20260817-104500.yaml
+++ b/.changelog/unreleased/improvements-20260817-104500.yaml
@@ -1,0 +1,3 @@
+kind: improvements
+body: The historian output keeps `data_contract_version` in the stored metadata, readable as `attribute->>'data_contract_version'`, so a connected application can tell which contract version a reading arrived under. All versions share one table and one `umh.tag` row, so no column recorded it and excluding it as structural discarded it outright (ENG-5474)
+time: 2026-08-17T10:45:00.000000+02:00

--- a/.changelog/unreleased/improvements-20260817-104500.yaml
+++ b/.changelog/unreleased/improvements-20260817-104500.yaml
@@ -1,3 +1,3 @@
 kind: improvements
-body: The historian output keeps `data_contract_version` in the stored metadata, readable as `attribute->>'data_contract_version'`, so a connected application can tell which contract version a reading arrived under. All versions share one table and one `umh.tag` row, so no column recorded it and excluding it as structural discarded it outright (ENG-5474)
+body: The historian output stores `data_contract_version` as metadata, read as `attribute->>'data_contract_version'`, so a connected application can tell which contract version a reading arrived under. All versions of a contract share one table and one `umh.tag` row, so no column recorded the version and it was previously dropped (ENG-5474)
 time: 2026-08-17T10:45:00.000000+02:00

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -52,6 +52,15 @@ and writes two hypertables:
 `umh.get_topic_id(location_path, virtual_path, data_contract, tag_name)` resolves a tag to
 its `topic_id` for ad-hoc and Grafana queries.
 
+> **The contract version lives in the metadata.** All versions of a contract share one table and
+> one `umh.tag` row — `_pump_v1` and `_pump_v2` are both `_pump` — so no column records which
+> version a reading arrived under. `data_contract_version` is therefore kept as metadata rather
+> than stripped as structural, and reads back as
+> `attribute->>'data_contract_version'`. It only appears where it means something: the `uns`
+> output sets it on the validated path, so an unversioned contract like `_historian` carries no
+> version key at all rather than an empty one. Because the version is part of the de-duplication
+> fingerprint, a contract-version bump writes a fresh attribute row instead of being swallowed.
+
 > **Note on the contract name.** You configure the bare form (`pump`), which is used verbatim
 > in the table names (`umh.value_pump`, `umh.attribute_pump`). The `umh.tag.data_contract_name`
 > *column*, however, stores the UNS form with a leading underscore (`_pump`) to match the

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -52,14 +52,15 @@ and writes two hypertables:
 `umh.get_topic_id(location_path, virtual_path, data_contract, tag_name)` resolves a tag to
 its `topic_id` for ad-hoc and Grafana queries.
 
-> **The contract version lives in the metadata.** All versions of a contract share one table and
-> one `umh.tag` row — `_pump_v1` and `_pump_v2` are both `_pump` — so no column records which
-> version a reading arrived under. `data_contract_version` is therefore kept as metadata rather
-> than stripped as structural, and reads back as
-> `attribute->>'data_contract_version'`. It only appears where it means something: the `uns`
-> output sets it on the validated path, so an unversioned contract like `_historian` carries no
-> version key at all rather than an empty one. Because the version is part of the de-duplication
-> fingerprint, a contract-version bump writes a fresh attribute row instead of being swallowed.
+> **Where the contract version is stored.** `_pump_v1` and `_pump_v2` both write to
+> `umh.value_pump` and share one `umh.tag` row, so no column records which version a reading
+> arrived under. The version is stored as metadata instead, read as
+> `attribute->>'data_contract_version'`.
+>
+> The `uns` output sets that key only after a schema check passes, so an unversioned contract like
+> `_historian` has no version key rather than an empty one. The version is part of the
+> de-duplication fingerprint, so moving a tag to a new contract version writes a fresh attribute
+> row.
 
 > **Note on the contract name.** You configure the bare form (`pump`), which is used verbatim
 > in the table names (`umh.value_pump`, `umh.attribute_pump`). The `umh.tag.data_contract_name`

--- a/historian_plugin/metadata.go
+++ b/historian_plugin/metadata.go
@@ -21,10 +21,9 @@ import (
 )
 
 // Structural keys are already stored as columns/dimensions or are transport routing.
-// data_contract_version is deliberately NOT here: NormalizeContract strips _vN so every version
-// shares one umh.tag row, which means no column holds the version and excluding it discarded it
-// outright (ENG-5474). It is stored as metadata instead, readable as
-// attribute->>'data_contract_version'.
+// data_contract_version is not in this list: NormalizeContract strips _vN, so all versions share one
+// umh.tag row and no column holds the version. Excluding it dropped it entirely (ENG-5474); it is
+// stored as metadata, read as attribute->>'data_contract_version'.
 var skipStructural = toSet(
 	"location_path", "data_contract", "virtual_path", "tag_name",
 	"data_contract_name",

--- a/historian_plugin/metadata.go
+++ b/historian_plugin/metadata.go
@@ -21,9 +21,13 @@ import (
 )
 
 // Structural keys are already stored as columns/dimensions or are transport routing.
+// data_contract_version is deliberately NOT here: NormalizeContract strips _vN so every version
+// shares one umh.tag row, which means no column holds the version and excluding it discarded it
+// outright (ENG-5474). It is stored as metadata instead, readable as
+// attribute->>'data_contract_version'.
 var skipStructural = toSet(
 	"location_path", "data_contract", "virtual_path", "tag_name",
-	"data_contract_name", "data_contract_version",
+	"data_contract_name",
 	"data_contract_bypassed", "data_contract_bypass_reason",
 	"umh_topic", "bridged_by", "origin", "origin_id",
 	"kafka_topic", "kafka_key", "kafka_msg_key", "kafka_partition", "kafka_offset",

--- a/historian_plugin/metadata_test.go
+++ b/historian_plugin/metadata_test.go
@@ -27,10 +27,29 @@ var _ = Describe("metadata", func() {
 		"location_path":          "acme.line1", // structural -> excluded in all-mode
 		"opcua_source_timestamp": "x",          // high-churn -> excluded in all-mode
 		"_ltree":                 "internal",   // underscore-prefixed -> excluded in all-mode
+		"data_contract_version":  "1",          // kept: no column holds it (ENG-5474)
 	}
 
 	It("all-mode excludes structural, high-churn, and _-prefixed", func() {
-		Expect(tsh.SelectMetaKeys(meta, true, nil, nil)).To(ConsistOf("serialNumber"))
+		Expect(tsh.SelectMetaKeys(meta, true, nil, nil)).To(ConsistOf("serialNumber", "data_contract_version"))
+	})
+
+	It("keeps data_contract_version, which no column holds, while still dropping the name, which one does", func() {
+		m := map[string]string{
+			"data_contract_name":          "_pump",
+			"data_contract_version":       "3",
+			"data_contract_bypassed":      "true",
+			"data_contract_bypass_reason": "registry unreachable",
+		}
+		got := tsh.SelectMetaKeys(m, true, nil, nil)
+		Expect(got).To(ConsistOf("data_contract_version"),
+			"NormalizeContract strips _vN so all versions share one umh.tag row; without this the version is discarded outright")
+	})
+
+	It("still drops the version when the user blacklists it", func() {
+		m := map[string]string{"data_contract_version": "3", "serialNumber": "abc"}
+		excl := tsh.NewMetaExcluder([]string{"data_contract_version"})
+		Expect(tsh.SelectMetaKeys(m, true, nil, excl)).To(ConsistOf("serialNumber"))
 	})
 	It("allowlist-mode takes the list verbatim (blacklist NOT applied)", func() {
 		Expect(tsh.SelectMetaKeys(meta, false, []string{"serialNumber", "opcua_source_timestamp"}, nil)).

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -817,6 +817,41 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(v).To(Equal("abc"))
 	})
 
+	It("stores the data contract version, which no column holds, in the attribute row", func() {
+		h := connected("ver")
+		defer h.Close(ctx)
+		msg := mkMsg(1.0, 1000, "_ver_v3", "l.a", "t", map[string]string{
+			"data_contract_name":    "_ver",
+			"data_contract_version": "3",
+			"serialNumber":          "abc",
+		})
+		Expect(h.WriteBatch(ctx, service.MessageBatch{msg})).To(Succeed())
+		v, ok := h.AttributeValue(ctx, "ver", "data_contract_version")
+		Expect(ok).To(BeTrue(), "all versions share one umh.tag row, so metadata is the only place the version survives")
+		Expect(v).To(Equal("3"))
+		_, ok = h.AttributeValue(ctx, "ver", "data_contract_name")
+		Expect(ok).To(BeFalse(), "the name is already a column on umh.tag")
+	})
+
+	It("writes no version key for a contract that never carried one", func() {
+		h := connected("nover")
+		defer h.Close(ctx)
+		msg := mkMsg(1.0, 1000, "_nover", "l.a", "t", map[string]string{"serialNumber": "abc"})
+		Expect(h.WriteBatch(ctx, service.MessageBatch{msg})).To(Succeed())
+		_, ok := h.AttributeValue(ctx, "nover", "data_contract_version")
+		Expect(ok).To(BeFalse(), "the uns output sets the version only on the validated path, and an absent key is not stored blank")
+	})
+
+	It("emits a fresh attribute row when the contract version changes", func() {
+		h := connected("verbump")
+		defer h.Close(ctx)
+		v1 := mkMsg(1.0, 1000, "_verbump_v1", "l.a", "t", map[string]string{"data_contract_version": "1"})
+		v2 := mkMsg(2.0, 2000, "_verbump_v2", "l.a", "t", map[string]string{"data_contract_version": "2"})
+		Expect(h.WriteBatch(ctx, service.MessageBatch{v1})).To(Succeed())
+		Expect(h.WriteBatch(ctx, service.MessageBatch{v2})).To(Succeed())
+		Expect(h.CountAttributeRows(ctx, "verbump")).To(Equal(2), "the version is part of the dedup fingerprint, so a bump is recorded rather than swallowed")
+	})
+
 	It("omits blacklisted metadata keys from the stored attribute row", func() {
 		h := connected("excl")
 		defer h.Close(ctx)


### PR DESCRIPTION
## Problem

`data_contract_version` never reached the database. It was in the historian's structural
skip list, which is for keys already stored as a column. The version has no column: all
versions of a contract share one `umh.tag` row.

## What we are shipping

- The version is stored as metadata. Query it with `attribute->>'data_contract_version'`.
- A contract with no version, like `_historian`, stores no version key.
- Moving a tag from `_pump_v1` to `_pump_v2` writes a new attribute row.

## What we are NOT shipping

No column, no migration. The metadata allowlist could do this too, but only if you turn off
`metadata_keys_all` and list every key by hand, so the fix goes in the plugin.

Fixes ENG-5474
