### PR TITLE
fix(historian): apply compression and retention to every data contract

### DIFF
--- a/.changelog/unreleased/fixes-20260826-092538.yaml
+++ b/.changelog/unreleased/fixes-20260826-092538.yaml
@@ -1,3 +1,0 @@
-kind: fixes
-body: Compression and retention policies now apply to every historian data contract, not just the first one written to a database. A contract whose tables were created without them picks them up the next time its bridge starts (ENG-5757)
-time: 2026-08-26T09:25:38.213572+02:00

--- a/.changelog/unreleased/fixes-20260826-092538.yaml
+++ b/.changelog/unreleased/fixes-20260826-092538.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: Compression and retention policies now apply to every historian data contract, not just the first one written to a database. A contract whose tables were created without them picks them up the next time its bridge starts (ENG-5757)
+time: 2026-08-26T09:25:38.213572+02:00

--- a/.changelog/unreleased/fixes-20260826-154709.yaml
+++ b/.changelog/unreleased/fixes-20260826-154709.yaml
@@ -1,3 +1,3 @@
 kind: fixes
-body: The historian output now applies compression and retention to every data contract, not only the first one on a database; chunks on every later contract were previously never compressed and never dropped. Retention reaches only a hypertable that holds no data yet, so upgrading never deletes stored rows, and for a contract that already holds data the output logs the add_retention_policy statement to run by hand (ENG-5757)
+body: The historian output now applies compression and retention to every data contract. Previously it was only applied to the first one. This is backwards-compatible with existing historian-setups. (ENG-5757)
 time: 2026-08-26T15:47:09.959042+02:00

--- a/.changelog/unreleased/fixes-20260826-154709.yaml
+++ b/.changelog/unreleased/fixes-20260826-154709.yaml
@@ -1,3 +1,3 @@
 kind: fixes
-body: The historian output now applies compression and retention to every data contract, not only the first one on a database; chunks on every later contract were previously never compressed and never dropped. A contract still missing its policies gets them the next time the output starts, and if retention is set, TimescaleDB then drops chunks older than that window, so check retention against the policies already applied before upgrading (ENG-5757)
+body: The historian output now applies compression and retention to every data contract, not only the first one on a database; chunks on every later contract were previously never compressed and never dropped. Retention is applied only to a hypertable that holds no data yet, so upgrading never deletes history: for a contract that already holds data the output logs the add_retention_policy statement to run by hand (ENG-5757)
 time: 2026-08-26T15:47:09.959042+02:00

--- a/.changelog/unreleased/fixes-20260826-154709.yaml
+++ b/.changelog/unreleased/fixes-20260826-154709.yaml
@@ -1,3 +1,3 @@
 kind: fixes
-body: The historian output now applies compression and retention to every data contract, not only the first one on a database; chunks on every later contract were previously never compressed and never dropped. A contract still missing its policies gets them the next time its bridge starts, and if retention is set, TimescaleDB then drops chunks older than that window, so check retention against the policies already applied before upgrading (ENG-5757)
+body: The historian output now applies compression and retention to every data contract, not only the first one on a database; chunks on every later contract were previously never compressed and never dropped. A contract still missing its policies gets them the next time the output starts, and if retention is set, TimescaleDB then drops chunks older than that window, so check retention against the policies already applied before upgrading (ENG-5757)
 time: 2026-08-26T15:47:09.959042+02:00

--- a/.changelog/unreleased/fixes-20260826-154709.yaml
+++ b/.changelog/unreleased/fixes-20260826-154709.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: The historian output now applies compression and retention to every data contract, not only the first one on a database; chunks on every later contract were previously never compressed and never dropped. A contract still missing its policies gets them the next time its bridge starts, and if retention is set, TimescaleDB then drops chunks older than that window, so check retention against the policies already applied before upgrading (ENG-5757)
+time: 2026-08-26T15:47:09.959042+02:00

--- a/.changelog/unreleased/fixes-20260826-154709.yaml
+++ b/.changelog/unreleased/fixes-20260826-154709.yaml
@@ -1,3 +1,3 @@
 kind: fixes
-body: The historian output now applies compression and retention to every data contract, not only the first one on a database; chunks on every later contract were previously never compressed and never dropped. Retention is applied only to a hypertable that holds no data yet, so upgrading never deletes history: for a contract that already holds data the output logs the add_retention_policy statement to run by hand (ENG-5757)
+body: The historian output now applies compression and retention to every data contract, not only the first one on a database; chunks on every later contract were previously never compressed and never dropped. Retention reaches only a hypertable that holds no data yet, so upgrading never deletes stored rows, and for a contract that already holds data the output logs the add_retention_policy statement to run by hand (ENG-5757)
 time: 2026-08-26T15:47:09.959042+02:00

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -373,6 +373,8 @@ when a configured interval differs from the one its table was created with.
 Both intervals default to `168h`, which is 7 days. To change one on an existing database, for a
 contract named `pump`:
 
+Both intervals default to `168h`, which is 7 days, so pick a width that differs from that:
+
 ```sql
 SELECT set_chunk_time_interval('umh.value_pump', INTERVAL '1 day');
 SELECT set_chunk_time_interval('umh.attribute_pump', INTERVAL '30 days');

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -29,7 +29,7 @@ No JavaScript processor or hand-written `sql_raw` is needed.
 | `sslmode` | no | `require` | `require` \| `disable` \| `verify-full`. |
 | `sslrootcert` / `sslcert` / `sslkey` | no | `""` | TLS cert paths inside the container. |
 | `allow_datatype_changes` | no | `false` | Let a tag change datatype (numeric ↔ text) instead of dropping the offending rows as poison. The tag then holds both, and `umh.tag.value_type` keeps the first type seen — read it with `coalesce(value_num::text, value_text)`. Applies to every contract, versioned or not. |
-| `data_contract_name` | yes | — | Bare lowercase contract name, e.g. `pump`; no leading `_`, no `_vN` suffix, 53 characters or fewer so that `umh.attribute_<contract>` stays inside PostgreSQL's 63-byte identifier limit. Stored in `umh.tag.data_contract_name` in its UNS form with a leading underscore (`_pump`), matching the topic's data-contract segment. |
+| `data_contract_name` | yes | — | Bare lowercase contract name, e.g. `pump`; no leading `_`, no `_vN` suffix, 53 characters or fewer. Stored in `umh.tag.data_contract_name` in its UNS form with a leading underscore (`_pump`), matching the topic's data-contract segment. |
 | `metadata_keys_all` | no | `true` | Store every metadata key except structural/high-churn keys and any `metadata_keys_exclude` match. |
 | `metadata_keys` | no | `[]` | Allowlist used only when `metadata_keys_all=false`. |
 | `metadata_keys_exclude` | no | `[]` | Blacklist applied only when `metadata_keys_all=true`. Each entry is an exact key name or a trailing-`*` prefix (e.g. `opcua_*`); matches are dropped on top of the built-in exclusions. A bare `*` drops everything. Ignored in allowlist mode. |

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -339,6 +339,12 @@ the same tables. To avoid schema drift, a given contract/database must be writte
 hypertables that does not already have such a policy. A contract added to a database that already
 holds other contracts gets its own policies too.
 
+A hypertable with no such policy gets one when the output starts, whether the table is new or
+already holds history. For retention that means TimescaleDB drops everything older than the window
+once the retention job next runs, so check `retention` against the policies already applied before
+pointing an output at tables it did not create. The output warns for each hypertable that already
+holds data, and names the statement that cancels the policy.
+
 An interval that is already applied is never changed. Editing `compress_after` or `retention`
 therefore has **no effect** on tables that already have those policies. This is intentional: a
 config edit should not rewrite how production history is compressed, or for retention **deleted**.
@@ -375,15 +381,6 @@ because the output looks for the policy rather than for whether it is scheduled.
 `compress_after` has no empty value, so compression cannot be switched off this way: a compression
 policy removed on the database is re-created when the output next starts, as are the compression
 settings if they were turned off.
-
-### Upgrading from a build that applied policies once per database
-
-Contracts other than the first on a database were left without policies by that build, so their
-chunks were never compressed and old ones never dropped. The first start after upgrading applies
-the configured values to them, and if `retention` is set, TimescaleDB drops everything older than
-that window once the retention job runs. Check `retention` against the applied policies before
-upgrading. The output warns for each hypertable that already holds data, and names the statement
-that cancels the policy.
 
 ## Changing the chunk interval
 

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -335,22 +335,16 @@ the same tables. To avoid schema drift, a given contract/database must be writte
 
 ## Changing compression or retention
 
-`compress_after` and `retention` are applied per contract, to each of that contract's two
-hypertables that does not already have such a policy. A contract added to a database that already
-holds other contracts gets its own policies too.
+`compress_after` and `retention` are applied per contract, to each of a contract's two hypertables
+that has no such policy yet, including a table that already holds history. For retention that means
+TimescaleDB drops everything older than the window once its job next runs, so check `retention`
+before pointing an output at tables it did not create. Before scheduling retention on a table that
+holds data, the output warns and names the statement that cancels it.
 
-A hypertable with no such policy gets one when the output starts, whether the table is new or
-already holds history. For retention that means TimescaleDB drops everything older than the window
-once the retention job next runs, so check `retention` against the policies already applied before
-pointing an output at tables it did not create. The output warns for each hypertable that already
-holds data, and names the statement that cancels the policy.
-
-An interval that is already applied is never changed. Editing `compress_after` or `retention`
-therefore has **no effect** on tables that already have those policies. This is intentional: a
-config edit should not rewrite how production history is compressed, or for retention **deleted**.
-When the output starts it logs a warning if the applied policy differs from the config, but it does
-not change the policy. The check covers both of a contract's hypertables, so a policy that differs
-on one of them alone is reported.
+An interval that is already applied is never changed, so editing `compress_after` or `retention` has
+**no effect** on a table that already has that policy: a config edit should not rewrite how
+production history is compressed, or for retention **deleted**. On start the output warns about a
+divergence on either hypertable instead, and leaves the policy alone.
 
 To change them on an existing database, update the TimescaleDB policies directly, on **both**
 hypertables for the contract. For a contract named `pump`:

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -335,7 +335,7 @@ the same tables. To avoid schema drift, a given contract/database must be writte
 
 ## Changing compression or retention
 
-`compress_after` and `retention` are applied **per contract**, to each of that contract's two
+`compress_after` and `retention` are applied per contract, to each of that contract's two
 hypertables that does not already have such a policy. A contract added to a database that already
 holds other contracts gets its own policies too.
 
@@ -345,19 +345,6 @@ config edit should not rewrite how production history is compressed, or for rete
 When the output starts it logs a warning if the applied policy differs from the config, but it does
 not change the policy. That check reads `umh.value_<contract>`, so a policy that differs on
 `umh.attribute_<contract>` alone is not reported.
-
-**Upgrading from a build that applied policies once per database.** Contracts other than the first
-on a database were left without policies by that build, so their chunks were never compressed and
-never dropped. The first start after upgrading applies the configured values to them, and if
-`retention` is set, TimescaleDB drops everything older than that window once the retention job
-runs. Check `retention` against the policies actually applied before upgrading. The output warns
-for each hypertable it is about to give a retention policy to while it already holds data, and
-names the statement that cancels it.
-
-Compression cannot be switched off from this output: `compress_after` has no empty or off value, so
-a compression policy removed on the database is re-created when the output next starts, and so are
-the compression settings if they were turned off. Only retention can be switched off.
-
 
 To change them on an existing database, update the TimescaleDB policies directly, on **both**
 hypertables for the contract. For a contract named `pump`:
@@ -372,19 +359,31 @@ SELECT remove_compression_policy('umh.value_pump', if_exists => true);
 SELECT add_compression_policy('umh.value_pump', INTERVAL '7 days');
 ```
 
-To stop dropping data entirely, clear `retention` in this output's config **and** remove the policy
-from the database. A deleted policy looks the same as a contract that never had one, so a policy
-removed while a non-empty `retention` stays in the config is re-created the next time the output
-starts. Removing a policy on the database takes effect immediately; a reconnect does not re-create
-it, only a restart does.
+Removing a policy takes effect immediately. Setting the same value in this output's config afterward
+silences the drift warning, and gives the next contract that interval.
 
-Disabling a policy's job rather than removing it (`ALTER JOB ... SET scheduled = false`) also
-survives a restart, because the output looks for the policy, not for whether it is scheduled.
+### Switching a policy off
 
-After changing a policy on the database, set the **same** value in this output's config too. The
-config value is what a contract still without that policy gets, so matching it both silences the
-drift warning and gives the next contract the same interval.
+Only retention can be switched off, and it takes two steps: clear `retention` in this output's
+config, and remove the policy from the database. A deleted policy looks the same as a contract that
+never had one, so a policy removed while a non-empty `retention` stays in the config comes back the
+next time the output starts. A reconnect does not bring it back; only a restart does.
 
