### PR TITLE
Drop timestamp_ms from stored historian tag metadata

### DIFF
--- a/.changelog/unreleased/fixes-20260827-115439.yaml
+++ b/.changelog/unreleased/fixes-20260827-115439.yaml
@@ -1,0 +1,3 @@
+kind: fixes
+body: The historian no longer stores timestamp_ms as a tag attribute, which previously wrote one attribute row per data point (ENG-5768)
+time: 2026-08-27T11:54:39.894259+02:00

--- a/historian_plugin/metadata.go
+++ b/historian_plugin/metadata.go
@@ -35,7 +35,7 @@ var skipStructural = toSet(
 
 // High-churn keys change on nearly every message and defeat metadata dedup.
 var highChurn = toSet(
-	"kafka_timestamp_ms",
+	"timestamp_ms", "kafka_timestamp_ms",
 	"opcua_source_timestamp", "opcua_server_timestamp", "opcua_attr_statuscode",
 	"opcua_heartbeat_message",
 	"spb_sequence", "spb_bdseq", "spb_timestamp", "spb_metric_index",

--- a/historian_plugin/metadata_test.go
+++ b/historian_plugin/metadata_test.go
@@ -70,6 +70,11 @@ var _ = Describe("metadata", func() {
 		// this being {"k":"v"}, never [["k","v"]].
 		Expect(tsh.Fingerprint(map[string]string{"serialNumber": "abc"})).To(Equal(`{"serialNumber":"abc"}`))
 	})
+	It("all-mode excludes timestamp_ms, which changes on every message", func() {
+		m := map[string]string{"timestamp_ms": "1730986400000", "serialNumber": "abc"}
+		Expect(tsh.SelectMetaKeys(m, true, nil, nil)).To(ConsistOf("serialNumber"))
+	})
+
 	It("flags high-churn keys present in the built map", func() {
 		md := map[string]string{"opcua_source_timestamp": "x", "serialNumber": "abc"}
 		Expect(tsh.HighChurnKeys(md)).To(ConsistOf("opcua_source_timestamp"))


### PR DESCRIPTION
## Problem

The historian stores `timestamp_ms` as tag metadata. Its value is different on every
message, so the attribute fingerprint changes every time and each data point writes a
row into the attribute table.

## What we are shipping

- `timestamp_ms` joins the built-in high-churn exclusion list, so it is no longer stored
  as an attribute in the default `metadata_keys_all` mode.

## What we are NOT shipping

- Nothing cleans up attribute rows already written; existing tables keep their per-point
  rows until pruned by hand.
- Allowlist mode (`metadata_keys_all=false`) is unchanged by design: an explicit
  `metadata_keys` entry still wins, and the existing high-churn warning covers it.

Fixes ENG-5768
