### PR TITLE
ci: retry the depot image build and document umh-core testing

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -69,16 +69,40 @@ runs:
           type=ref,event=pr
           type=sha
 
+    # wretry passes the wrapped action's inputs as one string, so every value has
+    # to survive on a single line. Tags never contain a comma and depot splits on
+    # one; label values do contain commas, so they are indented to stay a block.
+    - name: Flatten the build inputs for the retry wrapper
+      id: flat
+      shell: bash
+      env:
+        TAGS_JSON: ${{ steps.meta.outputs.json }}
+        LABELS: ${{ steps.meta.outputs.labels }}
+      run: |
+        set -euo pipefail
+        echo "tags=$(jq -r '.tags | join(",")' <<<"$TAGS_JSON")" >> "$GITHUB_OUTPUT"
+        {
+          echo 'labels<<__EOF__'
+          printf '%s\n' "$LABELS" | sed 's/^/          /'
+          echo '__EOF__'
+        } >> "$GITHUB_OUTPUT"
+
+    # Depot occasionally drops the build stream mid-`go build` ("keepalive ping
+    # failed to receive ACK"), failing the job with nothing wrong in the tree.
     - name: Build and Push Docker Image
-      uses: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       with:
-        project: ${{ inputs.depot-project-id }}
-        token: ${{ inputs.depot-token }}
-        push: true
-        platforms: linux/amd64,linux/arm64
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          APP_VERSION=${{ steps.meta.outputs.version }}
-        provenance: false
-        file: ./Dockerfile
+        action: depot/build-push-action@9785b135c3c76c33db102e45be96a25ab55cd507 # v1
+        attempt_limit: 2
+        attempt_delay: 15000
+        with: |
+          project: ${{ inputs.depot-project-id }}
+          token: ${{ inputs.depot-token }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.flat.outputs.tags }}
+          labels: |
+            ${{ steps.flat.outputs.labels }}
+          build-args: APP_VERSION=${{ steps.meta.outputs.version }}
+          provenance: false
+          file: ./Dockerfile

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -69,22 +69,20 @@ runs:
           type=ref,event=pr
           type=sha
 
-    # wretry passes the wrapped action's inputs as one string, so every value has
-    # to survive on a single line. Tags never contain a comma and depot splits on
-    # one; label values do contain commas, so they are indented to stay a block.
-    - name: Flatten the build inputs for the retry wrapper
-      id: flat
+    # wretry parses the wrapped action's inputs as YAML, so a value spanning
+    # lines breaks the document. JSON-encode both: valid YAML, one line, and the
+    # newlines depot splits tags and labels on survive as escapes.
+    - name: Encode the build inputs for the retry wrapper
+      id: enc
       shell: bash
       env:
-        TAGS_JSON: ${{ steps.meta.outputs.json }}
+        META_JSON: ${{ steps.meta.outputs.json }}
         LABELS: ${{ steps.meta.outputs.labels }}
       run: |
         set -euo pipefail
-        echo "tags=$(jq -r '.tags | join(",")' <<<"$TAGS_JSON")" >> "$GITHUB_OUTPUT"
         {
-          echo 'labels<<__EOF__'
-          printf '%s\n' "$LABELS" | sed 's/^/          /'
-          echo '__EOF__'
+          echo "tags=$(jq -r '.tags | join("\n")' <<<"$META_JSON" | jq -Rs .)"
+          echo "labels=$(jq -Rs . <<<"$LABELS")"
         } >> "$GITHUB_OUTPUT"
 
     # Depot occasionally drops the build stream mid-`go build` ("keepalive ping
@@ -100,9 +98,8 @@ runs:
           token: ${{ inputs.depot-token }}
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.flat.outputs.tags }}
-          labels: |
-            ${{ steps.flat.outputs.labels }}
+          tags: ${{ steps.enc.outputs.tags }}
+          labels: ${{ steps.enc.outputs.labels }}
           build-args: APP_VERSION=${{ steps.meta.outputs.version }}
           provenance: false
           file: ./Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,21 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
+      # Depot occasionally drops the build stream mid-`go build`
+      # ("keepalive ping failed to receive ACK"), which fails the job even though
+      # nothing is wrong with the tree. One automatic retry keeps a PR's image
+      # available for umh-core testing without a manual re-run.
       - name: Build and Push Docker Image