+Disabling the policy's job instead (`ALTER JOB ... SET scheduled = false`) survives a restart,
+because the output looks for the policy rather than for whether it is scheduled.
+
+`compress_after` has no empty value, so compression cannot be switched off this way: a compression
+policy removed on the database is re-created when the output next starts, as are the compression
+settings if they were turned off.
+
+### Upgrading from a build that applied policies once per database
+
+Contracts other than the first on a database were left without policies by that build, so their
+chunks were never compressed and old ones never dropped. The first start after upgrading applies
+the configured values to them, and if `retention` is set, TimescaleDB drops everything older than
+that window once the retention job runs. Check `retention` against the applied policies before
+upgrading. The output warns for each hypertable that already holds data, and names the statement
+that cancels the policy.
 
 ## Changing the chunk interval
 

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -388,10 +388,12 @@ A hypertable is stored as chunks, each holding one time range of rows; `value_ch
 `attribute_chunk_interval` set how wide that range is. The width decides how much a time-filtered
 query can skip, and how coarsely compression and retention act, since both work on whole chunks.
 
-The interval reaches the database only when the table is created. The reason is the one the policies
-give: a config edit should not reorganize production history. Unlike the policies, a chunk interval
-is never filled in later, because `create_hypertable` is a no-op once the table exists. On restart
-the output warns if a configured interval differs from the one its table was created with.
+The interval reaches the database only when the table is created. The reason is the one the
+policies give: a config edit should not reorganize production history. On restart the output warns
+when a configured interval differs from the one its table was created with.
+
+Unlike the policies, a chunk interval is never filled in later: `create_hypertable` is a no-op once
+the table exists.
 
 Both intervals default to `168h`, which is 7 days. To change one on an existing database, for a
 contract named `pump`:

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -343,8 +343,8 @@ An interval that is already applied is never changed. Editing `compress_after` o
 therefore has **no effect** on tables that already have those policies. This is intentional: a
 config edit should not rewrite how production history is compressed, or for retention **deleted**.
 When the output starts it logs a warning if the applied policy differs from the config, but it does
-not change the policy. That check reads `umh.value_<contract>`, so a policy that differs on
-`umh.attribute_<contract>` alone is not reported.
+not change the policy. The check covers both of a contract's hypertables, so a policy that differs
+on one of them alone is reported.
 
 To change them on an existing database, update the TimescaleDB policies directly, on **both**
 hypertables for the contract. For a contract named `pump`:

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -34,7 +34,7 @@ No JavaScript processor or hand-written `sql_raw` is needed.
 | `metadata_keys` | no | `[]` | Allowlist used only when `metadata_keys_all=false`. |
 | `metadata_keys_exclude` | no | `[]` | Blacklist applied only when `metadata_keys_all=true`. Each entry is an exact key name or a trailing-`*` prefix (e.g. `opcua_*`); matches are dropped on top of the built-in exclusions. A bare `*` drops everything. Ignored in allowlist mode. |
 | `compress_after` | no | `168h` | Compress chunks older than this. Applied to each of a contract's hypertables that has no compression policy yet; changing it afterward has no effect, and compression cannot be switched off (see [Changing compression or retention](#changing-compression-or-retention)). |
-| `retention` | no | `""` | Drop chunks older than this; empty keeps data forever. Applied to each of a contract's hypertables that has no retention policy yet; changing it afterward has no effect, and a policy removed on the database returns unless this is cleared too (see [Changing compression or retention](#changing-compression-or-retention)). |
+| `retention` | no | `""` | Drop chunks older than this; empty keeps data forever. Applied only to a hypertable that has no retention policy yet **and holds no data**; changing it afterward has no effect (see [Changing compression or retention](#changing-compression-or-retention)). |
 | `value_chunk_interval` | no | `168h` | Chunk width of `umh.value_<contract>`. Applied when the table is created; changing it afterward has no effect (see [Changing the chunk interval](#changing-the-chunk-interval)). |
 | `attribute_chunk_interval` | no | `168h` | Chunk width of `umh.attribute_<contract>`. Attribute rows are written only when a tag's metadata changes, so this table is much sparser than the value table. Applied when the table is created. |
 | `batching` | no | — | benthos batch policy (`count` / `period` / `byte_size`). The whole batch is written in one transaction, so larger batches raise throughput; e.g. `count: 1000`, `period: 1s`. |
@@ -336,10 +336,18 @@ the same tables. To avoid schema drift, a given contract/database must be writte
 ## Changing compression or retention
 
 `compress_after` and `retention` are applied per contract, to each of a contract's two hypertables
-that has no such policy yet, including a table that already holds history. For retention that means
-TimescaleDB drops everything older than the window once its job next runs, so check `retention`
-before pointing an output at tables it did not create. Before scheduling retention on a table that
-holds data, the output warns and names the statement that cancels it.
+that has no such policy yet. Compression is applied whether or not the table already holds history,
+since compressing a chunk destroys nothing. **Retention is applied only to a hypertable that holds
+no data**, because it drops every chunk older than the window: a restart must not delete history
+that a config value written months ago now covers. On a hypertable that already holds data the
+output warns instead, and names the statement that applies the policy by hand:
+
+```
+historian: umh.value_pump already holds data, so the configured retention (720h0m0s) was not applied
+to it. Applying it drops every chunk older than that. To apply it, run
+add_retention_policy('umh.value_pump', INTERVAL '2592000 seconds'); to stop this warning, clear
+retention in the config.
+```
 
 An interval that is already applied is never changed, so editing `compress_after` or `retention` has
 **no effect** on a table that already has that policy: a config edit should not rewrite how
@@ -364,17 +372,15 @@ silences the drift warning, and gives the next contract that interval.
 
 ### Switching a policy off
 
-Only retention can be switched off, and it takes two steps: clear `retention` in this output's
-config, and remove the policy from the database. A deleted policy looks the same as a contract that
-never had one, so a policy removed while a non-empty `retention` stays in the config comes back the
-next time the output starts. A reconnect does not bring it back; only a restart does.
+Removing a retention policy from a hypertable that holds data is enough: it is not re-created, even
+with `retention` still set in the config, and the output warns on each start until the config is
+cleared too. On an empty hypertable a removed policy does come back on the next start, so clear
+`retention` first there.
 
-Disabling the policy's job instead (`ALTER JOB ... SET scheduled = false`) survives a restart,
-because the output looks for the policy rather than for whether it is scheduled.
-
-`compress_after` has no empty value, so compression cannot be switched off this way: a compression
-policy removed on the database is re-created when the output next starts, as are the compression
-settings if they were turned off.
+`compress_after` has no empty value, so compression cannot be switched off: a compression policy
+removed on the database is re-created when the output next starts, as are the compression settings if
+they were turned off. Disabling the job instead (`ALTER JOB ... SET scheduled = false`) does survive
+a restart, because the output looks for the policy rather than for whether it is scheduled.
 
 ## Changing the chunk interval
 

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -29,7 +29,7 @@ No JavaScript processor or hand-written `sql_raw` is needed.
 | `sslmode` | no | `require` | `require` \| `disable` \| `verify-full`. |
 | `sslrootcert` / `sslcert` / `sslkey` | no | `""` | TLS cert paths inside the container. |
 | `allow_datatype_changes` | no | `false` | Let a tag change datatype (numeric ↔ text) instead of dropping the offending rows as poison. The tag then holds both, and `umh.tag.value_type` keeps the first type seen — read it with `coalesce(value_num::text, value_text)`. Applies to every contract, versioned or not. |
-| `data_contract_name` | yes | — | Bare lowercase contract name, e.g. `pump`; no leading `_`, no `_vN` suffix. Stored in `umh.tag.data_contract_name` in its UNS form with a leading underscore (`_pump`), matching the topic's data-contract segment. |
+| `data_contract_name` | yes | — | Bare lowercase contract name, e.g. `pump`; no leading `_`, no `_vN` suffix, 53 characters or fewer so that `umh.attribute_<contract>` stays inside PostgreSQL's 63-byte identifier limit. Stored in `umh.tag.data_contract_name` in its UNS form with a leading underscore (`_pump`), matching the topic's data-contract segment. |
 | `metadata_keys_all` | no | `true` | Store every metadata key except structural/high-churn keys and any `metadata_keys_exclude` match. |
 | `metadata_keys` | no | `[]` | Allowlist used only when `metadata_keys_all=false`. |
 | `metadata_keys_exclude` | no | `[]` | Blacklist applied only when `metadata_keys_all=true`. Each entry is an exact key name or a trailing-`*` prefix (e.g. `opcua_*`); matches are dropped on top of the built-in exclusions. A bare `*` drops everything. Ignored in allowlist mode. |

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -33,8 +33,8 @@ No JavaScript processor or hand-written `sql_raw` is needed.
 | `metadata_keys_all` | no | `true` | Store every metadata key except structural/high-churn keys and any `metadata_keys_exclude` match. |
 | `metadata_keys` | no | `[]` | Allowlist used only when `metadata_keys_all=false`. |
 | `metadata_keys_exclude` | no | `[]` | Blacklist applied only when `metadata_keys_all=true`. Each entry is an exact key name or a trailing-`*` prefix (e.g. `opcua_*`); matches are dropped on top of the built-in exclusions. A bare `*` drops everything. Ignored in allowlist mode. |
-| `compress_after` | no | `168h` | Compress chunks older than this. Applied once at first bootstrap; changing it afterward has no effect (see [Changing compression or retention](#changing-compression-or-retention)). |
-| `retention` | no | `""` | Drop chunks older than this; empty keeps data forever. Applied once at first bootstrap; changing it afterward has no effect (see [Changing compression or retention](#changing-compression-or-retention)). |
+| `compress_after` | no | `168h` | Compress chunks older than this. Applied to each of a contract's hypertables that has no compression policy yet; changing it afterward has no effect (see [Changing compression or retention](#changing-compression-or-retention)). |
+| `retention` | no | `""` | Drop chunks older than this; empty keeps data forever. Applied to each of a contract's hypertables that has no retention policy yet; changing it afterward has no effect (see [Changing compression or retention](#changing-compression-or-retention)). |
 | `value_chunk_interval` | no | `168h` | Chunk width of `umh.value_<contract>`. Applied when the table is created; changing it afterward has no effect (see [Changing the chunk interval](#changing-the-chunk-interval)). |
 | `attribute_chunk_interval` | no | `168h` | Chunk width of `umh.attribute_<contract>`. Attribute rows are written only when a tag's metadata changes, so this table is much sparser than the value table. Applied when the table is created. |
 | `batching` | no | — | benthos batch policy (`count` / `period` / `byte_size`). The whole batch is written in one transaction, so larger batches raise throughput; e.g. `count: 1000`, `period: 1s`. |
@@ -333,12 +333,15 @@ the same tables. To avoid schema drift, a given contract/database must be writte
 
 ## Changing compression or retention
 
-`compress_after` and `retention` are applied **once, at first bootstrap**, and are deliberately
-not re-applied when the output restarts. Editing them in the config therefore has **no
-effect** on a database that already has the tables. This is intentional: a config edit (or a form
-change in the Management Console) should not silently change how production history is compressed
-or — for retention — **deleted**. On restart the output logs a warning if the applied policy
-differs from the config, so drift stays visible, but it does not act on it.
+`compress_after` and `retention` are applied **per contract**, to each of that contract's two
+hypertables that does not already have such a policy. A contract added to a database that already
+holds other contracts gets its own policies too.
+
+An interval that is already applied is never changed. Editing `compress_after` or `retention`
+therefore has **no effect** on tables that already have those policies. This is intentional: a
+config edit should not rewrite how production history is compressed, or for retention **deleted**.
+On restart the output logs a warning if the applied policy differs from the config, but it does not
+change the policy.
 
 To change them on an existing database, update the TimescaleDB policies directly, on **both**
 hypertables for the contract. For a contract named `pump`:
@@ -353,8 +356,10 @@ SELECT remove_compression_policy('umh.value_pump', if_exists => true);
 SELECT add_compression_policy('umh.value_pump', INTERVAL '7 days');
 ```
 
-To stop dropping data entirely (the `retention: ""` default), remove the retention policy and do
-not re-add it. Changing either policy takes effect immediately and never needs a restart.
+To stop dropping data entirely, clear `retention` in this output's config **and** remove the policy
+from the database. A deleted policy looks the same as a contract that never had one, so a policy
+removed while a non-empty `retention` stays in the config is re-created the next time the output
+starts. Removing a policy on the database takes effect immediately.
 
 After changing a policy on the database, set the **same** value in this output's config too. The
 config value is still what a fresh bootstrap of a new database uses, and matching it silences the

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -400,8 +400,6 @@ the output warns if a configured interval differs from the one its table was cre
 Both intervals default to `168h`, which is 7 days. To change one on an existing database, for a
 contract named `pump`:
 
-Both intervals default to `168h`, which is 7 days, so pick a width that differs from that:
-
 ```sql
 SELECT set_chunk_time_interval('umh.value_pump', INTERVAL '1 day');
 SELECT set_chunk_time_interval('umh.attribute_pump', INTERVAL '30 days');

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -322,10 +322,8 @@ sources by their path segments, not by punctuation that folds.
 ## Schema and compatibility
 
 The plugin owns the schema: it bootstraps the baseline DDL into the `umh` schema
-idempotently when the output starts and **never changes the columns or types of an
-already-created `umh.value_<contract>` / `umh.attribute_<contract>` table**. It does set
-TimescaleDB compression settings on a table that has none yet, which takes a brief exclusive
-lock on that table. A breaking schema change ships
+idempotently when the output starts and **never changes the columns or types of an already-created
+`umh.value_<contract>` / `umh.attribute_<contract>` table**. A breaking schema change ships
 as a new contract (new tables), never an in-place migration. (`ltree` stays in `public`,
 its conventional shared home.)
 
@@ -337,7 +335,8 @@ the same tables. To avoid schema drift, a given contract/database must be writte
 
 `compress_after` and `retention` are applied per contract, to each of a contract's two hypertables
 that has no such policy yet. Compression is applied whether or not the table already holds history,
-since compressing a chunk destroys nothing. **Retention is applied only to a hypertable that holds
+since compressing a chunk destroys nothing; enabling it on a table that has no compression settings
+takes a brief exclusive lock on that table. **Retention is applied only to a hypertable that holds
 no data**, because it drops every chunk older than the window: a restart must not delete history
 that a config value written months ago now covers. On a hypertable that already holds data the
 output warns instead, and names the statement that applies the policy by hand:

--- a/docs/output/historian.md
+++ b/docs/output/historian.md
@@ -33,8 +33,8 @@ No JavaScript processor or hand-written `sql_raw` is needed.
 | `metadata_keys_all` | no | `true` | Store every metadata key except structural/high-churn keys and any `metadata_keys_exclude` match. |
 | `metadata_keys` | no | `[]` | Allowlist used only when `metadata_keys_all=false`. |
 | `metadata_keys_exclude` | no | `[]` | Blacklist applied only when `metadata_keys_all=true`. Each entry is an exact key name or a trailing-`*` prefix (e.g. `opcua_*`); matches are dropped on top of the built-in exclusions. A bare `*` drops everything. Ignored in allowlist mode. |
-| `compress_after` | no | `168h` | Compress chunks older than this. Applied to each of a contract's hypertables that has no compression policy yet; changing it afterward has no effect (see [Changing compression or retention](#changing-compression-or-retention)). |
-| `retention` | no | `""` | Drop chunks older than this; empty keeps data forever. Applied to each of a contract's hypertables that has no retention policy yet; changing it afterward has no effect (see [Changing compression or retention](#changing-compression-or-retention)). |
+| `compress_after` | no | `168h` | Compress chunks older than this. Applied to each of a contract's hypertables that has no compression policy yet; changing it afterward has no effect, and compression cannot be switched off (see [Changing compression or retention](#changing-compression-or-retention)). |
+| `retention` | no | `""` | Drop chunks older than this; empty keeps data forever. Applied to each of a contract's hypertables that has no retention policy yet; changing it afterward has no effect, and a policy removed on the database returns unless this is cleared too (see [Changing compression or retention](#changing-compression-or-retention)). |
 | `value_chunk_interval` | no | `168h` | Chunk width of `umh.value_<contract>`. Applied when the table is created; changing it afterward has no effect (see [Changing the chunk interval](#changing-the-chunk-interval)). |
 | `attribute_chunk_interval` | no | `168h` | Chunk width of `umh.attribute_<contract>`. Attribute rows are written only when a tag's metadata changes, so this table is much sparser than the value table. Applied when the table is created. |
 | `batching` | no | — | benthos batch policy (`count` / `period` / `byte_size`). The whole batch is written in one transaction, so larger batches raise throughput; e.g. `count: 1000`, `period: 1s`. |
@@ -322,8 +322,10 @@ sources by their path segments, not by punctuation that folds.
 ## Schema and compatibility
 
 The plugin owns the schema: it bootstraps the baseline DDL into the `umh` schema
-idempotently when the output starts and **never alters an already-created
-`umh.value_<contract>` / `umh.attribute_<contract>` table**. A breaking schema change ships
+idempotently when the output starts and **never changes the columns or types of an
+already-created `umh.value_<contract>` / `umh.attribute_<contract>` table**. It does set
+TimescaleDB compression settings on a table that has none yet, which takes a brief exclusive
+lock on that table. A breaking schema change ships
 as a new contract (new tables), never an in-place migration. (`ltree` stays in `public`,
 its conventional shared home.)
 
@@ -340,8 +342,22 @@ holds other contracts gets its own policies too.
 An interval that is already applied is never changed. Editing `compress_after` or `retention`
 therefore has **no effect** on tables that already have those policies. This is intentional: a
 config edit should not rewrite how production history is compressed, or for retention **deleted**.
-On restart the output logs a warning if the applied policy differs from the config, but it does not
-change the policy.
+When the output starts it logs a warning if the applied policy differs from the config, but it does
+not change the policy. That check reads `umh.value_<contract>`, so a policy that differs on
+`umh.attribute_<contract>` alone is not reported.
+
+**Upgrading from a build that applied policies once per database.** Contracts other than the first
+on a database were left without policies by that build, so their chunks were never compressed and
+never dropped. The first start after upgrading applies the configured values to them, and if
+`retention` is set, TimescaleDB drops everything older than that window once the retention job
+runs. Check `retention` against the policies actually applied before upgrading. The output warns
+for each hypertable it is about to give a retention policy to while it already holds data, and
+names the statement that cancels it.
+
+Compression cannot be switched off from this output: `compress_after` has no empty or off value, so
+a compression policy removed on the database is re-created when the output next starts, and so are
+the compression settings if they were turned off. Only retention can be switched off.
+
 
 To change them on an existing database, update the TimescaleDB policies directly, on **both**
 hypertables for the contract. For a contract named `pump`:
@@ -359,11 +375,16 @@ SELECT add_compression_policy('umh.value_pump', INTERVAL '7 days');
 To stop dropping data entirely, clear `retention` in this output's config **and** remove the policy
 from the database. A deleted policy looks the same as a contract that never had one, so a policy
 removed while a non-empty `retention` stays in the config is re-created the next time the output
-starts. Removing a policy on the database takes effect immediately.
+starts. Removing a policy on the database takes effect immediately; a reconnect does not re-create
+it, only a restart does.
+
+Disabling a policy's job rather than removing it (`ALTER JOB ... SET scheduled = false`) also
+survives a restart, because the output looks for the policy, not for whether it is scheduled.
 
 After changing a policy on the database, set the **same** value in this output's config too. The
-config value is still what a fresh bootstrap of a new database uses, and matching it silences the
-drift warning on restart.
+config value is what a contract still without that policy gets, so matching it both silences the
+drift warning and gives the next contract the same interval.
+
 
 ## Changing the chunk interval
 
@@ -371,9 +392,10 @@ A hypertable is stored as chunks, each holding one time range of rows; `value_ch
 `attribute_chunk_interval` set how wide that range is. The width decides how much a time-filtered
 query can skip, and how coarsely compression and retention act, since both work on whole chunks.
 
-The interval reaches the database only when the table is created. The reason is the one the
-policies give: a config edit should not reorganize production history. On restart the output warns
-when a configured interval differs from the one its table was created with.
+The interval reaches the database only when the table is created. The reason is the one the policies
+give: a config edit should not reorganize production history. Unlike the policies, a chunk interval
+is never filled in later, because `create_hypertable` is a no-op once the table exists. On restart
+the output warns if a configured interval differs from the one its table was created with.
 
 Both intervals default to `168h`, which is 7 days. To change one on an existing database, for a
 contract named `pump`:

--- a/historian_plugin/export_test.go
+++ b/historian_plugin/export_test.go
@@ -397,6 +397,12 @@ func (h *HistorianTestHandle) AppliedChunkInterval(ctx context.Context, table st
 
 func (h *HistorianTestHandle) WarnChunkDrift(ctx context.Context) { h.o.warnChunkDrift(ctx) }
 
+func (h *HistorianTestHandle) WarnPolicyDrift(ctx context.Context) { h.o.warnPolicyDrift(ctx) }
+
+func (h *HistorianTestHandle) WarnRetentionAboutToDrop(ctx context.Context) {
+	h.o.warnRetentionAboutToDrop(ctx)
+}
+
 func BootstrapSQLWithPoliciesForTest(contract string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
 	return bootstrapSQL(bootstrapConfig{
 		contract:       contract,

--- a/historian_plugin/export_test.go
+++ b/historian_plugin/export_test.go
@@ -423,9 +423,8 @@ func (h *HistorianTestHandle) SetPolicies(compressAfter time.Duration, retention
 
 func (h *HistorianTestHandle) PolicyIntervals(ctx context.Context, table string) (*int64, *int64) {
 	ExpectWithOffset(1, h.o.pool).NotTo(BeNil(), "Connect must succeed before PolicyIntervals")
-	var compressAfter, retention *int64
-	ExpectWithOffset(1, h.o.pool.QueryRow(ctx, policyIntervalSQL("policy_compression", "compress_after"), table).Scan(&compressAfter)).To(Succeed())
-	ExpectWithOffset(1, h.o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&retention)).To(Succeed())
+	compressAfter, retention, err := h.o.readAppliedPolicies(ctx, table)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return compressAfter, retention
 }
 

--- a/historian_plugin/export_test.go
+++ b/historian_plugin/export_test.go
@@ -402,6 +402,31 @@ func (h *HistorianTestHandle) AppliedChunkInterval(ctx context.Context, table st
 
 func (h *HistorianTestHandle) WarnChunkDrift(ctx context.Context) { h.o.warnChunkDrift(ctx) }
 
+func BootstrapSQLWithPoliciesForTest(contract string, compressAfter time.Duration, retention time.Duration) string {
+	return bootstrapSQL(bootstrapConfig{
+		contract:       contract,
+		compressAfter:  compressAfter,
+		retention:      retention,
+		retentionSet:   retention > 0,
+		valueChunk:     168 * time.Hour,
+		attributeChunk: 168 * time.Hour,
+	})
+}
+
+func (h *HistorianTestHandle) SetPolicies(compressAfter time.Duration, retention time.Duration) {
+	h.o.compressAfter = compressAfter
+	h.o.retention = retention
+	h.o.retentionSet = retention > 0
+}
+
+func (h *HistorianTestHandle) PolicyIntervals(ctx context.Context, table string) (*int64, *int64) {
+	ExpectWithOffset(1, h.o.pool).NotTo(BeNil(), "Connect must succeed before PolicyIntervals")
+	var compressAfter, retention *int64
+	ExpectWithOffset(1, h.o.pool.QueryRow(ctx, policyIntervalSQL("policy_compression", "compress_after"), table).Scan(&compressAfter)).To(Succeed())
+	ExpectWithOffset(1, h.o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&retention)).To(Succeed())
+	return compressAfter, retention
+}
+
 func (h *HistorianTestHandle) ExecSQL(ctx context.Context, sql string) error {
 	_, err := h.o.pool.Exec(ctx, sql)
 	return err

--- a/historian_plugin/export_test.go
+++ b/historian_plugin/export_test.go
@@ -32,12 +32,7 @@ func HistorianConfig() *service.ConfigSpec { return historianConfig() }
 
 // BootstrapSQLForTest renders the bootstrap DDL for a contract (default policies).
 func BootstrapSQLForTest(contract string) string {
-	return bootstrapSQL(bootstrapConfig{
-		contract:       contract,
-		compressAfter:  168 * time.Hour,
-		valueChunk:     168 * time.Hour,
-		attributeChunk: 168 * time.Hour,
-	})
+	return BootstrapSQLWithPoliciesForTest(contract, 168*time.Hour, 0, false)
 }
 
 // SchemaVersionForTest exposes the highest schema-migration version the bootstrap applies
@@ -402,21 +397,22 @@ func (h *HistorianTestHandle) AppliedChunkInterval(ctx context.Context, table st
 
 func (h *HistorianTestHandle) WarnChunkDrift(ctx context.Context) { h.o.warnChunkDrift(ctx) }
 
-func BootstrapSQLWithPoliciesForTest(contract string, compressAfter time.Duration, retention time.Duration) string {
+func BootstrapSQLWithPoliciesForTest(contract string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
 	return bootstrapSQL(bootstrapConfig{
 		contract:       contract,
 		compressAfter:  compressAfter,
 		retention:      retention,
-		retentionSet:   retention > 0,
+		retentionSet:   retentionSet,
 		valueChunk:     168 * time.Hour,
 		attributeChunk: 168 * time.Hour,
 	})
 }
 
-func (h *HistorianTestHandle) SetPolicies(compressAfter time.Duration, retention time.Duration) {
+func (h *HistorianTestHandle) SetPolicies(compressAfter time.Duration, retention time.Duration, retentionSet bool) {
+	ExpectWithOffset(1, h.o.pool).To(BeNil(), "SetPolicies must be called before Connect")
 	h.o.compressAfter = compressAfter
 	h.o.retention = retention
-	h.o.retentionSet = retention > 0
+	h.o.retentionSet = retentionSet
 }
 
 func (h *HistorianTestHandle) PolicyIntervals(ctx context.Context, table string) (*int64, *int64) {

--- a/historian_plugin/export_test.go
+++ b/historian_plugin/export_test.go
@@ -397,10 +397,10 @@ func (h *HistorianTestHandle) AppliedChunkInterval(ctx context.Context, table st
 
 func (h *HistorianTestHandle) WarnChunkDrift(ctx context.Context) { h.o.warnChunkDrift(ctx) }
 
-func (h *HistorianTestHandle) WarnPolicyDrift(ctx context.Context) { h.o.warnPolicyDrift(ctx) }
+func (h *HistorianTestHandle) WarnPolicyDrift(ctx context.Context) { h.o.warnPolicyDrift(ctx, nil) }
 
-func (h *HistorianTestHandle) WarnRetentionAboutToDrop(ctx context.Context) {
-	h.o.warnRetentionAboutToDrop(ctx)
+func (h *HistorianTestHandle) WarnRetentionNotApplied(ctx context.Context) {
+	h.o.warnRetentionNotApplied(ctx)
 }
 
 func BootstrapSQLWithPoliciesForTest(contract string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -347,7 +347,7 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 			return err
 		}
 		defer conn.Release()
-		o.warnRetentionRecreate(bootCtx)
+		o.warnRetentionAboutToDrop(bootCtx)
 		if _, err := conn.Exec(bootCtx, o.renderBootstrapDDL()); err != nil {
 			return fmt.Errorf("schema bootstrap failed: %w", err) // guard stays false -> next Connect retries
 		}
@@ -400,17 +400,17 @@ func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int
 	return appliedComp, appliedRet, nil
 }
 
-// warnRetentionRecreate runs before the bootstrap DDL, because afterwards the applied policy matches
+// warnRetentionAboutToDrop runs before the bootstrap DDL, because afterwards the applied policy matches
 // config and warnPolicyDrift has nothing left to report. A failed lookup is logged, not swallowed:
 // this is the only signal before chunks start being dropped.
-func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
+func (o *historianOutput) warnRetentionAboutToDrop(ctx context.Context) {
 	if !o.retentionSet {
 		return
 	}
 	for _, table := range []string{"value_" + o.contract, "attribute_" + o.contract} {
 		var chunks int
 		if err := o.pool.QueryRow(ctx, hypertableChunkCountSQL, table).Scan(&chunks); err != nil {
-			o.logger.Warnf("historian: cannot read the chunk count of umh.%s, so cannot say whether retention (%s) will drop existing chunks: %v", table, o.retention, err)
+			o.logger.Warnf("historian: cannot read the chunk count of umh.%s, so cannot say whether retention (%s) drops existing chunks: %v", table, o.retention, err)
 			continue
 		}
 		if chunks == 0 {
@@ -424,7 +424,7 @@ func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 		if applied != nil {
 			continue
 		}
-		o.logger.Warnf("historian: umh.%s holds data and had no retention policy, so retention (%s) is now scheduled and older chunks will be dropped. To keep them, run remove_retention_policy('umh.%s') and clear retention here.", table, o.retention, table)
+		o.logger.Warnf("historian: retention (%s) is now scheduled on umh.%s, which already holds data, so older chunks will be dropped. To keep them, run remove_retention_policy('umh.%s') and clear retention in the config.", o.retention, table, table)
 	}
 }
 

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -310,7 +310,13 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 		// if_not_exists => TRUE reports a policy it declined to change as a notice and returns -1, so
 		// without this the decline reaches no log.
 		cfg.ConnConfig.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
-			o.logger.Warnf("TimescaleDB historian: %s: %s", n.Severity, n.Message)
+			// WARNING is what add_*_policy raises when if_not_exists makes it decline; NOTICE is
+			// routine bootstrap chatter ("trigger ... does not exist, skipping") on every start.
+			if n.Severity == "WARNING" {
+				o.logger.Warnf("historian: %s", n.Message)
+				return
+			}
+			o.logger.Debugf("historian: %s: %s", n.Severity, n.Message)
 		}
 		// Each in-flight batch holds a pooled connection for its write tx, so a pool smaller than
 		// max_in_flight silently caps concurrency. pgxpool defaults to max(4, NumCPU), below the

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -390,16 +390,14 @@ func (o *historianOutput) probeWritable(ctx context.Context) error {
 	return nil
 }
 
-// readAppliedPolicies reads the intervals applied to this contract, in seconds. A nil interval means
-// no such policy is scheduled; a failed read is an error. It reads the value table only, which holds
-// because bootstrap has just put back whatever either table was missing.
-func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int64, error) {
-	table := "value_" + o.contract
+// readAppliedPolicies reads the intervals applied to one hypertable, in seconds. A nil interval
+// means no such policy is scheduled; a failed read is an error.
+func (o *historianOutput) readAppliedPolicies(ctx context.Context, hypertableName string) (*int64, *int64, error) {
 	var appliedComp, appliedRet *int64
-	if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_compression", "compress_after"), table).Scan(&appliedComp); err != nil {
+	if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_compression", "compress_after"), hypertableName).Scan(&appliedComp); err != nil {
 		return nil, nil, err
 	}
-	if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&appliedRet); err != nil {
+	if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), hypertableName).Scan(&appliedRet); err != nil {
 		return nil, nil, err
 	}
 	return appliedComp, appliedRet, nil
@@ -437,18 +435,20 @@ func (o *historianOutput) warnRetentionAboutToDrop(ctx context.Context) {
 // only from the bootstrap branch, so drift an operator introduces while the output is running is
 // not reported until it next starts. Best-effort: a failed read is logged and never fails Connect.
 func (o *historianOutput) warnPolicyDrift(ctx context.Context) {
-	appliedComp, appliedRet, err := o.readAppliedPolicies(ctx)
-	if err != nil {
-		o.logger.Warnf("historian: cannot read the policies applied to umh.value_%s, so cannot report drift: %v", o.contract, err)
-		return
-	}
 	var retentionWant *int64
 	if o.retentionSet {
 		v := int64(o.retention.Seconds())
 		retentionWant = &v
 	}
-	for _, w := range policyDriftWarnings(int64(o.compressAfter.Seconds()), appliedComp, retentionWant, appliedRet) {
-		o.logger.Warnf("historian: %s. The applied value stays in force.", w)
+	for _, table := range []string{"value_" + o.contract, "attribute_" + o.contract} {
+		appliedComp, appliedRet, err := o.readAppliedPolicies(ctx, table)
+		if err != nil {
+			o.logger.Warnf("historian: cannot read the policies applied to umh.%s, so cannot report drift: %v", table, err)
+			continue
+		}
+		for _, w := range policyDriftWarnings(int64(o.compressAfter.Seconds()), appliedComp, retentionWant, appliedRet) {
+			o.logger.Warnf("historian: umh.%s: %s. The applied value stays in force.", table, w)
+		}
 	}
 }
 

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -27,6 +27,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
@@ -305,6 +306,12 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 			return fmt.Errorf("invalid connection settings: %s", o.redact(err)) // DSN echoes the password
 		}
 		cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec // simple protocol (pgbouncer txn pool)
+		// pgx drops server notices unless this is set, and the bootstrap needs them: add_*_policy with
+		// if_not_exists => TRUE reports a policy it declined to change as a notice and returns -1, so
+		// without this the decline reaches no log.
+		cfg.ConnConfig.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
+			o.logger.Warnf("TimescaleDB historian: %s: %s", n.Severity, n.Message)
+		}
 		// Each in-flight batch holds a pooled connection for its write tx, so a pool smaller than
 		// max_in_flight silently caps concurrency. pgxpool defaults to max(4, NumCPU), below the
 		// default 8; size it to max_in_flight+1 (+1 for Connect-time checks). A larger DSN
@@ -402,7 +409,9 @@ func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int
 // holds chunks. The gate cannot tell a policy an operator removed from one that never existed, so
 // the removal is undone and TimescaleDB resumes dropping chunks. Runs before the bootstrap DDL,
 // because afterwards the applied policy matches config and warnPolicyDrift has nothing to report.
-// Best-effort: introspection errors are swallowed so an unexpected catalog shape never fails Connect.
+// A failed lookup is logged rather than swallowed: this is the only signal standing between a
+// deliberate removal and chunks being dropped, so its own failure has to be visible, and it must not
+// fail Connect.
 func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 	if !o.retentionSet {
 		return
@@ -410,19 +419,21 @@ func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 	for _, table := range []string{"value_" + o.contract, "attribute_" + o.contract} {
 		var chunks int
 		if err := o.pool.QueryRow(ctx, hypertableChunkCountSQL, table).Scan(&chunks); err != nil {
-			return
+			o.logger.Warnf("TimescaleDB historian: could not read the chunk count of umh.%s (%v), so this start cannot say whether applying the configured retention (%s) will drop existing chunks. Check the retention policy on umh.%s before the retention job next runs.", table, err, o.retention, table)
+			continue
 		}
 		if chunks == 0 {
 			continue
 		}
 		var applied *int64
 		if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&applied); err != nil {
-			return
+			o.logger.Warnf("TimescaleDB historian: could not read the retention policy of umh.%s (%v), so this start cannot say whether it is about to apply the configured retention (%s) to a table that already holds data.", table, err, o.retention)
+			continue
 		}
 		if applied != nil {
 			continue
 		}
-		o.logger.Warnf("TimescaleDB historian: umh.%s already holds data and has no retention policy, so this start applies the configured retention (%s) and TimescaleDB will drop chunks older than that. Clear retention in this output's config to keep the policy removed.", table, o.retention)
+		o.logger.Warnf("TimescaleDB historian: umh.%s already holds data and had no retention policy, so this start has scheduled the configured retention (%s) and TimescaleDB will drop chunks older than that when the retention job next runs. To keep the data, run SELECT remove_retention_policy('umh.%s') before then, and clear retention in this output's config so the next start does not schedule it again.", table, o.retention, table)
 	}
 }
 
@@ -433,6 +444,7 @@ func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 func (o *historianOutput) warnPolicyDrift(ctx context.Context) {
 	appliedComp, appliedRet, err := o.readAppliedPolicies(ctx)
 	if err != nil {
+		o.logger.Warnf("TimescaleDB historian: could not read the compression/retention policies applied to umh.value_%s (%v), so this start cannot report whether they match this output's config. Read them with SELECT proc_name, config FROM timescaledb_information.jobs WHERE hypertable_name = 'value_%s'.", o.contract, err, o.contract)
 		return
 	}
 	var retentionWant *int64

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -353,11 +353,11 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 			return err
 		}
 		defer conn.Release()
-		o.warnRetentionAboutToDrop(bootCtx)
 		if _, err := conn.Exec(bootCtx, o.renderBootstrapDDL()); err != nil {
 			return fmt.Errorf("schema bootstrap failed: %w", err) // guard stays false -> next Connect retries
 		}
-		o.warnPolicyDrift(bootCtx)
+		retentionNotApplied := o.warnRetentionNotApplied(bootCtx)
+		o.warnPolicyDrift(bootCtx, retentionNotApplied)
 		o.warnChunkDrift(bootCtx)
 		o.bootstrapped = true
 	}
@@ -403,17 +403,18 @@ func (o *historianOutput) readAppliedPolicies(ctx context.Context, hypertableNam
 	return appliedComp, appliedRet, nil
 }
 
-// warnRetentionAboutToDrop runs before the bootstrap DDL: afterwards the applied policy matches
-// config and warnPolicyDrift has nothing left to report. Its own lookup failures are logged, since
-// this is the only signal before chunks start being dropped.
-func (o *historianOutput) warnRetentionAboutToDrop(ctx context.Context) {
+// warnRetentionNotApplied names the hypertables the bootstrap left without the configured retention
+// policy because they already hold chunks. It returns them so warnPolicyDrift does not report the
+// same absence a second time as drift.
+func (o *historianOutput) warnRetentionNotApplied(ctx context.Context) map[string]struct{} {
+	notApplied := map[string]struct{}{}
 	if !o.retentionSet {
-		return
+		return notApplied
 	}
 	for _, table := range []string{"value_" + o.contract, "attribute_" + o.contract} {
 		var chunks int
 		if err := o.pool.QueryRow(ctx, hypertableChunkCountSQL, table).Scan(&chunks); err != nil {
-			o.logger.Warnf("historian: cannot read the chunk count of umh.%s, so cannot say whether retention (%s) drops existing chunks: %v", table, o.retention, err)
+			o.logger.Warnf("historian: cannot read the chunk count of umh.%s, so cannot say whether retention (%s) was applied to it: %v", table, o.retention, err)
 			continue
 		}
 		if chunks == 0 {
@@ -427,14 +428,16 @@ func (o *historianOutput) warnRetentionAboutToDrop(ctx context.Context) {
 		if applied != nil {
 			continue
 		}
-		o.logger.Warnf("historian: retention (%s) is now scheduled on umh.%s, which already holds data, so older chunks will be dropped. To keep them, run remove_retention_policy('umh.%s') and clear retention in the config.", o.retention, table, table)
+		notApplied[table] = struct{}{}
+		o.logger.Warnf("historian: umh.%s already holds data, so the configured retention (%s) was not applied to it. Applying it drops every chunk older than that. To apply it, run add_retention_policy('umh.%s', %s); to stop this warning, clear retention in the config.", table, o.retention, table, intervalSQL(o.retention))
 	}
+	return notApplied
 }
 
 // warnPolicyDrift warns when the applied compression/retention policy differs from config. Called
 // only from the bootstrap branch, so drift an operator introduces while the output is running is
 // not reported until it next starts. Best-effort: a failed read is logged and never fails Connect.
-func (o *historianOutput) warnPolicyDrift(ctx context.Context) {
+func (o *historianOutput) warnPolicyDrift(ctx context.Context, retentionNotApplied map[string]struct{}) {
 	var retentionWant *int64
 	if o.retentionSet {
 		v := int64(o.retention.Seconds())
@@ -446,7 +449,11 @@ func (o *historianOutput) warnPolicyDrift(ctx context.Context) {
 			o.logger.Warnf("historian: cannot read the policies applied to umh.%s, so cannot report drift: %v", table, err)
 			continue
 		}
-		for _, w := range policyDriftWarnings(int64(o.compressAfter.Seconds()), appliedComp, retentionWant, appliedRet) {
+		want := retentionWant
+		if _, reported := retentionNotApplied[table]; reported {
+			want = nil
+		}
+		for _, w := range policyDriftWarnings(int64(o.compressAfter.Seconds()), appliedComp, want, appliedRet) {
 			o.logger.Warnf("historian: umh.%s: %s. The applied value stays in force.", table, w)
 		}
 	}

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -380,8 +380,8 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 // only as an endless WriteBatch NACK and the output stalls instead of failing visibly.
 // Read-only catalog lookup, so it is safe on every Connect and under concurrency.
 func (o *historianOutput) probeWritable(ctx context.Context) error {
-	valueTbl := "umh.value_" + o.contract
-	attrTbl := "umh.attribute_" + o.contract
+	valueTbl := "umh." + o.valueTable()
+	attrTbl := "umh." + o.attributeTable()
 	var ok bool
 	if err := o.pool.QueryRow(ctx,
 		"SELECT has_table_privilege($1, 'INSERT') AND has_table_privilege($2, 'INSERT')",
@@ -407,6 +407,17 @@ func (o *historianOutput) readAppliedPolicies(ctx context.Context, hypertableNam
 	return appliedComp, appliedRet, nil
 }
 
+// valueTable, attributeTable and hypertables name the two tables this output's contract owns. The
+// bootstrap DDL builds the same names from CONTRACT_SLOT, so a change to either side has to be made
+// on both.
+func (o *historianOutput) valueTable() string     { return "value_" + o.contract }
+func (o *historianOutput) attributeTable() string { return "attribute_" + o.contract }
+
+// hypertables lists them in the order every per-table check walks them.
+func (o *historianOutput) hypertables() []string {
+	return []string{o.valueTable(), o.attributeTable()}
+}
+
 // warnRetentionNotApplied names the hypertables the bootstrap left without the configured retention
 // policy because they already hold chunks. It returns them so warnPolicyDrift does not report the
 // same absence a second time as drift.
@@ -415,18 +426,14 @@ func (o *historianOutput) warnRetentionNotApplied(ctx context.Context) map[strin
 	if !o.retentionSet {
 		return notApplied
 	}
-	for _, table := range []string{"value_" + o.contract, "attribute_" + o.contract} {
+	for _, table := range o.hypertables() {
 		var chunks int
-		if err := o.pool.QueryRow(ctx, hypertableChunkCountSQL, table).Scan(&chunks); err != nil {
-			o.logger.Warnf("historian: cannot read the chunk count of umh.%s, so cannot say whether retention (%s) was applied to it: %v", table, o.retention, err)
+		var applied *int64
+		if err := o.pool.QueryRow(ctx, retentionSkipSQL(), table).Scan(&chunks, &applied); err != nil {
+			o.logger.Warnf("historian: cannot read the chunk count and retention policy of umh.%s, so cannot say whether retention (%s) was applied to it: %v", table, o.retention, err)
 			continue
 		}
 		if chunks == 0 {
-			continue
-		}
-		var applied *int64
-		if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&applied); err != nil {
-			o.logger.Warnf("historian: cannot read the retention policy of umh.%s: %v", table, err)
 			continue
 		}
 		if applied != nil {
@@ -447,7 +454,7 @@ func (o *historianOutput) warnPolicyDrift(ctx context.Context, retentionNotAppli
 		v := int64(o.retention.Seconds())
 		retentionWant = &v
 	}
-	for _, table := range []string{"value_" + o.contract, "attribute_" + o.contract} {
+	for _, table := range o.hypertables() {
 		appliedComp, appliedRet, err := o.readAppliedPolicies(ctx, table)
 		if err != nil {
 			o.logger.Warnf("historian: cannot read the policies applied to umh.%s, so cannot report drift: %v", table, err)
@@ -489,8 +496,8 @@ func (o *historianOutput) readChunkIntervalOrWarn(ctx context.Context, table str
 // warnChunkDrift warns when a table's chunk interval differs from config. create_hypertable is a
 // no-op once the table exists, so editing an interval and restarting otherwise has no visible effect.
 func (o *historianOutput) warnChunkDrift(ctx context.Context) {
-	appliedValue := o.readChunkIntervalOrWarn(ctx, "value_"+o.contract)
-	appliedAttribute := o.readChunkIntervalOrWarn(ctx, "attribute_"+o.contract)
+	appliedValue := o.readChunkIntervalOrWarn(ctx, o.valueTable())
+	appliedAttribute := o.readChunkIntervalOrWarn(ctx, o.attributeTable())
 	for _, w := range chunkDriftWarnings(int64(o.valueChunk.Seconds()), appliedValue, int64(o.attributeChunk.Seconds()), appliedAttribute) {
 		o.logger.Warnf("historian: %s. The applied width stays in force, and existing chunks keep theirs.", w)
 	}

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -392,10 +392,10 @@ func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int
 	return appliedComp, appliedRet, nil
 }
 
-// warnPolicyDrift warns when the applied compression/retention policy differs from config. Policies
-// are set once at first bootstrap, so editing compress_after/retention and restarting otherwise has
-// no visible effect. Best-effort: introspection errors are swallowed so an unexpected catalog shape
-// never fails Connect.
+// warnPolicyDrift warns when the applied compression/retention policy differs from config. An
+// interval already applied is never changed by bootstrap, so editing compress_after/retention and
+// restarting otherwise has no visible effect. Best-effort: introspection errors are swallowed so an
+// unexpected catalog shape never fails Connect.
 func (o *historianOutput) warnPolicyDrift(ctx context.Context) {
 	appliedComp, appliedRet, err := o.readAppliedPolicies(ctx)
 	if err != nil {

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -340,6 +340,7 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 			return err
 		}
 		defer conn.Release()
+		o.warnRetentionRecreate(bootCtx)
 		if _, err := conn.Exec(bootCtx, o.renderBootstrapDDL()); err != nil {
 			return fmt.Errorf("schema bootstrap failed: %w", err) // guard stays false -> next Connect retries
 		}
@@ -390,6 +391,34 @@ func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int
 	}
 	_ = o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&appliedRet)
 	return appliedComp, appliedRet, nil
+}
+
+// warnRetentionRecreate warns before bootstrap adds a retention policy to a hypertable that already
+// holds chunks. The gate cannot tell a policy an operator removed from one that never existed, so
+// the removal is undone and TimescaleDB resumes dropping chunks. Runs before the bootstrap DDL,
+// because afterwards the applied policy matches config and warnPolicyDrift has nothing to report.
+// Best-effort: introspection errors are swallowed so an unexpected catalog shape never fails Connect.
+func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
+	if !o.retentionSet {
+		return
+	}
+	for _, table := range []string{"value_" + o.contract, "attribute_" + o.contract} {
+		var chunks int
+		if err := o.pool.QueryRow(ctx, hypertableChunkCountSQL, table).Scan(&chunks); err != nil {
+			return
+		}
+		if chunks == 0 {
+			continue
+		}
+		var applied *int64
+		if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&applied); err != nil {
+			return
+		}
+		if applied != nil {
+			continue
+		}
+		o.logger.Warnf("TimescaleDB historian: umh.%s already holds data and has no retention policy, so this start applies the configured retention (%s) and TimescaleDB will drop chunks older than that. Clear retention in this output's config to keep the policy removed.", table, o.retention)
+	}
 }
 
 // warnPolicyDrift warns when the applied compression/retention policy differs from config. An

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -378,18 +378,23 @@ func (o *historianOutput) probeWritable(ctx context.Context) error {
 }
 
 // readAppliedPolicies reads the compression/retention intervals (in seconds) TimescaleDB currently
-// has applied for this contract, as nil-able pointers (nil = no such policy scheduled). Both
-// hypertables get identical policies, so the value table is representative. It returns an error only
-// if the compression lookup itself fails (an unexpected catalog shape); the retention lookup is
-// best-effort. This is the I/O read half of warnPolicyDrift, split out so the drift check reads as
-// read -> compare (pure policyDriftWarnings) -> log.
+// has applied for this contract, as nil-able pointers (nil = no such policy scheduled). It reads the
+// value table only, which is safe here because bootstrap has just run in the same branch and put
+// back whatever was missing on either table; a policy that differs on umh.attribute_<contract> alone
+// is not reported. A failed lookup is an error rather than a nil interval: nil means "no policy is
+// scheduled", and warnPolicyDrift turns that into "your configured retention is not applied", which
+// is a false statement to make because the read failed. This is the I/O read half of
+// warnPolicyDrift, split out so the drift check reads as read -> compare (pure
+// policyDriftWarnings) -> log.
 func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int64, error) {
 	table := "value_" + o.contract
 	var appliedComp, appliedRet *int64
 	if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_compression", "compress_after"), table).Scan(&appliedComp); err != nil {
 		return nil, nil, err
 	}
-	_ = o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&appliedRet)
+	if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&appliedRet); err != nil {
+		return nil, nil, err
+	}
 	return appliedComp, appliedRet, nil
 }
 

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -384,15 +384,10 @@ func (o *historianOutput) probeWritable(ctx context.Context) error {
 	return nil
 }
 
-// readAppliedPolicies reads the compression/retention intervals (in seconds) TimescaleDB currently
-// has applied for this contract, as nil-able pointers (nil = no such policy scheduled). It reads the
-// value table only, which is safe here because bootstrap has just run in the same branch and put
-// back whatever was missing on either table; a policy that differs on umh.attribute_<contract> alone
-// is not reported. A failed lookup is an error rather than a nil interval: nil means "no policy is
-// scheduled", and warnPolicyDrift turns that into "your configured retention is not applied", which
-// is a false statement to make because the read failed. This is the I/O read half of
-// warnPolicyDrift, split out so the drift check reads as read -> compare (pure
-// policyDriftWarnings) -> log.
+// readAppliedPolicies reads the intervals applied to this contract, in seconds; nil means no such
+// policy is scheduled, and a failed read is an error, because warnPolicyDrift would otherwise report
+// a missing policy that it never managed to look for. It reads the value table only, which holds
+// because bootstrap has just put back whatever either table was missing.
 func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int64, error) {
 	table := "value_" + o.contract
 	var appliedComp, appliedRet *int64
@@ -405,13 +400,9 @@ func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int
 	return appliedComp, appliedRet, nil
 }
 
-// warnRetentionRecreate warns before bootstrap adds a retention policy to a hypertable that already
-// holds chunks. The gate cannot tell a policy an operator removed from one that never existed, so
-// the removal is undone and TimescaleDB resumes dropping chunks. Runs before the bootstrap DDL,
-// because afterwards the applied policy matches config and warnPolicyDrift has nothing to report.
-// A failed lookup is logged rather than swallowed: this is the only signal standing between a
-// deliberate removal and chunks being dropped, so its own failure has to be visible, and it must not
-// fail Connect.
+// warnRetentionRecreate runs before the bootstrap DDL, because afterwards the applied policy matches
+// config and warnPolicyDrift has nothing left to report. A failed lookup is logged, not swallowed:
+// this is the only signal before chunks start being dropped.
 func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 	if !o.retentionSet {
 		return
@@ -419,7 +410,7 @@ func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 	for _, table := range []string{"value_" + o.contract, "attribute_" + o.contract} {
 		var chunks int
 		if err := o.pool.QueryRow(ctx, hypertableChunkCountSQL, table).Scan(&chunks); err != nil {
-			o.logger.Warnf("TimescaleDB historian: could not read the chunk count of umh.%s (%v), so this start cannot say whether applying the configured retention (%s) will drop existing chunks. Check the retention policy on umh.%s before the retention job next runs.", table, err, o.retention, table)
+			o.logger.Warnf("historian: cannot read the chunk count of umh.%s, so cannot say whether retention (%s) will drop existing chunks: %v", table, o.retention, err)
 			continue
 		}
 		if chunks == 0 {
@@ -427,13 +418,13 @@ func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 		}
 		var applied *int64
 		if err := o.pool.QueryRow(ctx, policyIntervalSQL("policy_retention", "drop_after"), table).Scan(&applied); err != nil {
-			o.logger.Warnf("TimescaleDB historian: could not read the retention policy of umh.%s (%v), so this start cannot say whether it is about to apply the configured retention (%s) to a table that already holds data.", table, err, o.retention)
+			o.logger.Warnf("historian: cannot read the retention policy of umh.%s: %v", table, err)
 			continue
 		}
 		if applied != nil {
 			continue
 		}
-		o.logger.Warnf("TimescaleDB historian: umh.%s already holds data and had no retention policy, so this start has scheduled the configured retention (%s) and TimescaleDB will drop chunks older than that when the retention job next runs. To keep the data, run SELECT remove_retention_policy('umh.%s') before then, and clear retention in this output's config so the next start does not schedule it again.", table, o.retention, table)
+		o.logger.Warnf("historian: umh.%s holds data and had no retention policy, so retention (%s) is now scheduled and older chunks will be dropped. To keep them, run remove_retention_policy('umh.%s') and clear retention here.", table, o.retention, table)
 	}
 }
 
@@ -443,7 +434,7 @@ func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 func (o *historianOutput) warnPolicyDrift(ctx context.Context) {
 	appliedComp, appliedRet, err := o.readAppliedPolicies(ctx)
 	if err != nil {
-		o.logger.Warnf("TimescaleDB historian: could not read the compression/retention policies applied to umh.value_%s (%v), so this start cannot report whether they match this output's config. Read them with SELECT proc_name, config FROM timescaledb_information.jobs WHERE hypertable_name = 'value_%s'.", o.contract, err, o.contract)
+		o.logger.Warnf("historian: cannot read the policies applied to umh.value_%s, so cannot report drift: %v", o.contract, err)
 		return
 	}
 	var retentionWant *int64

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -437,10 +437,9 @@ func (o *historianOutput) warnRetentionRecreate(ctx context.Context) {
 	}
 }
 
-// warnPolicyDrift warns when the applied compression/retention policy differs from config. An
-// interval already applied is never changed by bootstrap, so editing compress_after/retention and
-// restarting otherwise has no visible effect. Best-effort: introspection errors are swallowed so an
-// unexpected catalog shape never fails Connect.
+// warnPolicyDrift warns when the applied compression/retention policy differs from config. Called
+// only from the bootstrap branch, so drift an operator introduces while the output is running is
+// not reported until it next starts. Best-effort: a failed read is logged and never fails Connect.
 func (o *historianOutput) warnPolicyDrift(ctx context.Context) {
 	appliedComp, appliedRet, err := o.readAppliedPolicies(ctx)
 	if err != nil {

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -390,9 +390,8 @@ func (o *historianOutput) probeWritable(ctx context.Context) error {
 	return nil
 }
 
-// readAppliedPolicies reads the intervals applied to this contract, in seconds; nil means no such
-// policy is scheduled, and a failed read is an error, because warnPolicyDrift would otherwise report
-// a missing policy that it never managed to look for. It reads the value table only, which holds
+// readAppliedPolicies reads the intervals applied to this contract, in seconds. A nil interval means
+// no such policy is scheduled; a failed read is an error. It reads the value table only, which holds
 // because bootstrap has just put back whatever either table was missing.
 func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int64, error) {
 	table := "value_" + o.contract
@@ -406,8 +405,8 @@ func (o *historianOutput) readAppliedPolicies(ctx context.Context) (*int64, *int
 	return appliedComp, appliedRet, nil
 }
 
-// warnRetentionAboutToDrop runs before the bootstrap DDL, because afterwards the applied policy matches
-// config and warnPolicyDrift has nothing left to report. A failed lookup is logged, not swallowed:
+// warnRetentionAboutToDrop runs before the bootstrap DDL: afterwards the applied policy matches
+// config and warnPolicyDrift has nothing left to report. Its own lookup failures are logged, since
 // this is the only signal before chunks start being dropped.
 func (o *historianOutput) warnRetentionAboutToDrop(ctx context.Context) {
 	if !o.retentionSet {

--- a/historian_plugin/output_historian.go
+++ b/historian_plugin/output_historian.go
@@ -307,16 +307,20 @@ func (o *historianOutput) Connect(ctx context.Context) error {
 		}
 		cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeExec // simple protocol (pgbouncer txn pool)
 		// pgx drops server notices unless this is set, and the bootstrap needs them: add_*_policy with
-		// if_not_exists => TRUE reports a policy it declined to change as a notice and returns -1, so
-		// without this the decline reaches no log.
+		// if_not_exists => TRUE reports a policy it declined to change as a WARNING notice and returns
+		// -1, so without this the decline reaches no log.
+		// SeverityUnlocalized is the protocol's V field, which is never translated. Severity carries
+		// the server's lc_messages translation, so it cannot be compared against an English literal.
+		// https://www.postgresql.org/docs/current/protocol-error-fields.html
 		cfg.ConnConfig.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
-			// WARNING is what add_*_policy raises when if_not_exists makes it decline; NOTICE is
-			// routine bootstrap chatter ("trigger ... does not exist, skipping") on every start.
-			if n.Severity == "WARNING" {
-				o.logger.Warnf("historian: %s", n.Message)
-				return
+			switch n.SeverityUnlocalized {
+			case "PANIC", "FATAL", "ERROR":
+				o.logger.Errorf("historian: %s: %s", n.SeverityUnlocalized, n.Message)
+			case "WARNING":
+				o.logger.Warnf("historian: %s: %s", n.SeverityUnlocalized, n.Message)
+			default:
+				o.logger.Debugf("historian: %s: %s", n.SeverityUnlocalized, n.Message)
 			}
-			o.logger.Debugf("historian: %s: %s", n.Severity, n.Message)
 		}
 		// Each in-flight batch holds a pooled connection for its write tx, so a pool smaller than
 		// max_in_flight silently caps concurrency. pgxpool defaults to max(4, NumCPU), below the

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -347,6 +347,38 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(*compressAfter).To(Equal(int64(3600)))
 	})
 
+	It("names both tables when the applied policies cannot be read", func() {
+		h := connected("polunread")
+		defer h.Close(ctx)
+
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+
+		logs := h.CaptureLogs()
+		h.WarnPolicyDrift(cancelled)
+
+		Expect(logs()).To(ContainSubstring("cannot read the policies applied to umh.value_polunread"))
+		Expect(logs()).To(ContainSubstring("cannot read the policies applied to umh.attribute_polunread"))
+		Expect(logs()).NotTo(ContainSubstring("stays in force"))
+	})
+
+	It("names both tables when the retention pre-check cannot read the chunk count", func() {
+		h := tsh.NewHistorianTestHandle(sharedDSN, "retunread")
+		h.SetPolicies(168*time.Hour, 24*time.Hour, true)
+		Expect(h.Connect(ctx)).To(Succeed())
+		defer h.Close(ctx)
+
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+
+		logs := h.CaptureLogs()
+		h.WarnRetentionAboutToDrop(cancelled)
+
+		Expect(logs()).To(ContainSubstring("cannot read the chunk count of umh.value_retunread"))
+		Expect(logs()).To(ContainSubstring("cannot read the chunk count of umh.attribute_retunread"))
+		Expect(logs()).NotTo(ContainSubstring("older chunks will be dropped"))
+	})
+
 	It("does not advance the topic sequence when re-resolving an existing topic", func() {
 		h := connected("noburn")
 		defer h.Close(ctx)

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -214,8 +214,8 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		first := tsh.NewHistorianTestHandle(sharedDSN, "polfirst")
 		first.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(first.Connect(ctx)).To(Succeed())
-		defer first.Close(ctx)
 		Expect(first.SchemaVersion(ctx)).To(Equal(1))
+		first.Close(ctx)
 
 		second := tsh.NewHistorianTestHandle(sharedDSN, "polsecond")
 		second.SetPolicies(168*time.Hour, 720*time.Hour, true)
@@ -237,9 +237,10 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polattr")
 		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
-		defer h.Close(ctx)
 		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.attribute_polattr')")).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT add_retention_policy('umh.attribute_polattr', INTERVAL '90 days')")).To(Succeed())
+
+		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polattr")
 		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
@@ -255,7 +256,6 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "pollegacy")
 		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
-		defer h.Close(ctx)
 		Expect(h.WriteBatch(ctx, service.MessageBatch{
 			mkMsg(1.0, float64(time.Now().UnixMilli()), "_pollegacy_v1", "acme.line1", "x", nil),
 		})).To(Succeed())
@@ -264,6 +264,8 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 			Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('"+table+"')")).To(Succeed())
 			Expect(h.ExecSQL(ctx, "ALTER TABLE "+table+" SET (timescaledb.compress = false)")).To(Succeed())
 		}
+
+		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "pollegacy")
 		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
@@ -295,12 +297,13 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
 		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
-		defer h.Close(ctx)
 		Expect(h.WriteBatch(ctx, service.MessageBatch{
 			mkMsg(1.0, float64(time.Now().UnixMilli()), "_polwarn_v1", "acme.line1", "x", map[string]string{"serialNumber": "sn-1"}),
 		})).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.value_polwarn')")).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.attribute_polwarn')")).To(Succeed())
+
+		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
 		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
@@ -321,9 +324,10 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
 		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
-		defer h.Close(ctx)
 		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.value_polkeep')")).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT add_retention_policy('umh.value_polkeep', INTERVAL '90 days')")).To(Succeed())
+
+		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
 		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
@@ -341,12 +345,13 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polchunk")
 		h.SetPolicies(time.Hour, 0, false)
 		Expect(h.Connect(ctx)).To(Succeed())
-		defer h.Close(ctx)
 		Expect(h.WriteBatch(ctx, service.MessageBatch{
 			mkMsg(1.0, 1000, "_polchunk_v1", "acme.line1", "x", nil),
 		})).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT compress_chunk(c, if_not_compressed => true) FROM show_chunks('umh.value_polchunk') c")).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT remove_compression_policy('umh.value_polchunk')")).To(Succeed())
+
+		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polchunk")
 		restarted.SetPolicies(time.Hour, 0, false)

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -182,10 +182,10 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 	It("a fresh handle connects to an already-bootstrapped database and reads/writes (restart path)", func() {
 		// First handle bootstraps the schema and writes one point.
 		h1 := connected("recon")
-		defer h1.Close(ctx)
 		Expect(h1.WriteBatch(ctx, service.MessageBatch{
 			mkMsg(1.0, 1000, "_recon_v1", "acme.line1", "x", nil),
 		})).To(Succeed())
+		h1.Close(ctx)
 
 		h2 := tsh.NewHistorianTestHandle(sharedDSN, "recon")
 		Expect(h2.Connect(ctx)).To(Succeed())
@@ -474,12 +474,12 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 	It("re-warms after restart (fresh handle) without bumping the sequence", func() {
 		h1 := connected("restart2")
-		defer h1.Close(ctx)
 		Expect(h1.WriteBatch(ctx, service.MessageBatch{
 			mkMsg(1.0, 1000, "_restart2_v1", "acme.line1", "a", nil),
 			mkMsg(2.0, 1000, "_restart2_v1", "acme.line1", "b", nil),
 		})).To(Succeed())
 		seq := h1.TopicSeqValue(ctx)
+		h1.Close(ctx)
 
 		// A fresh handle == the restart path (no in-process state). Writing the SAME, existing
 		// topics resolves them via lookup with no sequence bump.

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -292,11 +292,13 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
 		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 		_, retention := restarted.PolicyIntervals(ctx, "value_polkeep")
 		Expect(retention).NotTo(BeNil())
 		Expect(*retention).To(Equal(int64(90 * 24 * 3600)))
+		Expect(logs()).To(ContainSubstring("does not match the retention policy applied in the database"))
 	})
 
 	It("re-adds a removed compression policy on a hypertable that already has compressed chunks", func() {

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -391,6 +391,17 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(logs()).NotTo(ContainSubstring("was not applied to it"))
 	})
 
+	It("logs a server warning at warning level and a routine notice at debug", func() {
+		h := connected("noticesev")
+		defer h.Close(ctx)
+
+		logs := h.CaptureLogs()
+		Expect(h.ExecSQL(ctx, "DO $$ BEGIN RAISE WARNING 'declined something'; RAISE NOTICE 'skipping something'; END $$;")).To(Succeed())
+
+		Expect(logs()).To(ContainSubstring("level=warning msg=historian: WARNING: declined something"))
+		Expect(logs()).To(ContainSubstring("level=debug msg=historian: NOTICE: skipping something"))
+	})
+
 	It("does not advance the topic sequence when re-resolving an existing topic", func() {
 		h := connected("noburn")
 		defer h.Close(ctx)

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -222,7 +222,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		logs := second.CaptureLogs()
 		Expect(second.Connect(ctx)).To(Succeed())
 		defer second.Close(ctx)
-		Expect(logs()).NotTo(ContainSubstring("already holds data"))
+		Expect(logs()).NotTo(ContainSubstring("had no retention policy"))
 
 		for _, table := range []string{"value_polsecond", "attribute_polsecond"} {
 			compressAfter, retention := second.PolicyIntervals(ctx, table)
@@ -279,8 +279,8 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 
-		Expect(logs()).To(ContainSubstring("umh.value_polwarn already holds data and had no retention policy"))
-		Expect(logs()).To(ContainSubstring("umh.attribute_polwarn already holds data and had no retention policy"))
+		Expect(logs()).To(ContainSubstring("umh.value_polwarn holds data and had no retention policy"))
+		Expect(logs()).To(ContainSubstring("umh.attribute_polwarn holds data and had no retention policy"))
 		Expect(logs()).To(ContainSubstring("remove_retention_policy('umh.value_polwarn')"))
 		_, retention := restarted.PolicyIntervals(ctx, "value_polwarn")
 		Expect(retention).NotTo(BeNil())
@@ -322,7 +322,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
-		Expect(logs()).NotTo(ContainSubstring("already holds data"))
+		Expect(logs()).NotTo(ContainSubstring("had no retention policy"))
 		compressAfter, _ := restarted.PolicyIntervals(ctx, "value_polchunk")
 		Expect(compressAfter).NotTo(BeNil())
 		Expect(*compressAfter).To(Equal(int64(3600)))

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -162,8 +162,8 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 
-		Expect(logs()).To(ContainSubstring(fmt.Sprintf("configured compress_after (%ds)", seconds(handleDefaultCompress))))
-		Expect(logs()).To(ContainSubstring(fmt.Sprintf("applied in the database (%ds)", seconds(appliedCompress))))
+		Expect(logs()).To(ContainSubstring(fmt.Sprintf("umh.value_poldrift: configured compress_after (%ds)", seconds(handleDefaultCompress))))
+		Expect(logs()).To(ContainSubstring(fmt.Sprintf("applied compression policy (%ds)", seconds(appliedCompress))))
 		Expect(logs()).To(ContainSubstring("stays in force"))
 	})
 
@@ -231,6 +231,24 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 			Expect(retention).NotTo(BeNil(), table)
 			Expect(*retention).To(Equal(int64(720*3600)), table)
 		}
+	})
+
+	It("reports drift on the attribute hypertable alone", func() {
+		h := tsh.NewHistorianTestHandle(sharedDSN, "polattr")
+		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		Expect(h.Connect(ctx)).To(Succeed())
+		defer h.Close(ctx)
+		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.attribute_polattr')")).To(Succeed())
+		Expect(h.ExecSQL(ctx, "SELECT add_retention_policy('umh.attribute_polattr', INTERVAL '90 days')")).To(Succeed())
+
+		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polattr")
+		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		logs := restarted.CaptureLogs()
+		Expect(restarted.Connect(ctx)).To(Succeed())
+		defer restarted.Close(ctx)
+
+		Expect(logs()).To(ContainSubstring("umh.attribute_polattr: configured retention (2592000s) does not match the applied retention policy (7776000s)"))
+		Expect(logs()).NotTo(ContainSubstring("umh.value_polattr: configured retention"))
 	})
 
 	It("gives a contract left without policies by an older build both of them on the next start", func() {
@@ -303,7 +321,8 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		_, retention := restarted.PolicyIntervals(ctx, "value_polkeep")
 		Expect(retention).NotTo(BeNil())
 		Expect(*retention).To(Equal(int64(90 * 24 * 3600)))
-		Expect(logs()).To(ContainSubstring("does not match the retention policy applied in the database"))
+		Expect(logs()).To(ContainSubstring("umh.value_polkeep: configured retention (2592000s) does not match the applied retention policy (7776000s)"))
+		Expect(logs()).NotTo(ContainSubstring("umh.attribute_polkeep: configured retention"))
 	})
 
 	It("re-adds a removed compression policy on a hypertable that already has compressed chunks", func() {

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -231,6 +231,28 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		}
 	})
 
+	It("warns and re-creates a retention policy removed on a hypertable that holds data", func() {
+		h := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
+		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		Expect(h.Connect(ctx)).To(Succeed())
+		defer h.Close(ctx)
+		Expect(h.WriteBatch(ctx, service.MessageBatch{
+			mkMsg(1.0, 1000, "_polwarn_v1", "acme.line1", "x", nil),
+		})).To(Succeed())
+		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.value_polwarn')")).To(Succeed())
+
+		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
+		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		logs := restarted.CaptureLogs()
+		Expect(restarted.Connect(ctx)).To(Succeed())
+		defer restarted.Close(ctx)
+
+		Expect(logs()).To(ContainSubstring("umh.value_polwarn already holds data and has no retention policy"))
+		_, retention := restarted.PolicyIntervals(ctx, "value_polwarn")
+		Expect(retention).NotTo(BeNil())
+		Expect(*retention).To(Equal(int64(720 * 3600)))
+	})
+
 	It("keeps an operator's own retention interval across a restart", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
 		h.SetPolicies(168*time.Hour, 720*time.Hour, true)

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -213,6 +213,64 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(h.SchemaVersion(ctx)).To(Equal(1))
 	})
 
+	It("applies compression and retention to a contract added after the database was bootstrapped", func() {
+		first := tsh.NewHistorianTestHandle(sharedDSN, "polfirst")
+		first.SetPolicies(168*time.Hour, 720*time.Hour)
+		Expect(first.Connect(ctx)).To(Succeed())
+		defer first.Close(ctx)
+		Expect(first.SchemaVersion(ctx)).To(Equal(1))
+
+		second := tsh.NewHistorianTestHandle(sharedDSN, "polsecond")
+		second.SetPolicies(168*time.Hour, 720*time.Hour)
+		Expect(second.Connect(ctx)).To(Succeed())
+		defer second.Close(ctx)
+
+		for _, table := range []string{"value_polsecond", "attribute_polsecond"} {
+			compressAfter, retention := second.PolicyIntervals(ctx, table)
+			Expect(compressAfter).NotTo(BeNil(), table)
+			Expect(*compressAfter).To(Equal(int64(168*3600)), table)
+			Expect(retention).NotTo(BeNil(), table)
+			Expect(*retention).To(Equal(int64(720*3600)), table)
+		}
+	})
+
+	It("keeps an operator's own retention interval across a restart", func() {
+		h := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
+		h.SetPolicies(168*time.Hour, 720*time.Hour)
+		Expect(h.Connect(ctx)).To(Succeed())
+		defer h.Close(ctx)
+		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.value_polkeep')")).To(Succeed())
+		Expect(h.ExecSQL(ctx, "SELECT add_retention_policy('umh.value_polkeep', INTERVAL '90 days')")).To(Succeed())
+
+		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
+		restarted.SetPolicies(168*time.Hour, 720*time.Hour)
+		Expect(restarted.Connect(ctx)).To(Succeed())
+		defer restarted.Close(ctx)
+		_, retention := restarted.PolicyIntervals(ctx, "value_polkeep")
+		Expect(retention).NotTo(BeNil())
+		Expect(*retention).To(Equal(int64(90 * 24 * 3600)))
+	})
+
+	It("re-adds a removed compression policy on a hypertable that already has compressed chunks", func() {
+		h := tsh.NewHistorianTestHandle(sharedDSN, "polchunk")
+		h.SetPolicies(time.Hour, 0)
+		Expect(h.Connect(ctx)).To(Succeed())
+		defer h.Close(ctx)
+		Expect(h.WriteBatch(ctx, service.MessageBatch{
+			mkMsg(1.0, 1000, "_polchunk_v1", "acme.line1", "x", nil),
+		})).To(Succeed())
+		Expect(h.ExecSQL(ctx, "SELECT compress_chunk(c, if_not_compressed => true) FROM show_chunks('umh.value_polchunk') c")).To(Succeed())
+		Expect(h.ExecSQL(ctx, "SELECT remove_compression_policy('umh.value_polchunk')")).To(Succeed())
+
+		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polchunk")
+		restarted.SetPolicies(time.Hour, 0)
+		Expect(restarted.Connect(ctx)).To(Succeed())
+		defer restarted.Close(ctx)
+		compressAfter, _ := restarted.PolicyIntervals(ctx, "value_polchunk")
+		Expect(compressAfter).NotTo(BeNil())
+		Expect(*compressAfter).To(Equal(int64(3600)))
+	})
+
 	It("does not advance the topic sequence when re-resolving an existing topic", func() {
 		h := connected("noburn")
 		defer h.Close(ctx)

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -219,8 +219,10 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 		second := tsh.NewHistorianTestHandle(sharedDSN, "polsecond")
 		second.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		logs := second.CaptureLogs()
 		Expect(second.Connect(ctx)).To(Succeed())
 		defer second.Close(ctx)
+		Expect(logs()).NotTo(ContainSubstring("already holds data"))
 
 		for _, table := range []string{"value_polsecond", "attribute_polsecond"} {
 			compressAfter, retention := second.PolicyIntervals(ctx, table)
@@ -237,7 +239,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(h.Connect(ctx)).To(Succeed())
 		defer h.Close(ctx)
 		Expect(h.WriteBatch(ctx, service.MessageBatch{
-			mkMsg(1.0, 1000, "_pollegacy_v1", "acme.line1", "x", nil),
+			mkMsg(1.0, float64(time.Now().UnixMilli()), "_pollegacy_v1", "acme.line1", "x", nil),
 		})).To(Succeed())
 		for _, table := range []string{"umh.value_pollegacy", "umh.attribute_pollegacy"} {
 			Expect(h.ExecSQL(ctx, "SELECT remove_compression_policy('"+table+"')")).To(Succeed())
@@ -266,9 +268,10 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(h.Connect(ctx)).To(Succeed())
 		defer h.Close(ctx)
 		Expect(h.WriteBatch(ctx, service.MessageBatch{
-			mkMsg(1.0, 1000, "_polwarn_v1", "acme.line1", "x", nil),
+			mkMsg(1.0, float64(time.Now().UnixMilli()), "_polwarn_v1", "acme.line1", "x", map[string]string{"serialNumber": "sn-1"}),
 		})).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.value_polwarn')")).To(Succeed())
+		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.attribute_polwarn')")).To(Succeed())
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
 		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
@@ -276,7 +279,9 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 
-		Expect(logs()).To(ContainSubstring("umh.value_polwarn already holds data and has no retention policy"))
+		Expect(logs()).To(ContainSubstring("umh.value_polwarn already holds data and had no retention policy"))
+		Expect(logs()).To(ContainSubstring("umh.attribute_polwarn already holds data and had no retention policy"))
+		Expect(logs()).To(ContainSubstring("remove_retention_policy('umh.value_polwarn')"))
 		_, retention := restarted.PolicyIntervals(ctx, "value_polwarn")
 		Expect(retention).NotTo(BeNil())
 		Expect(*retention).To(Equal(int64(720 * 3600)))
@@ -314,8 +319,10 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polchunk")
 		restarted.SetPolicies(time.Hour, 0, false)
+		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
+		Expect(logs()).NotTo(ContainSubstring("already holds data"))
 		compressAfter, _ := restarted.PolicyIntervals(ctx, "value_polchunk")
 		Expect(compressAfter).NotTo(BeNil())
 		Expect(*compressAfter).To(Equal(int64(3600)))

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -231,6 +231,35 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		}
 	})
 
+	It("gives a contract left without policies by an older build both of them on the next start", func() {
+		h := tsh.NewHistorianTestHandle(sharedDSN, "pollegacy")
+		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		Expect(h.Connect(ctx)).To(Succeed())
+		defer h.Close(ctx)
+		Expect(h.WriteBatch(ctx, service.MessageBatch{
+			mkMsg(1.0, 1000, "_pollegacy_v1", "acme.line1", "x", nil),
+		})).To(Succeed())
+		for _, table := range []string{"umh.value_pollegacy", "umh.attribute_pollegacy"} {
+			Expect(h.ExecSQL(ctx, "SELECT remove_compression_policy('"+table+"')")).To(Succeed())
+			Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('"+table+"')")).To(Succeed())
+			Expect(h.ExecSQL(ctx, "ALTER TABLE "+table+" SET (timescaledb.compress = false)")).To(Succeed())
+		}
+
+		restarted := tsh.NewHistorianTestHandle(sharedDSN, "pollegacy")
+		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		Expect(restarted.Connect(ctx)).To(Succeed())
+		defer restarted.Close(ctx)
+
+		for _, table := range []string{"value_pollegacy", "attribute_pollegacy"} {
+			compressAfter, retention := restarted.PolicyIntervals(ctx, table)
+			Expect(compressAfter).NotTo(BeNil(), table)
+			Expect(*compressAfter).To(Equal(int64(168*3600)), table)
+			Expect(retention).NotTo(BeNil(), table)
+			Expect(*retention).To(Equal(int64(720*3600)), table)
+		}
+		Expect(restarted.CountValueRows(ctx, "pollegacy")).To(Equal(1))
+	})
+
 	It("warns and re-creates a retention policy removed on a hypertable that holds data", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
 		h.SetPolicies(168*time.Hour, 720*time.Hour, true)

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -96,6 +96,12 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 	seconds := func(d time.Duration) int64 { return int64(d.Seconds()) }
 
+	const (
+		configuredCompress  = 168 * time.Hour
+		configuredRetention = 720 * time.Hour
+		operatorRetention   = 90 * 24 * time.Hour
+	)
+
 	It("creates each hypertable with its own configured chunk interval", func() {
 		valueChunk := 24 * time.Hour
 		attributeChunk := 720 * time.Hour
@@ -212,13 +218,13 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 	It("applies compression and retention to a contract added after the database was bootstrapped", func() {
 		first := tsh.NewHistorianTestHandle(sharedDSN, "polfirst")
-		first.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		first.SetPolicies(configuredCompress, configuredRetention, true)
 		Expect(first.Connect(ctx)).To(Succeed())
 		Expect(first.SchemaVersion(ctx)).To(Equal(1))
 		first.Close(ctx)
 
 		second := tsh.NewHistorianTestHandle(sharedDSN, "polsecond")
-		second.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		second.SetPolicies(configuredCompress, configuredRetention, true)
 		logs := second.CaptureLogs()
 		Expect(second.Connect(ctx)).To(Succeed())
 		defer second.Close(ctx)
@@ -227,34 +233,34 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		for _, table := range []string{"value_polsecond", "attribute_polsecond"} {
 			compressAfter, retention := second.PolicyIntervals(ctx, table)
 			Expect(compressAfter).NotTo(BeNil(), table)
-			Expect(*compressAfter).To(Equal(int64(168*3600)), table)
+			Expect(*compressAfter).To(Equal(seconds(configuredCompress)), table)
 			Expect(retention).NotTo(BeNil(), table)
-			Expect(*retention).To(Equal(int64(720*3600)), table)
+			Expect(*retention).To(Equal(seconds(configuredRetention)), table)
 		}
 	})
 
 	It("reports drift on the attribute hypertable alone", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polattr")
-		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		h.SetPolicies(configuredCompress, configuredRetention, true)
 		Expect(h.Connect(ctx)).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.attribute_polattr')")).To(Succeed())
-		Expect(h.ExecSQL(ctx, "SELECT add_retention_policy('umh.attribute_polattr', INTERVAL '90 days')")).To(Succeed())
+		Expect(h.ExecSQL(ctx, fmt.Sprintf("SELECT add_retention_policy('umh.attribute_polattr', INTERVAL '%d seconds')", seconds(operatorRetention)))).To(Succeed())
 
 		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polattr")
-		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		restarted.SetPolicies(configuredCompress, configuredRetention, true)
 		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 
-		Expect(logs()).To(ContainSubstring("umh.attribute_polattr: configured retention (2592000s) does not match the applied retention policy (7776000s)"))
+		Expect(logs()).To(ContainSubstring(fmt.Sprintf("umh.attribute_polattr: configured retention (%ds) does not match the applied retention policy (%ds)", seconds(configuredRetention), seconds(operatorRetention))))
 		Expect(logs()).NotTo(ContainSubstring("umh.value_polattr: configured retention"))
 	})
 
 	It("gives a contract left without policies by an older build compression back, and retention only where nothing would be dropped", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "pollegacy")
-		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		h.SetPolicies(configuredCompress, configuredRetention, true)
 		Expect(h.Connect(ctx)).To(Succeed())
 		Expect(h.WriteBatch(ctx, service.MessageBatch{
 			mkMsg(1.0, float64(time.Now().UnixMilli()), "_pollegacy_v1", "acme.line1", "x", nil),
@@ -268,7 +274,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "pollegacy")
-		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		restarted.SetPolicies(configuredCompress, configuredRetention, true)
 		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
@@ -276,7 +282,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		for _, table := range []string{"value_pollegacy", "attribute_pollegacy"} {
 			compressAfter, _ := restarted.PolicyIntervals(ctx, table)
 			Expect(compressAfter).NotTo(BeNil(), table)
-			Expect(*compressAfter).To(Equal(int64(168*3600)), table)
+			Expect(*compressAfter).To(Equal(seconds(configuredCompress)), table)
 		}
 
 		Expect(restarted.CountValueRows(ctx, "pollegacy")).To(Equal(1))
@@ -284,18 +290,18 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 		_, valueRetention := restarted.PolicyIntervals(ctx, "value_pollegacy")
 		Expect(valueRetention).To(BeNil())
-		Expect(logs()).To(ContainSubstring("umh.value_pollegacy already holds data, so the configured retention (720h0m0s) was not applied to it"))
-		Expect(logs()).To(ContainSubstring("add_retention_policy('umh.value_pollegacy', INTERVAL '2592000 seconds')"))
+		Expect(logs()).To(ContainSubstring(fmt.Sprintf("umh.value_pollegacy already holds data, so the configured retention (%s) was not applied to it", configuredRetention)))
+		Expect(logs()).To(ContainSubstring(fmt.Sprintf("add_retention_policy('umh.value_pollegacy', INTERVAL '%d seconds')", seconds(configuredRetention))))
 
 		_, attributeRetention := restarted.PolicyIntervals(ctx, "attribute_pollegacy")
 		Expect(attributeRetention).NotTo(BeNil())
-		Expect(*attributeRetention).To(Equal(int64(720 * 3600)))
+		Expect(*attributeRetention).To(Equal(seconds(configuredRetention)))
 		Expect(logs()).NotTo(ContainSubstring("umh.attribute_pollegacy already holds data"))
 	})
 
 	It("leaves a retention policy removed on a hypertable that holds data, and says why", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
-		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		h.SetPolicies(configuredCompress, configuredRetention, true)
 		Expect(h.Connect(ctx)).To(Succeed())
 		Expect(h.WriteBatch(ctx, service.MessageBatch{
 			mkMsg(1.0, float64(time.Now().UnixMilli()), "_polwarn_v1", "acme.line1", "x", map[string]string{"serialNumber": "sn-1"}),
@@ -306,14 +312,14 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
-		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		restarted.SetPolicies(configuredCompress, configuredRetention, true)
 		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 
-		Expect(logs()).To(ContainSubstring("umh.value_polwarn already holds data, so the configured retention (720h0m0s) was not applied to it"))
-		Expect(logs()).To(ContainSubstring("umh.attribute_polwarn already holds data, so the configured retention (720h0m0s) was not applied to it"))
-		Expect(logs()).NotTo(ContainSubstring("configured retention (2592000s) is not applied"))
+		Expect(logs()).To(ContainSubstring(fmt.Sprintf("umh.value_polwarn already holds data, so the configured retention (%s) was not applied to it", configuredRetention)))
+		Expect(logs()).To(ContainSubstring(fmt.Sprintf("umh.attribute_polwarn already holds data, so the configured retention (%s) was not applied to it", configuredRetention)))
+		Expect(logs()).NotTo(ContainSubstring(fmt.Sprintf("configured retention (%ds) is not applied", seconds(configuredRetention))))
 		for _, table := range []string{"value_polwarn", "attribute_polwarn"} {
 			_, retention := restarted.PolicyIntervals(ctx, table)
 			Expect(retention).To(BeNil(), table)
@@ -322,22 +328,22 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 	It("keeps an operator's own retention interval across a restart", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
-		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		h.SetPolicies(configuredCompress, configuredRetention, true)
 		Expect(h.Connect(ctx)).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.value_polkeep')")).To(Succeed())
-		Expect(h.ExecSQL(ctx, "SELECT add_retention_policy('umh.value_polkeep', INTERVAL '90 days')")).To(Succeed())
+		Expect(h.ExecSQL(ctx, fmt.Sprintf("SELECT add_retention_policy('umh.value_polkeep', INTERVAL '%d seconds')", seconds(operatorRetention)))).To(Succeed())
 
 		h.Close(ctx)
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
-		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		restarted.SetPolicies(configuredCompress, configuredRetention, true)
 		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 		_, retention := restarted.PolicyIntervals(ctx, "value_polkeep")
 		Expect(retention).NotTo(BeNil())
-		Expect(*retention).To(Equal(int64(90 * 24 * 3600)))
-		Expect(logs()).To(ContainSubstring("umh.value_polkeep: configured retention (2592000s) does not match the applied retention policy (7776000s)"))
+		Expect(*retention).To(Equal(seconds(operatorRetention)))
+		Expect(logs()).To(ContainSubstring(fmt.Sprintf("umh.value_polkeep: configured retention (%ds) does not match the applied retention policy (%ds)", seconds(configuredRetention), seconds(operatorRetention))))
 		Expect(logs()).NotTo(ContainSubstring("umh.attribute_polkeep: configured retention"))
 	})
 
@@ -381,7 +387,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 	It("names both tables when the retention check cannot read the catalog", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "retunread")
-		h.SetPolicies(168*time.Hour, 24*time.Hour, true)
+		h.SetPolicies(configuredCompress, configuredRetention, true)
 		Expect(h.Connect(ctx)).To(Succeed())
 		defer h.Close(ctx)
 

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -181,9 +181,6 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 			mkMsg(1.0, 1000, "_recon_v1", "acme.line1", "x", nil),
 		})).To(Succeed())
 
-		// A second, independent handle (bootstrapped == false) connects to the SAME database --
-		// the real restart path, not the same-handle early return. Bootstrap runs again and must
-		// be idempotent; the ledger-gated policy block is skipped rather than re-applied.
 		h2 := tsh.NewHistorianTestHandle(sharedDSN, "recon")
 		Expect(h2.Connect(ctx)).To(Succeed())
 		defer h2.Close(ctx)
@@ -215,13 +212,13 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 	It("applies compression and retention to a contract added after the database was bootstrapped", func() {
 		first := tsh.NewHistorianTestHandle(sharedDSN, "polfirst")
-		first.SetPolicies(168*time.Hour, 720*time.Hour)
+		first.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(first.Connect(ctx)).To(Succeed())
 		defer first.Close(ctx)
 		Expect(first.SchemaVersion(ctx)).To(Equal(1))
 
 		second := tsh.NewHistorianTestHandle(sharedDSN, "polsecond")
-		second.SetPolicies(168*time.Hour, 720*time.Hour)
+		second.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(second.Connect(ctx)).To(Succeed())
 		defer second.Close(ctx)
 
@@ -236,14 +233,14 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 	It("keeps an operator's own retention interval across a restart", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
-		h.SetPolicies(168*time.Hour, 720*time.Hour)
+		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
 		defer h.Close(ctx)
 		Expect(h.ExecSQL(ctx, "SELECT remove_retention_policy('umh.value_polkeep')")).To(Succeed())
 		Expect(h.ExecSQL(ctx, "SELECT add_retention_policy('umh.value_polkeep', INTERVAL '90 days')")).To(Succeed())
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polkeep")
-		restarted.SetPolicies(168*time.Hour, 720*time.Hour)
+		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 		_, retention := restarted.PolicyIntervals(ctx, "value_polkeep")
@@ -253,7 +250,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 	It("re-adds a removed compression policy on a hypertable that already has compressed chunks", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polchunk")
-		h.SetPolicies(time.Hour, 0)
+		h.SetPolicies(time.Hour, 0, false)
 		Expect(h.Connect(ctx)).To(Succeed())
 		defer h.Close(ctx)
 		Expect(h.WriteBatch(ctx, service.MessageBatch{
@@ -263,7 +260,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(h.ExecSQL(ctx, "SELECT remove_compression_policy('umh.value_polchunk')")).To(Succeed())
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "polchunk")
-		restarted.SetPolicies(time.Hour, 0)
+		restarted.SetPolicies(time.Hour, 0, false)
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 		compressAfter, _ := restarted.PolicyIntervals(ctx, "value_polchunk")

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -222,7 +222,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		logs := second.CaptureLogs()
 		Expect(second.Connect(ctx)).To(Succeed())
 		defer second.Close(ctx)
-		Expect(logs()).NotTo(ContainSubstring("is now scheduled on"))
+		Expect(logs()).NotTo(ContainSubstring("was not applied to it"))
 
 		for _, table := range []string{"value_polsecond", "attribute_polsecond"} {
 			compressAfter, retention := second.PolicyIntervals(ctx, table)
@@ -251,7 +251,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(logs()).NotTo(ContainSubstring("umh.value_polattr: configured retention"))
 	})
 
-	It("gives a contract left without policies by an older build both of them on the next start", func() {
+	It("gives a contract left without policies by an older build compression back, and retention only where nothing would be dropped", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "pollegacy")
 		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
@@ -267,20 +267,31 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 
 		restarted := tsh.NewHistorianTestHandle(sharedDSN, "pollegacy")
 		restarted.SetPolicies(168*time.Hour, 720*time.Hour, true)
+		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 
 		for _, table := range []string{"value_pollegacy", "attribute_pollegacy"} {
-			compressAfter, retention := restarted.PolicyIntervals(ctx, table)
+			compressAfter, _ := restarted.PolicyIntervals(ctx, table)
 			Expect(compressAfter).NotTo(BeNil(), table)
 			Expect(*compressAfter).To(Equal(int64(168*3600)), table)
-			Expect(retention).NotTo(BeNil(), table)
-			Expect(*retention).To(Equal(int64(720*3600)), table)
 		}
+
 		Expect(restarted.CountValueRows(ctx, "pollegacy")).To(Equal(1))
+		Expect(restarted.CountAttributeRows(ctx, "pollegacy")).To(Equal(0))
+
+		_, valueRetention := restarted.PolicyIntervals(ctx, "value_pollegacy")
+		Expect(valueRetention).To(BeNil())
+		Expect(logs()).To(ContainSubstring("umh.value_pollegacy already holds data, so the configured retention (720h0m0s) was not applied to it"))
+		Expect(logs()).To(ContainSubstring("add_retention_policy('umh.value_pollegacy', INTERVAL '2592000 seconds')"))
+
+		_, attributeRetention := restarted.PolicyIntervals(ctx, "attribute_pollegacy")
+		Expect(attributeRetention).NotTo(BeNil())
+		Expect(*attributeRetention).To(Equal(int64(720 * 3600)))
+		Expect(logs()).NotTo(ContainSubstring("umh.attribute_pollegacy already holds data"))
 	})
 
-	It("warns and re-creates a retention policy removed on a hypertable that holds data", func() {
+	It("leaves a retention policy removed on a hypertable that holds data, and says why", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "polwarn")
 		h.SetPolicies(168*time.Hour, 720*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
@@ -297,12 +308,13 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 
-		Expect(logs()).To(ContainSubstring("retention (720h0m0s) is now scheduled on umh.value_polwarn"))
-		Expect(logs()).To(ContainSubstring("retention (720h0m0s) is now scheduled on umh.attribute_polwarn"))
-		Expect(logs()).To(ContainSubstring("remove_retention_policy('umh.value_polwarn')"))
-		_, retention := restarted.PolicyIntervals(ctx, "value_polwarn")
-		Expect(retention).NotTo(BeNil())
-		Expect(*retention).To(Equal(int64(720 * 3600)))
+		Expect(logs()).To(ContainSubstring("umh.value_polwarn already holds data, so the configured retention (720h0m0s) was not applied to it"))
+		Expect(logs()).To(ContainSubstring("umh.attribute_polwarn already holds data, so the configured retention (720h0m0s) was not applied to it"))
+		Expect(logs()).NotTo(ContainSubstring("configured retention (2592000s) is not applied"))
+		for _, table := range []string{"value_polwarn", "attribute_polwarn"} {
+			_, retention := restarted.PolicyIntervals(ctx, table)
+			Expect(retention).To(BeNil(), table)
+		}
 	})
 
 	It("keeps an operator's own retention interval across a restart", func() {
@@ -341,7 +353,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
-		Expect(logs()).NotTo(ContainSubstring("is now scheduled on"))
+		Expect(logs()).NotTo(ContainSubstring("was not applied to it"))
 		compressAfter, _ := restarted.PolicyIntervals(ctx, "value_polchunk")
 		Expect(compressAfter).NotTo(BeNil())
 		Expect(*compressAfter).To(Equal(int64(3600)))
@@ -362,7 +374,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(logs()).NotTo(ContainSubstring("stays in force"))
 	})
 
-	It("names both tables when the retention pre-check cannot read the chunk count", func() {
+	It("names both tables when the retention check cannot read the chunk count", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "retunread")
 		h.SetPolicies(168*time.Hour, 24*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
@@ -372,11 +384,11 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		cancel()
 
 		logs := h.CaptureLogs()
-		h.WarnRetentionAboutToDrop(cancelled)
+		h.WarnRetentionNotApplied(cancelled)
 
 		Expect(logs()).To(ContainSubstring("cannot read the chunk count of umh.value_retunread"))
 		Expect(logs()).To(ContainSubstring("cannot read the chunk count of umh.attribute_retunread"))
-		Expect(logs()).NotTo(ContainSubstring("older chunks will be dropped"))
+		Expect(logs()).NotTo(ContainSubstring("was not applied to it"))
 	})
 
 	It("does not advance the topic sequence when re-resolving an existing topic", func() {

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -374,7 +374,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(logs()).NotTo(ContainSubstring("stays in force"))
 	})
 
-	It("names both tables when the retention check cannot read the chunk count", func() {
+	It("names both tables when the retention check cannot read the catalog", func() {
 		h := tsh.NewHistorianTestHandle(sharedDSN, "retunread")
 		h.SetPolicies(168*time.Hour, 24*time.Hour, true)
 		Expect(h.Connect(ctx)).To(Succeed())
@@ -386,8 +386,8 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		logs := h.CaptureLogs()
 		h.WarnRetentionNotApplied(cancelled)
 
-		Expect(logs()).To(ContainSubstring("cannot read the chunk count of umh.value_retunread"))
-		Expect(logs()).To(ContainSubstring("cannot read the chunk count of umh.attribute_retunread"))
+		Expect(logs()).To(ContainSubstring("cannot read the chunk count and retention policy of umh.value_retunread"))
+		Expect(logs()).To(ContainSubstring("cannot read the chunk count and retention policy of umh.attribute_retunread"))
 		Expect(logs()).NotTo(ContainSubstring("was not applied to it"))
 	})
 

--- a/historian_plugin/output_integration_test.go
+++ b/historian_plugin/output_integration_test.go
@@ -222,7 +222,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		logs := second.CaptureLogs()
 		Expect(second.Connect(ctx)).To(Succeed())
 		defer second.Close(ctx)
-		Expect(logs()).NotTo(ContainSubstring("had no retention policy"))
+		Expect(logs()).NotTo(ContainSubstring("is now scheduled on"))
 
 		for _, table := range []string{"value_polsecond", "attribute_polsecond"} {
 			compressAfter, retention := second.PolicyIntervals(ctx, table)
@@ -279,8 +279,8 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
 
-		Expect(logs()).To(ContainSubstring("umh.value_polwarn holds data and had no retention policy"))
-		Expect(logs()).To(ContainSubstring("umh.attribute_polwarn holds data and had no retention policy"))
+		Expect(logs()).To(ContainSubstring("retention (720h0m0s) is now scheduled on umh.value_polwarn"))
+		Expect(logs()).To(ContainSubstring("retention (720h0m0s) is now scheduled on umh.attribute_polwarn"))
 		Expect(logs()).To(ContainSubstring("remove_retention_policy('umh.value_polwarn')"))
 		_, retention := restarted.PolicyIntervals(ctx, "value_polwarn")
 		Expect(retention).NotTo(BeNil())
@@ -322,7 +322,7 @@ var _ = Describe("TimescaleDB integration", Ordered, Label("postgres"), func() {
 		logs := restarted.CaptureLogs()
 		Expect(restarted.Connect(ctx)).To(Succeed())
 		defer restarted.Close(ctx)
-		Expect(logs()).NotTo(ContainSubstring("had no retention policy"))
+		Expect(logs()).NotTo(ContainSubstring("is now scheduled on"))
 		compressAfter, _ := restarted.PolicyIntervals(ctx, "value_polchunk")
 		Expect(compressAfter).NotTo(BeNil())
 		Expect(*compressAfter).To(Equal(int64(3600)))

--- a/historian_plugin/output_test.go
+++ b/historian_plugin/output_test.go
@@ -129,11 +129,24 @@ data_contract_name: pump
 			Expect(got).To(ContainSubstring("hypertable_name = '" + table + "' AND compression_enabled"))
 			Expect(got).To(ContainSubstring("proc_name = 'policy_compression' AND hypertable_schema = 'umh' AND hypertable_name = '" + table + "'"))
 			Expect(got).To(ContainSubstring("proc_name = 'policy_retention' AND hypertable_schema = 'umh' AND hypertable_name = '" + table + "'"))
+			Expect(got).To(ContainSubstring("FROM timescaledb_information.chunks WHERE hypertable_schema = 'umh' AND hypertable_name = '" + table + "'"))
 		}
 		Expect(strings.Count(got, "umh.schema_migrations WHERE version = 1")).To(Equal(1),
 			"the version-1 gate belongs to the migration ledger alone")
 		Expect(got).NotTo(ContainSubstring("remove_retention_policy"))
 		Expect(got).NotTo(ContainSubstring("remove_compression_policy"))
+	})
+
+	It("guards each retention add on the table being empty, and only retention", func() {
+		got := tsh.BootstrapSQLWithPoliciesForTest("pump", 168*time.Hour, 720*time.Hour, true)
+		for _, table := range []string{"value_pump", "attribute_pump"} {
+			retentionGuard := "IF NOT EXISTS (SELECT 1 FROM timescaledb_information.jobs WHERE proc_name = 'policy_retention' AND hypertable_schema = 'umh' AND hypertable_name = '" + table + "') AND NOT EXISTS (SELECT 1 FROM timescaledb_information.chunks WHERE hypertable_schema = 'umh' AND hypertable_name = '" + table + "') THEN"
+			Expect(got).To(ContainSubstring(retentionGuard), table)
+			compressionGuard := "IF NOT EXISTS (SELECT 1 FROM timescaledb_information.jobs WHERE proc_name = 'policy_compression' AND hypertable_schema = 'umh' AND hypertable_name = '" + table + "') THEN"
+			Expect(got).To(ContainSubstring(compressionGuard), table)
+		}
+		Expect(strings.Count(got, "timescaledb_information.chunks")).To(Equal(2),
+			"compression is not destructive, so only the retention adds consult the chunk list")
 	})
 
 	It("renders no retention policy for the shipped default of keep forever", func() {

--- a/historian_plugin/output_test.go
+++ b/historian_plugin/output_test.go
@@ -156,7 +156,8 @@ var _ = Describe("policy drift warnings", func() {
 		func(compressWant int64, appliedComp *int64, retentionWant *int64, appliedRet *int64, wantWarns int) {
 			Expect(tsh.PolicyDriftWarningsForTest(compressWant, appliedComp, retentionWant, appliedRet)).To(HaveLen(wantWarns))
 		},
-		Entry("quiet: compression not readable yet (not bootstrapped)", sevenDays, nil, sec(thirtyDays), nil, 0),
+		Entry("warn: no compression policy applied, and retention configured but not applied", sevenDays, nil, sec(thirtyDays), nil, 2),
+		Entry("warn: no compression policy applied, no retention configured", sevenDays, nil, nil, nil, 1),
 		Entry("quiet: compression matches, no retention configured", sevenDays, sec(sevenDays), nil, nil, 0),
 		Entry("quiet: compression and retention both match", sevenDays, sec(sevenDays), sec(thirtyDays), sec(thirtyDays), 0),
 		Entry("warn: compress_after changed after bootstrap", oneDay, sec(sevenDays), nil, nil, 1),

--- a/historian_plugin/output_test.go
+++ b/historian_plugin/output_test.go
@@ -121,10 +121,10 @@ data_contract_name: pump
 	It("gates compression/retention setup per hypertable, not on the schema ledger", func() {
 		got := tsh.BootstrapSQLWithPoliciesForTest("pump", 168*time.Hour, 720*time.Hour, true)
 		Expect(got).To(ContainSubstring("ALTER TABLE umh.value_pump SET ("))
-		Expect(got).To(ContainSubstring("add_compression_policy('umh.value_pump'"))
-		Expect(got).To(ContainSubstring("add_retention_policy('umh.value_pump'"))
-		Expect(got).To(ContainSubstring("add_compression_policy('umh.attribute_pump'"))
-		Expect(got).To(ContainSubstring("add_retention_policy('umh.attribute_pump'"))
+		for _, table := range []string{"umh.value_pump", "umh.attribute_pump"} {
+			Expect(got).To(ContainSubstring("add_compression_policy('" + table + "', INTERVAL '604800 seconds', if_not_exists => TRUE)"))
+			Expect(got).To(ContainSubstring("add_retention_policy('" + table + "', INTERVAL '2592000 seconds', if_not_exists => TRUE)"))
+		}
 		for _, table := range []string{"value_pump", "attribute_pump"} {
 			Expect(got).To(ContainSubstring("hypertable_name = '" + table + "' AND compression_enabled"))
 			Expect(got).To(ContainSubstring("proc_name = 'policy_compression' AND hypertable_schema = 'umh' AND hypertable_name = '" + table + "'"))

--- a/historian_plugin/output_test.go
+++ b/historian_plugin/output_test.go
@@ -16,6 +16,7 @@ package historian_plugin_test
 
 import (
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -117,13 +118,20 @@ data_contract_name: pump
 		Expect(got).NotTo(ContainSubstring("MIGRATIONS_SLOT")) // placeholder substituted
 	})
 
-	It("gates compression/retention setup on the ledger so it runs once at first bootstrap", func() {
-		got := tsh.BootstrapSQLForTest("pump")
-		// The policy DO block is wrapped in the version-1 ledger gate, so it never re-runs on
-		// restart: the ALTER can't hit the compressed-chunks error and retention is not stripped.
+	It("gates compression/retention setup per hypertable, not on the schema ledger", func() {
+		got := tsh.BootstrapSQLWithPoliciesForTest("pump", 168*time.Hour, 720*time.Hour)
 		Expect(got).To(ContainSubstring("ALTER TABLE umh.value_pump SET ("))
 		Expect(got).To(ContainSubstring("add_compression_policy('umh.value_pump'"))
-		// Runs only on empty tables, so no remove_* churn on restart.
+		Expect(got).To(ContainSubstring("add_retention_policy('umh.value_pump'"))
+		Expect(got).To(ContainSubstring("add_compression_policy('umh.attribute_pump'"))
+		Expect(got).To(ContainSubstring("add_retention_policy('umh.attribute_pump'"))
+		for _, table := range []string{"value_pump", "attribute_pump"} {
+			Expect(got).To(ContainSubstring("hypertable_name = '" + table + "'"))
+			Expect(got).To(ContainSubstring("hypertable_name = '" + table + "' AND compression_enabled"))
+		}
+		// The version-1 gate belongs to the migration ledger alone: a contract added to an
+		// already-migrated database must still get its own policies.
+		Expect(strings.Count(got, "umh.schema_migrations WHERE version = 1")).To(Equal(1))
 		Expect(got).NotTo(ContainSubstring("remove_retention_policy"))
 		Expect(got).NotTo(ContainSubstring("remove_compression_policy"))
 	})

--- a/historian_plugin/output_test.go
+++ b/historian_plugin/output_test.go
@@ -119,21 +119,28 @@ data_contract_name: pump
 	})
 
 	It("gates compression/retention setup per hypertable, not on the schema ledger", func() {
-		got := tsh.BootstrapSQLWithPoliciesForTest("pump", 168*time.Hour, 720*time.Hour)
+		got := tsh.BootstrapSQLWithPoliciesForTest("pump", 168*time.Hour, 720*time.Hour, true)
 		Expect(got).To(ContainSubstring("ALTER TABLE umh.value_pump SET ("))
 		Expect(got).To(ContainSubstring("add_compression_policy('umh.value_pump'"))
 		Expect(got).To(ContainSubstring("add_retention_policy('umh.value_pump'"))
 		Expect(got).To(ContainSubstring("add_compression_policy('umh.attribute_pump'"))
 		Expect(got).To(ContainSubstring("add_retention_policy('umh.attribute_pump'"))
 		for _, table := range []string{"value_pump", "attribute_pump"} {
-			Expect(got).To(ContainSubstring("hypertable_name = '" + table + "'"))
 			Expect(got).To(ContainSubstring("hypertable_name = '" + table + "' AND compression_enabled"))
+			Expect(got).To(ContainSubstring("proc_name = 'policy_compression' AND hypertable_schema = 'umh' AND hypertable_name = '" + table + "'"))
+			Expect(got).To(ContainSubstring("proc_name = 'policy_retention' AND hypertable_schema = 'umh' AND hypertable_name = '" + table + "'"))
 		}
-		// The version-1 gate belongs to the migration ledger alone: a contract added to an
-		// already-migrated database must still get its own policies.
-		Expect(strings.Count(got, "umh.schema_migrations WHERE version = 1")).To(Equal(1))
+		Expect(strings.Count(got, "umh.schema_migrations WHERE version = 1")).To(Equal(1),
+			"the version-1 gate belongs to the migration ledger alone")
 		Expect(got).NotTo(ContainSubstring("remove_retention_policy"))
 		Expect(got).NotTo(ContainSubstring("remove_compression_policy"))
+	})
+
+	It("renders no retention policy for the shipped default of keep forever", func() {
+		got := tsh.BootstrapSQLForTest("pump")
+		Expect(got).NotTo(ContainSubstring("add_retention_policy"))
+		Expect(got).NotTo(ContainSubstring("policy_retention"))
+		Expect(got).To(ContainSubstring("add_compression_policy('umh.value_pump'"))
 	})
 })
 

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -309,27 +309,31 @@ func sub(sql string, contract string) string {
 // the first. The ALTER needs a check of its own, because re-asserting it once compressed chunks
 // exist errors on older TimescaleDB 2.x. A policy deleted on the database while it stays in config
 // is re-created at the next bootstrap.
-func policyBlock(table string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
-	qualified := "umh." + table
+func policyBlock(hypertableName string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
+	qualifiedTable := "umh." + hypertableName
+	compressionEnabled := compressionEnabledSQL(hypertableName)
+	compressionPolicyExists := policyJobExistsSQL("policy_compression", hypertableName)
+
 	var b strings.Builder
 	fmt.Fprintf(&b, `DO $pol$
 BEGIN
-  IF NOT %[3]s THEN
-    ALTER TABLE %[1]s SET (
+  IF NOT %s THEN
+    ALTER TABLE %s SET (
       timescaledb.compress,
       timescaledb.compress_segmentby = 'topic_id',
       timescaledb.compress_orderby   = 'ts DESC'
     );
   END IF;
-  IF NOT %[4]s THEN
-    PERFORM add_compression_policy('%[1]s', %[2]s, if_not_exists => TRUE);
+  IF NOT %s THEN
+    PERFORM add_compression_policy('%s', %s, if_not_exists => TRUE);
   END IF;
-`, qualified, intervalSQL(compressAfter), compressionEnabledSQL(table), policyJobExistsSQL("policy_compression", table))
+`, compressionEnabled, qualifiedTable, compressionPolicyExists, qualifiedTable, intervalSQL(compressAfter))
 	if retentionSet {
-		fmt.Fprintf(&b, `  IF NOT %[2]s THEN
-    PERFORM add_retention_policy('%[1]s', %[3]s, if_not_exists => TRUE);
+		retentionPolicyExists := policyJobExistsSQL("policy_retention", hypertableName)
+		fmt.Fprintf(&b, `  IF NOT %s THEN
+    PERFORM add_retention_policy('%s', %s, if_not_exists => TRUE);
   END IF;
-`, qualified, policyJobExistsSQL("policy_retention", table), intervalSQL(retention))
+`, retentionPolicyExists, qualifiedTable, intervalSQL(retention))
 	}
 	b.WriteString("END $pol$;")
 	return b.String()
@@ -338,12 +342,12 @@ BEGIN
 // policyJobExistsSQL is policyIntervalSQL as a boolean, with the hypertable name inlined because a
 // DO block takes no parameters. procName is an internal constant and table is the validated
 // contract name, not user input.
-func policyJobExistsSQL(procName string, table string) string {
-	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.jobs WHERE proc_name = '%s' AND hypertable_schema = 'umh' AND hypertable_name = '%s')", procName, table)
+func policyJobExistsSQL(procName string, hypertableName string) string {
+	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.jobs WHERE proc_name = '%s' AND hypertable_schema = 'umh' AND hypertable_name = '%s')", procName, hypertableName)
 }
 
-func compressionEnabledSQL(table string) string {
-	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.hypertables WHERE hypertable_schema = 'umh' AND hypertable_name = '%s' AND compression_enabled)", table)
+func compressionEnabledSQL(hypertableName string) string {
+	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.hypertables WHERE hypertable_schema = 'umh' AND hypertable_name = '%s' AND compression_enabled)", hypertableName)
 }
 
 // policyIntervalSQL returns a query for the interval (in seconds) of a TimescaleDB policy job on

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -306,13 +306,9 @@ func sub(sql string, contract string) string {
 // policyBlock builds the compression/retention setup for one hypertable. Each check reads the
 // catalog for this hypertable, not umh.schema_migrations: that ledger holds one row per database
 // while the hypertables are per contract, so gating on it skipped every contract after the first.
-// The checks rely on the advisory lock this template takes at the top spanning them.
-//
-// The ALTER is checked separately because ALTER TABLE ... SET takes AccessExclusiveLock, and it
-// leaves an operator's own compress_segmentby / compress_orderby alone. if_not_exists on the adds
-// covers a check that reads false while the policy exists, which would otherwise abort the whole
-// bootstrap. A deleted policy and one that never existed are the same catalog state, so a removal
-// does not survive a restart.
+// The ALTER is checked separately because ALTER TABLE ... SET takes AccessExclusiveLock. The checks
+// rely on the advisory lock at the top of this template spanning them, and if_not_exists on the
+// adds covers a check that reads false while the policy exists.
 func policyBlock(hypertableName string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
 	qualifiedTable := "umh." + hypertableName
 	compressionEnabled := compressionEnabledSQL(hypertableName)
@@ -346,7 +342,7 @@ BEGIN
 // policyJobExistsSQL and compressionEnabledSQL inline the hypertable name because a DO block takes
 // no parameters. procName is an internal constant, and the name reaching them is the CONTRACT_SLOT
 // template placeholder, replaced later by sub() with a contract ValidateContract has already matched
-// against ^[a-z0-9_]+$ -- so neither is a path for user input.
+// against ^[a-z0-9_]+$, so neither is a path for user input.
 func policyJobExistsSQL(procName string, hypertableName string) string {
 	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.jobs WHERE proc_name = '%s' AND hypertable_schema = 'umh' AND hypertable_name = '%s')", procName, hypertableName)
 }

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -326,10 +326,11 @@ BEGIN
 `, compressionEnabled, qualifiedTable, compressionPolicyExists, qualifiedTable, intervalSQL(compressAfter))
 	if retentionSet {
 		retentionPolicyExists := policyJobExistsSQL("policy_retention", hypertableName)
-		fmt.Fprintf(&b, `  IF NOT %s THEN
+		holdsData := hypertableHasChunksSQL(hypertableName)
+		fmt.Fprintf(&b, `  IF NOT %s AND NOT %s THEN
     PERFORM add_retention_policy('%s', %s, if_not_exists => TRUE);
   END IF;
-`, retentionPolicyExists, qualifiedTable, intervalSQL(retention))
+`, retentionPolicyExists, holdsData, qualifiedTable, intervalSQL(retention))
 	}
 	b.WriteString("END $pol$;")
 	return b.String()
@@ -341,6 +342,10 @@ BEGIN
 // against ^[a-z0-9_]+$, so neither is a path for user input.
 func policyJobExistsSQL(procName string, hypertableName string) string {
 	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.jobs WHERE proc_name = '%s' AND hypertable_schema = 'umh' AND hypertable_name = '%s')", procName, hypertableName)
+}
+
+func hypertableHasChunksSQL(hypertableName string) string {
+	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.chunks WHERE hypertable_schema = 'umh' AND hypertable_name = '%s')", hypertableName)
 }
 
 func compressionEnabledSQL(hypertableName string) string {

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -357,7 +357,13 @@ func compressionEnabledSQL(hypertableName string) string {
 // one row (never ErrNoRows), so a nil scan means "no policy / catalog unavailable". procName and
 // configKey are internal constants, not user input.
 func policyIntervalSQL(procName string, configKey string) string {
-	return fmt.Sprintf(`SELECT (
+	return "SELECT " + policyIntervalSubquery(procName, configKey)
+}
+
+// policyIntervalSubquery is the same read as one scalar subquery, so a caller can select it beside
+// another one in a single statement.
+func policyIntervalSubquery(procName string, configKey string) string {
+	return fmt.Sprintf(`(
   SELECT EXTRACT(EPOCH FROM (config->>'%s')::interval)::bigint
     FROM timescaledb_information.jobs
    WHERE proc_name = '%s' AND hypertable_schema = 'umh' AND hypertable_name = $1
@@ -402,6 +408,13 @@ type bootstrapConfig struct {
 	retentionSet   bool
 	valueChunk     time.Duration
 	attributeChunk time.Duration
+}
+
+// retentionSkipSQL reads both facts the retention decision needs, in one round trip: how many chunks
+// the hypertable holds, and the interval of its retention policy (NULL when it has none). One
+// statement means one failure path, so a read that fails cannot leave half the decision made.
+func retentionSkipSQL() string {
+	return fmt.Sprintf("SELECT (%s), %s", hypertableChunkCountSQL, policyIntervalSubquery("policy_retention", "drop_after"))
 }
 
 // chunkIntervalSQL reads the chunk width applied to a umh hypertable, in seconds. A scalar subquery,

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -306,9 +306,18 @@ func sub(sql string, contract string) string {
 // policyBlock builds the compression/retention setup for one hypertable. Each check reads
 // TimescaleDB's catalog for this hypertable rather than umh.schema_migrations, which holds one row
 // per database while the hypertables are per contract: a ledger check skips every contract after
-// the first. The ALTER needs a check of its own, because re-asserting it once compressed chunks
-// exist errors on older TimescaleDB 2.x. A policy deleted on the database while it stays in config
-// is re-created at the next bootstrap.
+// the first. The checks are only safe together with the advisory lock this template takes at the
+// top, which spans them and the statements they guard.
+//
+// The ALTER needs a check of its own because ALTER TABLE ... SET takes AccessExclusiveLock, so
+// re-asserting settings that never change would lock the hypertable against reads and writes every
+// time the output starts. It also leaves an operator's own compress_segmentby / compress_orderby
+// alone, which nothing else here checks or reports.
+//
+// if_not_exists on the two adds is the second line of defense: a check that reads false while the
+// policy exists then declines instead of aborting the bootstrap transaction. A policy deleted on
+// the database while it stays in config is re-created the next time the output starts, because a
+// deleted policy and one that never existed are the same catalog state.
 func policyBlock(hypertableName string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
 	qualifiedTable := "umh." + hypertableName
 	compressionEnabled := compressionEnabledSQL(hypertableName)
@@ -339,9 +348,10 @@ BEGIN
 	return b.String()
 }
 
-// policyJobExistsSQL is policyIntervalSQL as a boolean, with the hypertable name inlined because a
-// DO block takes no parameters. procName is an internal constant and table is the validated
-// contract name, not user input.
+// policyJobExistsSQL and compressionEnabledSQL inline the hypertable name because a DO block takes
+// no parameters. procName is an internal constant, and the name reaching them is the CONTRACT_SLOT
+// template placeholder, replaced later by sub() with a contract ValidateContract has already matched
+// against ^[a-z0-9_]+$ -- so neither is a path for user input.
 func policyJobExistsSQL(procName string, hypertableName string) string {
 	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.jobs WHERE proc_name = '%s' AND hypertable_schema = 'umh' AND hypertable_name = '%s')", procName, hypertableName)
 }

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -322,12 +322,12 @@ BEGIN
     );
   END IF;
   IF NOT %[4]s THEN
-    PERFORM add_compression_policy('%[1]s', %[2]s);
+    PERFORM add_compression_policy('%[1]s', %[2]s, if_not_exists => TRUE);
   END IF;
 `, qualified, intervalSQL(compressAfter), compressionEnabledSQL(table), policyJobExistsSQL("policy_compression", table))
 	if retentionSet {
 		fmt.Fprintf(&b, `  IF NOT %[2]s THEN
-    PERFORM add_retention_policy('%[1]s', %[3]s);
+    PERFORM add_retention_policy('%[1]s', %[3]s, if_not_exists => TRUE);
   END IF;
 `, qualified, policyJobExistsSQL("policy_retention", table), intervalSQL(retention))
 	}

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -303,28 +303,47 @@ func sub(sql string, contract string) string {
 	return strings.ReplaceAll(sql, "CONTRACT_SLOT", contract)
 }
 
-// policyBlock generates the compression/retention setup for one hypertable, ledger-gated to run
-// once at first bootstrap (empty table, no compressed chunks). Running it every Connect broke two
-// ways: ALTER TABLE SET (compress...) errors once compressed chunks exist, and re-applying
-// retention un-scheduled an operator's manual policy. Consequence: editing compress_after/retention
-// needs a new migration step to re-apply.
+// policyBlock builds the compression/retention setup for one hypertable. Each check reads
+// TimescaleDB's catalog for this hypertable rather than umh.schema_migrations, which holds one row
+// per database while the hypertables are per contract: a ledger check skips every contract after
+// the first. The ALTER needs a check of its own, because re-asserting it once compressed chunks
+// exist errors on older TimescaleDB 2.x. A policy deleted on the database while it stays in config
+// is re-created at the next bootstrap.
 func policyBlock(table string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
+	qualified := "umh." + table
 	var b strings.Builder
 	fmt.Fprintf(&b, `DO $pol$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM umh.schema_migrations WHERE version = 1) THEN
+  IF NOT %[3]s THEN
     ALTER TABLE %[1]s SET (
       timescaledb.compress,
       timescaledb.compress_segmentby = 'topic_id',
       timescaledb.compress_orderby   = 'ts DESC'
     );
+  END IF;
+  IF NOT %[4]s THEN
     PERFORM add_compression_policy('%[1]s', %[2]s);
-`, table, intervalSQL(compressAfter))
+  END IF;
+`, qualified, intervalSQL(compressAfter), compressionEnabledSQL(table), policyJobExistsSQL("policy_compression", table))
 	if retentionSet {
-		fmt.Fprintf(&b, "    PERFORM add_retention_policy('%s', %s);\n", table, intervalSQL(retention))
+		fmt.Fprintf(&b, `  IF NOT %[2]s THEN
+    PERFORM add_retention_policy('%[1]s', %[3]s);
+  END IF;
+`, qualified, policyJobExistsSQL("policy_retention", table), intervalSQL(retention))
 	}
-	b.WriteString("  END IF;\nEND $pol$;")
+	b.WriteString("END $pol$;")
 	return b.String()
+}
+
+// policyJobExistsSQL is policyIntervalSQL as a boolean, with the hypertable name inlined because a
+// DO block takes no parameters. procName is an internal constant and table is the validated
+// contract name, not user input.
+func policyJobExistsSQL(procName string, table string) string {
+	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.jobs WHERE proc_name = '%s' AND hypertable_schema = 'umh' AND hypertable_name = '%s')", procName, table)
+}
+
+func compressionEnabledSQL(table string) string {
+	return fmt.Sprintf("EXISTS (SELECT 1 FROM timescaledb_information.hypertables WHERE hypertable_schema = 'umh' AND hypertable_name = '%s' AND compression_enabled)", table)
 }
 
 // policyIntervalSQL returns a query for the interval (in seconds) of a TimescaleDB policy job on
@@ -410,8 +429,8 @@ func bootstrapSQL(cfg bootstrapConfig) string {
 	slots := map[string]string{
 		"VALUE_CHUNK_SLOT":     intervalSQL(cfg.valueChunk),
 		"ATTRIBUTE_CHUNK_SLOT": intervalSQL(cfg.attributeChunk),
-		"VALUE_POLICY_SLOT":    policyBlock("umh.value_CONTRACT_SLOT", cfg.compressAfter, cfg.retention, cfg.retentionSet),
-		"ATTR_POLICY_SLOT":     policyBlock("umh.attribute_CONTRACT_SLOT", cfg.compressAfter, cfg.retention, cfg.retentionSet),
+		"VALUE_POLICY_SLOT":    policyBlock("value_CONTRACT_SLOT", cfg.compressAfter, cfg.retention, cfg.retentionSet),
+		"ATTR_POLICY_SLOT":     policyBlock("attribute_CONTRACT_SLOT", cfg.compressAfter, cfg.retention, cfg.retentionSet),
 		"MIGRATIONS_SLOT":      migrationsBlock(),
 	}
 	s := bootstrapTemplate

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -305,7 +305,7 @@ func sub(sql string, contract string) string {
 
 // policyBlock builds the compression/retention setup for one hypertable. Each check reads the
 // catalog for this hypertable, not umh.schema_migrations: that ledger holds one row per database
-// while the hypertables are per contract, so gating on it skipped every contract after the first.
+// while the hypertables are per contract, so gating on it skips every contract after the first.
 // The ALTER is checked separately because ALTER TABLE ... SET takes AccessExclusiveLock. The checks
 // rely on the advisory lock at the top of this template spanning them, and if_not_exists on the
 // adds covers a check that reads false while the policy exists.
@@ -378,17 +378,17 @@ func policyDriftWarnings(compressWant int64, appliedComp *int64, retentionWant *
 	var warns []string
 	switch {
 	case appliedComp == nil:
-		warns = append(warns, fmt.Sprintf("configured compress_after (%ds) is not applied in the database", compressWant))
+		warns = append(warns, fmt.Sprintf("configured compress_after (%ds) is not applied", compressWant))
 	case *appliedComp != compressWant:
-		warns = append(warns, fmt.Sprintf("configured compress_after (%ds) does not match the compression policy applied in the database (%ds)", compressWant, *appliedComp))
+		warns = append(warns, fmt.Sprintf("configured compress_after (%ds) does not match the applied compression policy (%ds)", compressWant, *appliedComp))
 	}
 	switch {
 	case retentionWant != nil && appliedRet == nil:
-		warns = append(warns, fmt.Sprintf("configured retention (%ds) is not applied in the database", *retentionWant))
+		warns = append(warns, fmt.Sprintf("configured retention (%ds) is not applied", *retentionWant))
 	case retentionWant != nil && *appliedRet != *retentionWant:
-		warns = append(warns, fmt.Sprintf("configured retention (%ds) does not match the retention policy applied in the database (%ds)", *retentionWant, *appliedRet))
+		warns = append(warns, fmt.Sprintf("configured retention (%ds) does not match the applied retention policy (%ds)", *retentionWant, *appliedRet))
 	case retentionWant == nil && appliedRet != nil:
-		warns = append(warns, fmt.Sprintf("retention is unset in config but a retention policy (%ds) is applied in the database", *appliedRet))
+		warns = append(warns, fmt.Sprintf("retention is unset in config but a retention policy (%ds) is applied", *appliedRet))
 	}
 	return warns
 }

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -303,21 +303,16 @@ func sub(sql string, contract string) string {
 	return strings.ReplaceAll(sql, "CONTRACT_SLOT", contract)
 }
 
-// policyBlock builds the compression/retention setup for one hypertable. Each check reads
-// TimescaleDB's catalog for this hypertable rather than umh.schema_migrations, which holds one row
-// per database while the hypertables are per contract: a ledger check skips every contract after
-// the first. The checks are only safe together with the advisory lock this template takes at the
-// top, which spans them and the statements they guard.
+// policyBlock builds the compression/retention setup for one hypertable. Each check reads the
+// catalog for this hypertable, not umh.schema_migrations: that ledger holds one row per database
+// while the hypertables are per contract, so gating on it skipped every contract after the first.
+// The checks rely on the advisory lock this template takes at the top spanning them.
 //
-// The ALTER needs a check of its own because ALTER TABLE ... SET takes AccessExclusiveLock, so
-// re-asserting settings that never change would lock the hypertable against reads and writes every
-// time the output starts. It also leaves an operator's own compress_segmentby / compress_orderby
-// alone, which nothing else here checks or reports.
-//
-// if_not_exists on the two adds is the second line of defense: a check that reads false while the
-// policy exists then declines instead of aborting the bootstrap transaction. A policy deleted on
-// the database while it stays in config is re-created the next time the output starts, because a
-// deleted policy and one that never existed are the same catalog state.
+// The ALTER is checked separately because ALTER TABLE ... SET takes AccessExclusiveLock, and it
+// leaves an operator's own compress_segmentby / compress_orderby alone. if_not_exists on the adds
+// covers a check that reads false while the policy exists, which would otherwise abort the whole
+// bootstrap. A deleted policy and one that never existed are the same catalog state, so a removal
+// does not survive a restart.
 func policyBlock(hypertableName string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
 	qualifiedTable := "umh." + hypertableName
 	compressionEnabled := compressionEnabledSQL(hypertableName)
@@ -372,8 +367,8 @@ func policyIntervalSQL(procName string, configKey string) string {
    LIMIT 1)`, configKey, procName)
 }
 
-// hypertableChunkCountSQL counts the chunks of one umh hypertable, so a policy about to be created
-// can be told apart from one being created on a table that already holds history.
+// hypertableChunkCountSQL counts the chunks of one umh hypertable: a policy created on an empty
+// table destroys nothing, one created on a table with history does.
 const hypertableChunkCountSQL = `SELECT count(*) FROM timescaledb_information.chunks
  WHERE hypertable_schema = 'umh' AND hypertable_name = $1`
 

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -358,6 +358,11 @@ func policyIntervalSQL(procName string, configKey string) string {
    LIMIT 1)`, configKey, procName)
 }
 
+// hypertableChunkCountSQL counts the chunks of one umh hypertable, so a policy about to be created
+// can be told apart from one being created on a table that already holds history.
+const hypertableChunkCountSQL = `SELECT count(*) FROM timescaledb_information.chunks
+ WHERE hypertable_schema = 'umh' AND hypertable_name = $1`
+
 // policyDriftWarnings compares configured compression/retention intervals against the ones
 // actually applied in the database (in seconds; nil = no such policy) and returns a warning per
 // divergence. appliedComp == nil means the compression policy could not be read -- either the

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -303,12 +303,8 @@ func sub(sql string, contract string) string {
 	return strings.ReplaceAll(sql, "CONTRACT_SLOT", contract)
 }
 
-// policyBlock builds the compression/retention setup for one hypertable. Each check reads the
-// catalog for this hypertable, not umh.schema_migrations: that ledger holds one row per database
-// while the hypertables are per contract, so gating on it skips every contract after the first.
-// The ALTER is checked separately because ALTER TABLE ... SET takes AccessExclusiveLock. The checks
-// rely on the advisory lock at the top of this template spanning them, and if_not_exists on the
-// adds covers a check that reads false while the policy exists.
+// policyBlock builds the compression/retention setup for one hypertable. Its checks and the
+// statements they guard have to stay inside the advisory lock this template takes at the top.
 func policyBlock(hypertableName string, compressAfter time.Duration, retention time.Duration, retentionSet bool) string {
 	qualifiedTable := "umh." + hypertableName
 	compressionEnabled := compressionEnabledSQL(hypertableName)
@@ -368,12 +364,9 @@ func policyIntervalSQL(procName string, configKey string) string {
 const hypertableChunkCountSQL = `SELECT count(*) FROM timescaledb_information.chunks
  WHERE hypertable_schema = 'umh' AND hypertable_name = $1`
 
-// policyDriftWarnings compares configured compression/retention intervals against the ones actually
-// applied in the database and returns a warning per divergence. An applied interval is nil when no
-// such policy is scheduled, and only that: a lookup that failed is an error the caller reports, so
-// this no longer treats a nil compression interval as "introspection is broken" and stays silent on
-// the retention checks because of it. retentionWant is nil when retention is unset in config (keep
-// forever), which is the one nil that means "wanted absent" rather than "is absent".
+// policyDriftWarnings returns one warning per divergence between the configured and the applied
+// intervals. An applied interval is nil when no such policy is scheduled. retentionWant is nil when
+// retention is unset in config, the one nil here that means "wanted absent" rather than "is absent".
 func policyDriftWarnings(compressWant int64, appliedComp *int64, retentionWant *int64, appliedRet *int64) []string {
 	var warns []string
 	switch {

--- a/historian_plugin/sql.go
+++ b/historian_plugin/sql.go
@@ -377,21 +377,18 @@ func policyIntervalSQL(procName string, configKey string) string {
 const hypertableChunkCountSQL = `SELECT count(*) FROM timescaledb_information.chunks
  WHERE hypertable_schema = 'umh' AND hypertable_name = $1`
 
-// policyDriftWarnings compares configured compression/retention intervals against the ones
-// actually applied in the database (in seconds; nil = no such policy) and returns a warning per
-// divergence. appliedComp == nil means the compression policy could not be read -- either the
-// catalog is unavailable on this server or the database was never bootstrapped -- so it returns
-// nothing rather than risk a false warning. Compression always has a policy after bootstrap, so
-// its presence doubles as the "introspection works" probe for the retention checks.
-// retentionWant is nil when retention is unset in config (keep forever); appliedRet is nil when no
-// retention policy is scheduled in the database. Both compression and retention use the same nil-able
-// representation for "not set".
+// policyDriftWarnings compares configured compression/retention intervals against the ones actually
+// applied in the database and returns a warning per divergence. An applied interval is nil when no
+// such policy is scheduled, and only that: a lookup that failed is an error the caller reports, so
+// this no longer treats a nil compression interval as "introspection is broken" and stays silent on
+// the retention checks because of it. retentionWant is nil when retention is unset in config (keep
+// forever), which is the one nil that means "wanted absent" rather than "is absent".
 func policyDriftWarnings(compressWant int64, appliedComp *int64, retentionWant *int64, appliedRet *int64) []string {
-	if appliedComp == nil {
-		return nil
-	}
 	var warns []string
-	if *appliedComp != compressWant {
+	switch {
+	case appliedComp == nil:
+		warns = append(warns, fmt.Sprintf("configured compress_after (%ds) is not applied in the database", compressWant))
+	case *appliedComp != compressWant:
 		warns = append(warns, fmt.Sprintf("configured compress_after (%ds) does not match the compression policy applied in the database (%ds)", compressWant, *appliedComp))
 	}
 	switch {

--- a/historian_plugin/transform.go
+++ b/historian_plugin/transform.go
@@ -71,6 +71,13 @@ func NormalizeContract(metaContract string) string {
 
 // ValidateContract checks that data_contract_name is a bare lowercase name (letters, digits,
 // underscores) with no leading underscore and no _vN version suffix.
+// maxContractLen keeps "attribute_" + the contract name inside PostgreSQL's 63-byte identifier
+// limit. Past it the server truncates the table name it creates, and two contracts that differ only
+// in the truncated tail share one pair of hypertables, so one contract's rows, policies and drift
+// warnings become the other's.
+// https://www.postgresql.org/docs/current/limits.html
+const maxContractLen = 63 - len("attribute_")
+
 func ValidateContract(c string) error {
 	if !reContract.MatchString(c) {
 		return fmt.Errorf("data_contract_name %q invalid: use a bare lowercase name (letters, digits, underscores), e.g. \"pump\"", c)
@@ -80,6 +87,9 @@ func ValidateContract(c string) error {
 	}
 	if reVersionSuffix.MatchString(c) {
 		return fmt.Errorf("data_contract_name %q must not carry a version suffix (\"pump\", not \"pump_v1\")", c)
+	}
+	if len(c) > maxContractLen {
+		return fmt.Errorf("data_contract_name %q is %d characters; use %d or fewer, because PostgreSQL truncates the table name at 63 bytes and two contracts sharing the first %d characters would then write to the same tables", c, len(c), maxContractLen, maxContractLen)
 	}
 	return nil
 }

--- a/historian_plugin/transform_test.go
+++ b/historian_plugin/transform_test.go
@@ -50,6 +50,8 @@ var _ = Describe("contract helpers", func() {
 		Entry("leading underscore rejected", "_pump", false),
 		Entry("version suffix rejected", "pump_v1", false),
 		Entry("empty rejected", "", false),
+		Entry("53 characters accepted, the longest that keeps umh.attribute_<name> under 64 bytes", strings.Repeat("p", 53), true),
+		Entry("54 characters rejected, since the server would truncate the attribute table", strings.Repeat("p", 54), false),
 	)
 })
 


### PR DESCRIPTION
Stacked on #441.

## Problem

Compression and retention only ever reached the first historian data contract on a database. The
policy block was gated on a row in `umh.schema_migrations`, which exists once per database, while
the hypertables it configures exist once per contract. Every later contract got its tables and no
policies, so its chunks were never compressed and old ones never dropped, with nothing in the logs
saying so.

## What we are shipping

- Every contract gets its own policies, including one added to a database that already holds others.
  A contract missing them gets them the next time its bridge starts.
- Policies are only ever added, never removed or altered. Retention is added only to a hypertable
  with no rows in it: on one that already holds rows the output logs the `add_retention_policy`
  statement to run instead, so no restart can delete stored data.
- A policy someone removes with `remove_retention_policy` is therefore not re-created while that
  hypertable holds rows, whatever `retention` says. On an empty hypertable the next start does
  re-create it, so clear `retention` in the config there.
- An interval an operator set on the database is never overwritten. A divergence is reported per
  hypertable, on both of a contract's tables.
- Docs and field descriptions match the behaviour, including the compatibility note: the
  compression-settings `ALTER` does run against an already-created table, taking a brief exclusive
  lock on it.

## What we are NOT shipping

- Retention on a hypertable that already holds rows. That stays an `add_retention_policy` someone
  runs deliberately; the output only prints it.
- A way to switch compression off. `compress_after` has no off value, so a compression policy
  removed on the database returns at the next start. An off value would also break the drift check's
  catalog probe, which relies on compression always having a policy, so it needs its own design.
- Changing an interval from the config: still no effect on a hypertable that already has that
  policy, and the drift warning is still the only signal.
- A physical name mapping for long contracts. A name over 53 characters is now refused at config
  parse, because PostgreSQL truncates `attribute_<contract>` at 63 bytes and two contracts differing
  only in the truncated tail would share one pair of tables. Supporting longer names is ENG-5765.

Fixes ENG-5757