+        id: build
+        continue-on-error: true
+        uses: ./.github/actions/build-docker
+        with:
+          image-name: ${{ github.repository }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          depot-project-id: ${{ secrets.DEPOT_PROJECT_ID }}
+          depot-token: ${{ secrets.DEPOT_TOKEN }}
+      - name: Build and Push Docker Image (retry)
+        if: steps.build.outcome == 'failure'
         uses: ./.github/actions/build-docker
         with:
           image-name: ${{ github.repository }}
@@ -57,13 +71,26 @@ jobs:
         with:
           header: docker-image
           message: |
-            **Docker Image Built**
+            **Docker Image Built** (linux/amd64 + linux/arm64)
 
-            ```
-            ghcr.io/united-manufacturing-hub/benthos-umh:sha-${{ steps.short-sha.outputs.SHORT_SHA }}
-            ```
+            | Tag | Points at |
+            |---|---|
+            | `sha-${{ steps.short-sha.outputs.SHORT_SHA }}` | this exact commit — use this for reproducible runs |
+            | `pr-${{ github.event.pull_request.number }}` | latest push to this PR — moves as you push |
 
-            Pull with:
+            Pull it:
             ```bash
             docker pull ghcr.io/united-manufacturing-hub/benthos-umh:sha-${{ steps.short-sha.outputs.SHORT_SHA }}
+            ```
+
+            Run it against umh-core — in `umh-core/Makefile`, set:
+            ```make
+            BENTHOS_UMH_VERSION = sha-${{ steps.short-sha.outputs.SHORT_SHA }}
+            ```
+            then `make build` in `umh-core/`. The Makefile extracts the `/benthos`
+            binary from this image for both architectures.
+
+            Check which plugins the image carries:
+            ```bash
+            docker run --rm ghcr.io/united-manufacturing-hub/benthos-umh:sha-${{ steps.short-sha.outputs.SHORT_SHA }} list inputs
             ```

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,21 +32,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      # Depot occasionally drops the build stream mid-`go build`
-      # ("keepalive ping failed to receive ACK"), which fails the job even though
-      # nothing is wrong with the tree. One automatic retry keeps a PR's image
-      # available for umh-core testing without a manual re-run.
       - name: Build and Push Docker Image
-        id: build
-        continue-on-error: true
-        uses: ./.github/actions/build-docker
-        with:
-          image-name: ${{ github.repository }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          depot-project-id: ${{ secrets.DEPOT_PROJECT_ID }}
-          depot-token: ${{ secrets.DEPOT_TOKEN }}
-      - name: Build and Push Docker Image (retry)
-        if: steps.build.outcome == 'failure'
         uses: ./.github/actions/build-docker
         with:
           image-name: ${{ github.repository }}


### PR DESCRIPTION
Split out of the Beckhoff ADS stack (#399), which had no reason to carry a CI change.

## Why

Depot sometimes drops the build stream mid-`go build` (`keepalive ping failed to receive ACK`) and fails the job. That costs a manual re-run, and until someone does it the PR has no image to test umh-core against.

## What changes

`depot/build-push-action` is wrapped in `Wandalen/wretry.action` **inside** `.github/actions/build-docker`, with `attempt_limit: 2` and a 15s delay. `main.yml` keeps a single build step.

The retry sits in the composite rather than the workflow because wretry's `action` input is `{owner}/{repo}@{ref}` and it retries JavaScript and Docker actions, not composite ones — so it cannot wrap `./.github/actions/build-docker`, but it can wrap `depot/build-push-action`, which is `using: node24`.

The PR comment that reports the image also changed: it lists both tags and says which one moves, gives the `docker pull` line, shows the `BENTHOS_UMH_VERSION` value to paste into `umh-core/Makefile`, and the `list inputs` command to check which plugins the image carries.

## Why the inputs are JSON-encoded

This is the part worth reviewing. wretry passes the wrapped action's inputs as one string and parses it as YAML, so any value that spans lines breaks the document. `tags` and `labels` from `docker/metadata-action` are both newline-separated, and `${{ }}` is substituted *after* the workflow YAML is parsed, so the continuation lines land wherever the expansion puts them.

Two shapes were tried and both failed at parse time, before the build ever ran:

- passing the outputs through with `toJSON()` — `can not read a block mapping entry; a multiline key may not be an implicit key (7:7)`. `toJSON` still spans lines, and depot would have received a JSON-quoted blob instead of a list.
- hand-indenting `labels` into a block — `bad indentation of a mapping entry (8:11)`, because the substituted lines do not line up with the block's own indent.

So an `enc` step runs the values through `jq -Rs`, which emits each as a JSON string: one line, quotes and newlines escaped, and valid YAML for any parser. depot splits tags and labels on the newlines, which survive as `\n`. Comma-joining was rejected for labels specifically: docker's parser deliberately does not split labels on commas, because values like `image.description` contain them.

Verified in [this run](https://github.com/united-manufacturing-hub/benthos-umh/actions/runs/34598559074) — both tags and all eight labels reach depot intact:

```
tags:   "ghcr.io/…/benthos-umh:pr-452\nghcr.io/…/benthos-umh:sha-092c57f\n"
labels: "…image.created=…\n…licenses=Apache-2.0\n…title=benthos-umh\n…version=pr-452\n"
```

## Notes for review

- **New third-party dependency**, pinned by commit SHA: `Wandalen/wretry.action@e68c23e` (v3.8.0). It is an action whose job is to execute other actions, and it runs with the Depot token and `packages: write`. Worth a deliberate yes or no.
- v3.8.0 is tagged 2025-01-09 while the repo was last pushed 2026-06-19; the marketplace still lists 3.8.0 as latest.
- Nesting wretry inside a composite action is not covered by their docs. The run above is the evidence that it works; it loads a `v3.8.0_js_action` variant to do it.
- `jq` on `depot-ubuntu-24.04` was an assumption — no existing job used it on a Depot runner. The run above confirms it is present.
- A genuine build failure now takes roughly twice as long to go red. Job timeout is 60 minutes and a normal build is well inside it.
- `comment-pr` is a separate job with `needs: build-docker`, so if both attempts fail the run fails and no comment is posted.

## Open question: is this a flake or an OOM?

Depot's [troubleshooting page](https://depot.dev/docs/container-builds/troubleshooting) attributes this exact error to "BuildKit ... shut down due to runner resource starvation, often caused by an Out of Memory (OOM) condition", and prescribes a larger worker size or auto-scaling, then support with the project ID. Their CLI went the same way: depot/cli#521 "Fail fast on a wedged builder connection" added gRPC keepalive defaults so a dead builder errors in seconds, deliberately without retrying, and #412 replaced the raw gRPC text with a message pointing at that page.

If these failures are the builder running out of memory while compiling for linux/amd64 and linux/arm64, a retry mostly produces two failures instead of one, and the supported fix is a worker-size change instead. I could not settle it from the failures to hand: the two runs that motivated this died at YAML parse time, before any build started. Reading a genuinely failed build log, or asking Depot support with the project ID, would decide whether this PR is the right fix or a workaround for a capacity problem.

No changelog fragment: CI only, nothing user-visible ships from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)